### PR TITLE
Add connectionWarningStyle setting for connection error warnings

### DIFF
--- a/src/common/models/setting.const.defaults.ts
+++ b/src/common/models/setting.const.defaults.ts
@@ -61,6 +61,7 @@ export const DEFAULT_SETTINGS: ObsidianLiveSyncSettings = {
     showStatusOnStatusbar: true,
     showOnlyIconsOnEditor: false,
     hideFileWarningNotice: false,
+    connectionWarningStyle: "banner",
     usePluginSync: false,
     autoSweepPlugins: false,
     autoSweepPluginsPeriodic: false,

--- a/src/common/models/setting.const.defaults.ts
+++ b/src/common/models/setting.const.defaults.ts
@@ -61,7 +61,7 @@ export const DEFAULT_SETTINGS: ObsidianLiveSyncSettings = {
     showStatusOnStatusbar: true,
     showOnlyIconsOnEditor: false,
     hideFileWarningNotice: false,
-    connectionWarningStyle: "banner",
+    networkWarningStyle: "",
     usePluginSync: false,
     autoSweepPlugins: false,
     autoSweepPluginsPeriodic: false,

--- a/src/common/models/setting.const.qr.ts
+++ b/src/common/models/setting.const.qr.ts
@@ -160,5 +160,5 @@ export const KeyIndexOfSettings: Record<keyof ObsidianLiveSyncSettings, number> 
     syncInternalFileOverwritePatterns: 153,
     useOnlyLocalChunk: 154,
     maxMTimeForReflectEvents: 155,
-    connectionWarningStyle: 156,
+    networkWarningStyle: 156,
 } as const;

--- a/src/common/models/setting.const.qr.ts
+++ b/src/common/models/setting.const.qr.ts
@@ -160,4 +160,5 @@ export const KeyIndexOfSettings: Record<keyof ObsidianLiveSyncSettings, number> 
     syncInternalFileOverwritePatterns: 153,
     useOnlyLocalChunk: 154,
     maxMTimeForReflectEvents: 155,
+    connectionWarningStyle: 156,
 } as const;

--- a/src/common/models/setting.const.ts
+++ b/src/common/models/setting.const.ts
@@ -53,3 +53,11 @@ export const MODE_SELECTIVE = 0;
 export const MODE_AUTOMATIC = 1;
 export const MODE_PAUSED = 2;
 export const MODE_SHINY = 3;
+
+// Network constants for banner setting
+export const NetworkWarningStyles = {
+    BANNER: "",
+    ICON: "icon",
+    HIDDEN: "hidden",
+} as const;
+

--- a/src/common/models/setting.type.ts
+++ b/src/common/models/setting.type.ts
@@ -316,7 +316,7 @@ interface UISettings {
      * How to display connection error warnings.
      * "banner" shows the full banner, "icon" shows only an icon, "hidden" suppresses entirely.
      */
-    connectionWarningStyle: "banner"|"icon"|"hidden"
+    networkWarningStyle: "" | "icon" | "hidden"
 
     /**
      * The language to be used for display.
@@ -977,21 +977,21 @@ interface DeletedFileMetadataSettings {
 
 interface ObsidianLiveSyncSettings_PluginSetting
     extends SyncMethodSettings,
-        UISettings,
-        FileHandlingSettings,
-        MergeBehaviourSettings,
-        EncryptedUserSettings,
-        PeriodicReplicationSettings,
-        InternalFileSettings,
-        PluginSyncSettings,
-        ModeSettings,
-        ExtraTweakSettings,
-        BetaTweakSettings,
-        ObsoleteSettings,
-        DebugModeSettings,
-        SettingSyncSettings,
-        SafetyValveSettings,
-        DataOnSettings {}
+    UISettings,
+    FileHandlingSettings,
+    MergeBehaviourSettings,
+    EncryptedUserSettings,
+    PeriodicReplicationSettings,
+    InternalFileSettings,
+    PluginSyncSettings,
+    ModeSettings,
+    ExtraTweakSettings,
+    BetaTweakSettings,
+    ObsoleteSettings,
+    DebugModeSettings,
+    SettingSyncSettings,
+    SafetyValveSettings,
+    DataOnSettings { }
 
 export type RemoteDBSettings = CouchDBConnection &
     BucketSyncSetting &

--- a/src/common/models/setting.type.ts
+++ b/src/common/models/setting.type.ts
@@ -313,6 +313,12 @@ interface UISettings {
     hideFileWarningNotice: boolean;
 
     /**
+     * How to display connection error warnings.
+     * "banner" shows the full banner, "icon" shows only an icon, "hidden" suppresses entirely.
+     */
+    connectionWarningStyle: "banner"|"icon"|"hidden"
+
+    /**
      * The language to be used for display.
      */
     displayLanguage: I18N_LANGS;

--- a/src/common/settingConstants.ts
+++ b/src/common/settingConstants.ts
@@ -53,10 +53,10 @@ export type AllSettingItemKey = AllStringItemKey | AllNumericItemKey | AllBoolea
 export type ValueOf<T extends AllSettingItemKey> = T extends AllStringItemKey
     ? string
     : T extends AllNumericItemKey
-      ? number
-      : T extends AllBooleanItemKey
-        ? boolean
-        : AllSettings[T];
+    ? number
+    : T extends AllBooleanItemKey
+    ? boolean
+    : AllSettings[T];
 
 export const SettingInformation: Partial<Record<keyof AllSettings, ConfigurationItem>> = {
     liveSync: {
@@ -407,8 +407,8 @@ export const SettingInformation: Partial<Record<keyof AllSettings, Configuration
         desc: "If enabled, the ⛔ icon will be shown inside the status instead of the file warnings banner. No details will be shown.",
     },
     networkWarningStyle: {
-        name: "Connection warning style",
-        desc: "How to display connection errors when the sync server is unreachable.",
+        name: "Network warning style",
+        desc: "How to display network errors when the sync server is unreachable.",
     },
     bucketPrefix: {
         name: "File prefix on the bucket",

--- a/src/common/settingConstants.ts
+++ b/src/common/settingConstants.ts
@@ -406,6 +406,10 @@ export const SettingInformation: Partial<Record<keyof AllSettings, Configuration
         name: "Show status icon instead of file warnings banner",
         desc: "If enabled, the ⛔ icon will be shown inside the status instead of the file warnings banner. No details will be shown.",
     },
+    connectionWarningStyle: {
+        name: "Connection warning style",
+        desc: "How to display connection errors when the sync server is unreachable.",
+    },
     bucketPrefix: {
         name: "File prefix on the bucket",
         desc: "Effectively a directory. Should end with `/`. e.g., `vault-name/`.",

--- a/src/common/settingConstants.ts
+++ b/src/common/settingConstants.ts
@@ -406,7 +406,7 @@ export const SettingInformation: Partial<Record<keyof AllSettings, Configuration
         name: "Show status icon instead of file warnings banner",
         desc: "If enabled, the ⛔ icon will be shown inside the status instead of the file warnings banner. No details will be shown.",
     },
-    connectionWarningStyle: {
+    networkWarningStyle: {
         name: "Connection warning style",
         desc: "How to display connection errors when the sync server is unreachable.",
     },


### PR DESCRIPTION
Adds a new `connectionWarningStyle` setting with three options:
- Banner: shows the full error banner (default, existing behavior)
- Icon only: shows a 🔗❌ icon instead of the full banner
- Hidden: suppresses connection warnings entirely

This addresses the issue where users disconnected from their sync server (e.g. Tailscale) are permanently shown an error banner, even though offline editing is a core Obsidian use case. This is especially obtrusive for mobile phone users.

Related PR: https://github.com/vrtmrz/obsidian-livesync/pull/804