### PR TITLE
perf: remove redundant work during database initialization

### DIFF
--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -114,7 +114,6 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
         await this.services.appLifecycle.onReady();
         await this.liveSyncLocalDB.initializeDatabase();
         this.ready.resolve();
-        this.liveSyncLocalDB.refreshSettings();
     }
     getBoundDatabaseService(options: () => DirectFileManipulatorOptions) {
         const _option = options;

--- a/src/pouchdb/LiveSyncLocalDB.ts
+++ b/src/pouchdb/LiveSyncLocalDB.ts
@@ -136,7 +136,6 @@ export class LiveSyncLocalDB {
     }
 
     async initializeDatabase(): Promise<boolean> {
-        await this._prepareHashFunctions();
         if (this.localDatabase != null) {
             this.localDatabase.removeAllListeners();
             await this.localDatabase.close();
@@ -169,8 +168,6 @@ export class LiveSyncLocalDB {
             // return false;
         }
         this._log("Opening Database...");
-        this._log("Database info", LOG_LEVEL_VERBOSE);
-        this._log(JSON.stringify(await this.localDatabase.info(), null, 2), LOG_LEVEL_VERBOSE);
         await this.managers.initialise();
         this.localDatabase.on("close", () => {
             this._log("Database closed.");


### PR DESCRIPTION
## Eliminate redundant work during database initialization

Three lines that add unnecessary latency to every `initializeDatabase()` call:

### 1. Remove no-op `_prepareHashFunctions()` call

At the top of `initializeDatabase()`, `_managers` is always `undefined` — the `LiveSyncManagers` instance is created ~20 lines later. So `_prepareHashFunctions()` (which optional-chains on `this._managers`) is a guaranteed no-op that just wastes an async tick. The real hash initialization happens later in `managers.initialise()`.

### 2. Remove unconditional `localDatabase.info()` call

This makes a network round-trip to CouchDB (`GET /db`) on every database initialization purely to log the result at `VERBOSE` level. The return value is never used for anything. For remote databases this adds ~500ms+ of latency for a debug log.

### 3. Remove redundant `refreshSettings()` after init

`DirectFileManipulator.init()` calls `refreshSettings()` immediately after `initializeDatabase()` completes. This re-creates the `HashManager` from scratch and loads the xxhash WASM module a second time — the first load already happened inside `initializeDatabase()` → `managers.initialise()` → `hashManager.initialise()`. The only other thing `refreshSettings()` does is populate `this.settings`, which is already set during construction and the managers' init.

### Impact

Measured on a headless CLI tool using `DirectFileManipulator` against a remote CouchDB:

| Operation | Before | After |
|-----------|--------|-------|
| Single-file operation (read/meta/delete) | ~7s | ~1s |

The effect on the Obsidian plugin should be similar proportionally during database open.