### PR TITLE
Fix: Use explicit Authorization header instead of PouchDB auth option…

### DIFF
--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -124,8 +124,17 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
                 _options?: PouchDB.Configuration.DatabaseConfiguration
             ): PouchDB.Database<T> {
                 const option = _option();
+                const authHeader = "Basic " + btoa(`${option.username}:${option.password}`);
                 return new PouchDB(option.url + "/" + option.database, {
-                    auth: { username: option.username, password: option.password },
+                    fetch: (url: string | Request, opts?: RequestInit) => {
+                        return fetch(url, {
+                            ...opts,
+                            headers: {
+                                ...opts?.headers,
+                                "Authorization": authHeader,
+                            },
+                        } as RequestInit);
+                    },
                 });
             }
         };


### PR DESCRIPTION
… for Deno 2 compatibility