### PR TITLE
fix: strip trailing slash from couchDB_URI to avoid double-slash 401

### DIFF
--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -203,7 +203,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
         }
     }
     async getReplicationPBKDF2Salt(setting: RemoteDBSettings, refresh?: boolean): Promise<Uint8Array<ArrayBuffer>> {
-        const server = `${setting.couchDB_URI}/${setting.couchDB_DBNAME}`;
+        const server = `${setting.couchDB_URI.replace(/\/+$/, "")}/${setting.couchDB_DBNAME}`;
         const manager = createSyncParamsHanderForServer(server, {
             put: (params: SyncParameters) => this.putSyncParameters(setting, params),
             get: () => this.getSyncParameters(setting),

--- a/src/pouchdb/chunks.ts
+++ b/src/pouchdb/chunks.ts
@@ -324,7 +324,7 @@ export async function purgeChunksRemote(setting: CouchDBConnection, docs: { id: 
         const buffer = makeChunkedArrayFromArray(docs);
         for (const chunkedPayload of buffer) {
             const rets = await _requestToCouchDBFetch(
-                `${setting.couchDB_URI}/${setting.couchDB_DBNAME}`,
+                `${setting.couchDB_URI.replace(/\/+$/, "")}/${setting.couchDB_DBNAME}`,
                 setting.couchDB_USER,
                 setting.couchDB_PASSWORD,
                 "_purge",

--- a/src/replication/couchdb/LiveSyncReplicator.ts
+++ b/src/replication/couchdb/LiveSyncReplicator.ts
@@ -193,7 +193,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         setting: RemoteDBSettings,
         refresh?: boolean
     ): Promise<Uint8Array<ArrayBuffer>> {
-        const server = `${setting.couchDB_URI}/${setting.couchDB_DBNAME}`;
+        const server = `${setting.couchDB_URI.replace(/\/+$/, "")}/${setting.couchDB_DBNAME}`;
         const manager = createSyncParamsHanderForServer(server, {
             put: (params: SyncParameters) => this.putSyncParameters(setting, params),
             get: () => this.getSyncParameters(setting),
@@ -796,7 +796,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             Logger($msg("Replicator.Message.VersionUpFlash"), LOG_LEVEL_NOTICE);
             return false;
         }
-        const uri = setting.couchDB_URI + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
+        const uri = setting.couchDB_URI.replace(/\/+$/, "") + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
         if (this.controller) {
             Logger("Another replication running.");
             return false;
@@ -1017,7 +1017,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         Logger($msg("liveSyncReplicator.remoteDbCreatedOrConnected"), LOG_LEVEL_NOTICE);
     }
     async markRemoteLocked(setting: RemoteDBSettings, locked: boolean, lockByClean: boolean) {
-        const uri = setting.couchDB_URI + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
+        const uri = setting.couchDB_URI.replace(/\/+$/, "") + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
         const dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
         if (typeof dbRet === "string") {
             Logger($msg("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
@@ -1056,7 +1056,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         await dbRet.db.put(remoteMilestone);
     }
     async markRemoteResolved(setting: RemoteDBSettings) {
-        const uri = setting.couchDB_URI + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
+        const uri = setting.couchDB_URI.replace(/\/+$/, "") + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
         const dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
         if (typeof dbRet === "string") {
             Logger($msg("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
@@ -1120,7 +1120,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
                   }
         ) satisfies CouchDBCredentials;
         return this.env.services.remote.connect(
-            settings.couchDB_URI + (settings.couchDB_DBNAME == "" ? "" : "/" + settings.couchDB_DBNAME),
+            settings.couchDB_URI.replace(/\/+$/, "") + (settings.couchDB_DBNAME == "" ? "" : "/" + settings.couchDB_DBNAME),
             auth,
             settings.disableRequestURI || isMobile,
             settings.encrypt ? settings.passphrase : settings.encrypt,
@@ -1231,7 +1231,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
     }
 
     async resetRemoteTweakSettings(setting: RemoteDBSettings): Promise<void> {
-        const uri = setting.couchDB_URI + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
+        const uri = setting.couchDB_URI.replace(/\/+$/, "") + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
         const dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
         if (typeof dbRet === "string") {
             Logger($msg("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
@@ -1256,7 +1256,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
     }
 
     async setPreferredRemoteTweakSettings(setting: RemoteDBSettings): Promise<void> {
-        const uri = setting.couchDB_URI + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
+        const uri = setting.couchDB_URI.replace(/\/+$/, "") + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
         const dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
         if (typeof dbRet === "string") {
             Logger($msg("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
@@ -1281,7 +1281,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
     }
 
     async getRemotePreferredTweakValues(setting: RemoteDBSettings): Promise<TweakValues | false> {
-        const uri = setting.couchDB_URI + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
+        const uri = setting.couchDB_URI.replace(/\/+$/, "") + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
         const dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
         if (typeof dbRet === "string") {
             Logger($msg("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
@@ -1305,7 +1305,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
     }
 
     async compactRemote(setting: RemoteDBSettings): Promise<boolean> {
-        const uri = setting.couchDB_URI + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
+        const uri = setting.couchDB_URI.replace(/\/+$/, "") + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
         const dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
         if (typeof dbRet === "string") {
             Logger($msg("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
@@ -1319,7 +1319,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
     async getRemoteStatus(setting: RemoteDBSettings): Promise<RemoteDBStatus | false> {
         const dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
         if (typeof dbRet === "string") {
-            const uri = setting.couchDB_URI + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
+            const uri = setting.couchDB_URI.replace(/\/+$/, "") + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
             Logger($msg("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
             return false;
         }
@@ -1333,7 +1333,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
     async countCompromisedChunks(setting: RemoteDBSettings = this.currentSettings): Promise<number | boolean> {
         const dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
         if (typeof dbRet === "string") {
-            const uri = setting.couchDB_URI + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
+            const uri = setting.couchDB_URI.replace(/\/+$/, "") + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
             Logger($msg("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
             return false;
         }
@@ -1346,7 +1346,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
     ): Promise<false | { node_info: Record<string, NodeData>; accepted_nodes: string[] }> {
         const dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
         if (typeof dbRet === "string") {
-            const uri = setting.couchDB_URI + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
+            const uri = setting.couchDB_URI.replace(/\/+$/, "") + (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
             Logger($msg("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
             return false;
         }


### PR DESCRIPTION
## Problem

When `couchDB_URI` ends with a trailing slash (e.g. `http://127.0.0.1:5984/`), concatenation with the database name produces a double-slash path:

- `http://127.0.0.1:5984/` + `/obsidiannotes` → `http://127.0.0.1:5984//obsidiannotes`

CouchDB does not match the route for `//obsidiannotes` and returns 401 `Name or password is incorrect.` — even though the credentials themselves are correct.

Reproduced log (the `https:////` shown is a separate logging-format artefact; the actual request URL has the double slash before the database name):

```
GET https://example.com//obsidiannotes/ 401 (Unauthorized)
The request may have failed. The reason sent by the server: 401:
Could not connect to https:////example.com/ : obsidiannotes
(unauthorized:Name or password is incorrect.)
```

## Root cause

Several call sites concatenate `setting.couchDB_URI` directly with `/<dbname>` without normalising the trailing slash:

- `src/replication/couchdb/LiveSyncReplicator.ts` — 8 occurrences
- `src/API/DirectFileManipulatorV2.ts` — 1 occurrence
- `src/pouchdb/chunks.ts` — 1 occurrence

## Fix

Strip trailing slashes at every concatenation site using `String.replace(/\/+$/, "")`. This is the minimal, locally-scoped change suggested in vrtmrz/obsidian-livesync#859 and avoids reshaping the public API.

## Testing

### Static checks (run from the parent repo with this submodule branch checked out)

| Check | Result |
| --- | --- |
| `npm run lint` (eslint over `src`, which includes `src/lib`) | ✅ clean |
| `npm run test:unit` (vitest, recursive over `**/*.unit.spec.ts`, covers 26 submodule test files) | ✅ 39 files / 889 tests passed |
| `npm run tsc-check` | ⚠️ Pre-existing errors only — none in the files touched by this PR; same errors reproduce on `main`. |

### End-to-end reproduction in a real Obsidian vault against a generic HTTPS CouchDB endpoint

1. Set up Self-hosted LiveSync via the Setup wizard (URI input does not strip the trailing slash).
2. Loaded the unfixed plugin → `GET .../obsidiannotes/` returns 401, request URL contains `//obsidiannotes`.
3. Loaded the fixed plugin built from this branch → the request URL is `.../obsidiannotes/` (single slash), and the 401 disappears (subsequent 404s are PouchDB's normal "does the remote DB exist?" probe).

The companion fix for `src/common/utils.ts` and `src/features/LocalDatabaseMainte/CmdLocalDatabaseMainte.ts` is filed against the parent repo.

Ref: vrtmrz/obsidian-livesync#859