### PR TITLE
fix: yield results from _enumerate when metaOnly is true

### DIFF
--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -400,7 +400,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
         // return;
     }
     async *_enumerate(startKey: string, endKey: string, opt: { metaOnly: boolean }) {
-        if (opt.metaOnly) return this.liveSyncLocalDB.findEntries(startKey, endKey, {});
+        if (opt.metaOnly) return yield* this.liveSyncLocalDB.findEntries(startKey, endKey, {});
         for await (const f of this.liveSyncLocalDB.findEntries(startKey, endKey, {})) {
             yield await this.getByMeta(f);
         }


### PR DESCRIPTION
## Problem

`DirectFileManipulator._enumerate()` silently returns zero results when called with `metaOnly: true`.

In an `async *` generator function, a bare `return <value>` doesn't yield anything to the caller — it just sets the generator's return value (which `for await...of` ignores). The current code returns the async iterator from `findEntries()` as a completion value instead of delegating to it.

```typescript
// Before: returns the iterator as a value, yields nothing
async *_enumerate(startKey, endKey, opt) {
    if (opt.metaOnly) return this.liveSyncLocalDB.findEntries(startKey, endKey, {});
    // ...
}
```

This means `enumerateAllNormalDocs({ metaOnly: true })` always produces an empty sequence.

## Fix

```typescript
// After: delegates to the iterator, yields all its values
if (opt.metaOnly) return yield* this.liveSyncLocalDB.findEntries(startKey, endKey, {});
```

`yield*` delegates to the inner async generator, forwarding all its values to the caller.


