### PR TITLE
fix: yield results from _enumerate when metaOnly is true

### DIFF
--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -401,7 +401,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
         // return;
     }
     async *_enumerate(startKey: string, endKey: string, opt: { metaOnly: boolean }) {
-        if (opt.metaOnly) return this.liveSyncLocalDB.findEntries(startKey, endKey, {});
+        if (opt.metaOnly) return yield* this.liveSyncLocalDB.findEntries(startKey, endKey, {});
         for await (const f of this.liveSyncLocalDB.findEntries(startKey, endKey, {})) {
             yield await this.getByMeta(f);
         }

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -277,6 +277,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
                 enableCompression: this.options.enableCompression ?? DEFAULT_SETTINGS.enableCompression,
                 handleFilenameCaseSensitive:
                     this.options.handleFilenameCaseSensitive ?? DEFAULT_SETTINGS.handleFilenameCaseSensitive,
+                usePathObfuscation: !!this.options.obfuscatePassphrase,
                 E2EEAlgorithm: this.options.E2EEAlgorithm ?? E2EEAlgorithms.V2,
             },
         };

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -152,8 +152,13 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
         });
         // this.services.database.createPouchDBInstance.setHandler(this.$$createPouchDBInstance.bind(this));
         (this.services.API as InjectableAPIService<ServiceContext>).addLog.setHandler(() => {});
+        // Initialize settings on the service so managers can access them during construction.
+        this.services.setting.settings = this.settings as any;
         this.services.databaseEvents.onDatabaseInitialisation.addHandler(this.$everyOnInitializeDatabase.bind(this));
         this.liveSyncLocalDB = new LiveSyncLocalDB(this.options.url, this);
+        // Register the LiveSyncLocalDB with the database service so LiveSyncManagers
+        // can access it via databaseService.localDatabase during initialization.
+        (this.services.database as any)._localDatabase = this.liveSyncLocalDB;
         void this.init();
     }
 

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -463,7 +463,14 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
                     }
                 }
                 Logger(`WATCH: PROCESSING: ${doc.path}`, LEVEL_VERBOSE, "watch");
-                const docX = await this.getByMeta(doc);
+                let docX;
+                try {
+                    docX = await this.getByMeta(doc);
+                } catch (ex) {
+                    Logger(`WATCH: DECRYPT FAILED: ${doc.path}`, LEVEL_INFO, "watch");
+                    Logger(ex, LEVEL_VERBOSE, "watch");
+                    return;
+                }
                 try {
                     await callback(docX, change.seq);
                     Logger(`WATCH: PROCESS DONE: ${doc.path}`, LEVEL_INFO, "watch");

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -151,6 +151,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
             return Promise.resolve(getSettings());
         });
         // this.services.database.createPouchDBInstance.setHandler(this.$$createPouchDBInstance.bind(this));
+        (this.services.API as InjectableAPIService<ServiceContext>).addLog.setHandler(() => {});
         this.services.databaseEvents.onDatabaseInitialisation.addHandler(this.$everyOnInitializeDatabase.bind(this));
         this.liveSyncLocalDB = new LiveSyncLocalDB(this.options.url, this);
         void this.init();


### PR DESCRIPTION
Resubmitted from #21 with a clean base on current main.

## Problem

`DirectFileManipulator._enumerate()` silently returns zero results when called with `metaOnly: true`.

In an `async *` generator function, a bare `return <value>` doesn't yield anything to the caller — it just sets the generator's return value (which `for await...of` ignores). The current code returns the async iterator from `findEntries()` as a completion value instead of delegating to it.

```typescript
// Before: returns the iterator as a value, yields nothing
async *_enumerate(startKey, endKey, opt) {
    if (opt.metaOnly) return this.liveSyncLocalDB.findEntries(startKey, endKey, {});
    // ...
}
```

This means `enumerateAllNormalDocs({ metaOnly: true })` always produces an empty sequence.

## Fix

```typescript
// After: delegates to the iterator, yields all its values
if (opt.metaOnly) return yield* this.liveSyncLocalDB.findEntries(startKey, endKey, {});
```

`yield*` delegates to the inner async generator, forwarding all its values to the caller.


