### PR TITLE
Fix compatibility between Cloudflare R2 and new `@aws-sdk/client-s3`

### DIFF
--- a/src/replication/journal/objectstore/JournalSyncMinio.ts
+++ b/src/replication/journal/objectstore/JournalSyncMinio.ts
@@ -34,6 +34,8 @@ export class JournalSyncMinio extends JournalSyncAbstract {
             maxAttempts: 4,
             retryStrategy: new ConfiguredRetryStrategy(4, (attempt: number) => 100 + attempt * 1000),
             requestHandler: this.useCustomRequestHandler ? this.env.$$customFetchHandler() : undefined,
+            requestChecksumCalculation: "WHEN_REQUIRED",
+            responseChecksumValidation: "WHEN_REQUIRED",
         });
         const bucketCustomHeaders = this.customHeaders;
         this._instance.middlewareStack.add(


### PR DESCRIPTION
In the current version of Self-hosted LiveSync (0.24.26), connecting to Cloudflare R2 fails. This is because R2 is incompatible with the newer AWS SDK. This pull request implements the fix detailed in the [R2 documentation](https://developers.cloudflare.com/r2/examples/aws/aws-sdk-js-v3/).