### PR TITLE
headless: implement HeadlessConfirm with sensible defaults

### DIFF
--- a/src/services/implements/headless/HeadlessAPIService.ts
+++ b/src/services/implements/headless/HeadlessAPIService.ts
@@ -7,31 +7,42 @@ import type { Confirm } from "@lib/interfaces/Confirm";
 import module from "node:crypto";
 declare const MANIFEST_VERSION: string | undefined;
 // declare const PACKAGE_VERSION: string | undefined;
+/**
+ * Headless implementation of Confirm that returns sensible defaults instead
+ * of throwing. Dialogs are logged to stderr so the prompts are visible in
+ * service logs, and the default/conservative action is taken automatically.
+ */
 export class HeadlessConfirm implements Confirm {
     askYesNo(message: string): Promise<"yes" | "no"> {
-        throw new Error("Method not implemented.");
+        console.error(`[Headless] ${message} → no`);
+        return Promise.resolve("no");
     }
     askString(title: string, key: string, placeholder: string, isPassword?: boolean): Promise<string | false> {
-        throw new Error("Method not implemented.");
+        console.error(`[Headless] String input required: ${title} → declined`);
+        return Promise.resolve(false);
     }
     askYesNoDialog(
         message: string,
         opt: { title?: string; defaultOption?: "Yes" | "No"; timeout?: number }
     ): Promise<"yes" | "no"> {
-        throw new Error("Method not implemented.");
+        const result = opt.defaultOption === "Yes" ? "yes" as const : "no" as const;
+        console.error(`[Headless] ${opt.title ?? "Confirm"}: ${message} → ${result}`);
+        return Promise.resolve(result);
     }
     askSelectString(message: string, items: string[]): Promise<string> {
-        throw new Error("Method not implemented.");
+        console.error(`[Headless] ${message} → ${items[0]}`);
+        return Promise.resolve(items[0]);
     }
     askSelectStringDialogue<T extends readonly string[]>(
         message: string,
         buttons: T,
         opt: { title?: string; defaultAction: T[number]; timeout?: number }
     ): Promise<T[number] | false> {
-        throw new Error("Method not implemented.");
+        console.error(`[Headless] ${opt.title ?? "Confirm"}: ${message} → ${String(opt.defaultAction)}`);
+        return Promise.resolve(opt.defaultAction);
     }
     askInPopup(key: string, dialogText: string, anchorCallback: (anchor: HTMLAnchorElement) => void): void {
-        throw new Error("Method not implemented.");
+        console.error(`[Headless] Popup (${key}): ${dialogText}`);
     }
     confirmWithMessage(
         title: string,
@@ -40,7 +51,8 @@ export class HeadlessConfirm implements Confirm {
         defaultAction: (typeof buttons)[number],
         timeout?: number
     ): Promise<(typeof buttons)[number] | false> {
-        throw new Error("Method not implemented.");
+        console.error(`[Headless] ${title}: ${contentMd} → ${defaultAction}`);
+        return Promise.resolve(defaultAction);
     }
 }
 export class HeadlessAPIService<T extends ServiceContext> extends InjectableAPIService<T> {


### PR DESCRIPTION
## Summary

`HeadlessConfirm` previously threw `"Method not implemented."` for every `Confirm` interface method, causing crashes in CLI and other headless environments when sync encountered interactive dialogs (e.g. configuration mismatch resolution, red flag handling).

This implements all methods with non-interactive defaults:
- `askSelectStringDialogue` / `confirmWithMessage`: return the `defaultAction`
- `askYesNoDialog`: respect the `defaultOption` parameter
- `askYesNo`: return `"no"` (conservative)
- `askString`: return `false` (no input available)
- `askInPopup`: no-op

All methods log the dialog prompt and selected action to stderr for visibility in service logs.

## Rationale for default choices

The `defaultAction` is used for all selection dialogs rather than always picking the first option. Some call sites have destructive operations (database rebuilds, chunk deletion, P2P peer acceptance) as `buttons[0]`, so a blanket "pick first" policy would be unsafe. Callers that need specific headless behavior should set an appropriate `defaultAction` or handle the headless case at the call site.

## Testing

Tested against a live CouchDB instance with E2EE and path obfuscation via the CLI app. The `sync` command previously crashed with `Error: Method not implemented.` at `HeadlessConfirm.askSelectStringDialogue` when a configuration mismatch was detected. After this change, the dialog is auto-resolved with the default action logged to stderr, and sync completes successfully.