### PR TITLE
fix: preserve user/pass when serializing sls+http(s) connection strings

### DIFF
--- a/src/common/ConnectionString.ts
+++ b/src/common/ConnectionString.ts
@@ -6,33 +6,62 @@ export type RemoteConfigurationResult =
     | { type: "p2p"; settings: P2PConnectionInfo }
     | { type: "webdav"; settings: any }; // TODO: Define WebDAV settings
 
+// `sls+xxx://` is a non-special scheme per the WHATWG URL spec, which means
+// `URL.host`, `URL.username`, and `URL.password` cannot be read or written.
+// We therefore parse and build URLs against a proxy special scheme (`https`)
+// and swap the prefix in/out via string manipulation.
+const PROXY_SCHEME = "https";
+
+function parseSlsUri(uriString: string): { url: URL; subscheme: string } {
+    const match = uriString.match(/^sls\+([^:]+):(.*)$/);
+    if (!match) {
+        throw new Error(`Unsupported URI: ${uriString}`);
+    }
+    const subscheme = match[1];
+    const rest = match[2];
+    return { url: new URL(`${PROXY_SCHEME}:${rest}`), subscheme };
+}
+
+function withSlsScheme(url: URL, subscheme: string): string {
+    const out = url.toString();
+    return `sls+${subscheme}:${out.slice(PROXY_SCHEME.length + 1)}`;
+}
+
 export class ConnectionStringParser {
     /**
      * Restore settings from URI
      */
     static parse(uriString: string): RemoteConfigurationResult {
-        const url = new URL(uriString);
-        const protocol = url.protocol.replace(":", "");
+        const match = uriString.match(/^sls\+([^:]+):/);
+        if (!match) {
+            throw new Error(`Unsupported URI: ${uriString}`);
+        }
+        const subscheme = match[1];
 
-        switch (protocol) {
-            case "sls+http":
-            case "sls+https":
+        // P2P keeps the original non-special-scheme parsing because the room ID
+        // can contain characters that special-scheme URL hosts cannot represent.
+        if (subscheme === "p2p") {
+            return {
+                type: "p2p",
+                settings: this.parseP2P(new URL(uriString)),
+            };
+        }
+
+        const { url } = parseSlsUri(uriString);
+        switch (subscheme) {
+            case "http":
+            case "https":
                 return {
                     type: "couchdb",
-                    settings: this.parseCouchDB(url),
+                    settings: this.parseCouchDB(url, subscheme),
                 };
-            case "sls+s3":
+            case "s3":
                 return {
                     type: "s3",
                     settings: this.parseS3(url),
                 };
-            case "sls+p2p":
-                return {
-                    type: "p2p",
-                    settings: this.parseP2P(url),
-                };
             default:
-                throw new Error(`Unsupported protocol: ${protocol}`);
+                throw new Error(`Unsupported protocol: sls+${subscheme}`);
         }
     }
 
@@ -52,10 +81,9 @@ export class ConnectionStringParser {
         }
     }
 
-    private static parseCouchDB(url: URL): CouchDBConnection {
-        const originalProtocol = (url.protocol.split("+")[1] || "https").replace(":", "");
+    private static parseCouchDB(url: URL, originalScheme: string): CouchDBConnection {
         return {
-            couchDB_URI: `${originalProtocol}://${url.host}${url.pathname === "/" ? "" : url.pathname}`,
+            couchDB_URI: `${originalScheme}://${url.host}${url.pathname === "/" ? "" : url.pathname}`,
             couchDB_USER: decodeURIComponent(url.username),
             couchDB_PASSWORD: decodeURIComponent(url.password),
             couchDB_DBNAME: url.searchParams.get("db") || "",
@@ -72,7 +100,10 @@ export class ConnectionStringParser {
 
     private static serializeCouchDB(settings: CouchDBConnection): string {
         const url = new URL(settings.couchDB_URI);
-        const newUrl = new URL(`sls+${url.protocol.replace(":", "")}://${url.host}${url.pathname}`);
+        const subscheme = url.protocol.replace(":", "");
+        // Build the URL using the standard scheme so username/password setters work,
+        // then swap it for the sls+scheme prefix at the end.
+        const newUrl = new URL(`${PROXY_SCHEME}://${url.host}${url.pathname}`);
         newUrl.username = encodeURIComponent(settings.couchDB_USER);
         newUrl.password = encodeURIComponent(settings.couchDB_PASSWORD);
         newUrl.searchParams.set("db", settings.couchDB_DBNAME);
@@ -86,7 +117,7 @@ export class ConnectionStringParser {
             newUrl.searchParams.set("jwtExp", `${settings.jwtExpDuration || 5}`);
         }
         if (settings.useRequestAPI) newUrl.searchParams.set("useRequestAPI", "true");
-        return newUrl.toString();
+        return withSlsScheme(newUrl, subscheme);
     }
 
     private static parseS3(url: URL): BucketSyncSetting {
@@ -106,7 +137,7 @@ export class ConnectionStringParser {
 
     private static serializeS3(settings: BucketSyncSetting): string {
         const url = new URL(settings.endpoint);
-        const newUrl = new URL(`sls+s3://${url.host}`);
+        const newUrl = new URL(`${PROXY_SCHEME}://${url.host}`);
         newUrl.username = encodeURIComponent(settings.accessKey);
         newUrl.password = encodeURIComponent(settings.secretKey);
         newUrl.searchParams.set("endpoint", settings.endpoint);
@@ -116,7 +147,7 @@ export class ConnectionStringParser {
         if (settings.bucketCustomHeaders) newUrl.searchParams.set("headers", settings.bucketCustomHeaders);
         if (settings.useCustomRequestHandler) newUrl.searchParams.set("useProxy", "true");
         if (!settings.forcePathStyle) newUrl.searchParams.set("pathStyle", "false");
-        return newUrl.toString();
+        return withSlsScheme(newUrl, "s3");
     }
 
     private static parseP2P(url: URL): P2PConnectionInfo {
@@ -135,6 +166,8 @@ export class ConnectionStringParser {
     }
 
     private static serializeP2P(settings: P2PConnectionInfo): string {
+        // P2P uses the non-special `sls+p2p:` scheme directly, because the room
+        // ID may contain characters that a special-scheme URL host disallows.
         const newUrl = new URL(`sls+p2p://${encodeURIComponent(settings.P2P_roomID)}`);
         newUrl.password = encodeURIComponent(settings.P2P_passphrase);
         if (!settings.P2P_Enabled) newUrl.searchParams.set("enabled", "false");

--- a/src/common/ConnectionString.unit.spec.ts
+++ b/src/common/ConnectionString.unit.spec.ts
@@ -45,6 +45,71 @@ describe("ConnectionStringParser CouchDB JWT", () => {
     });
 });
 
+describe("ConnectionStringParser CouchDB credentials round-trip", () => {
+    it("should preserve username and password through serialize/parse", () => {
+        const uri = ConnectionStringParser.serialize({
+            type: "couchdb",
+            settings: {
+                couchDB_URI: "https://example.com",
+                couchDB_USER: "user-name",
+                couchDB_PASSWORD: "p@ss:word!",
+                couchDB_DBNAME: "vault",
+                couchDB_CustomHeaders: "",
+                useJWT: false,
+                jwtAlgorithm: "",
+                jwtKey: "",
+                jwtKid: "",
+                jwtSub: "",
+                jwtExpDuration: 5,
+                useRequestAPI: false,
+            },
+        });
+
+        expect(uri.startsWith("sls+https://")).toBe(true);
+
+        const parsed = ConnectionStringParser.parse(uri);
+        if (parsed.type !== "couchdb") {
+            throw new Error("Expected couchdb type");
+        }
+
+        expect(parsed.settings.couchDB_URI).toBe("https://example.com");
+        expect(parsed.settings.couchDB_USER).toBe("user-name");
+        expect(parsed.settings.couchDB_PASSWORD).toBe("p@ss:word!");
+        expect(parsed.settings.couchDB_DBNAME).toBe("vault");
+    });
+
+    it("should preserve credentials for the http (insecure) variant too", () => {
+        const uri = ConnectionStringParser.serialize({
+            type: "couchdb",
+            settings: {
+                couchDB_URI: "http://127.0.0.1:5984",
+                couchDB_USER: "admin",
+                couchDB_PASSWORD: "secret",
+                couchDB_DBNAME: "vault",
+                couchDB_CustomHeaders: "",
+                useJWT: false,
+                jwtAlgorithm: "",
+                jwtKey: "",
+                jwtKid: "",
+                jwtSub: "",
+                jwtExpDuration: 5,
+                useRequestAPI: false,
+            },
+        });
+
+        expect(uri.startsWith("sls+http://")).toBe(true);
+
+        const parsed = ConnectionStringParser.parse(uri);
+        if (parsed.type !== "couchdb") {
+            throw new Error("Expected couchdb type");
+        }
+
+        expect(parsed.settings.couchDB_URI).toBe("http://127.0.0.1:5984");
+        expect(parsed.settings.couchDB_USER).toBe("admin");
+        expect(parsed.settings.couchDB_PASSWORD).toBe("secret");
+    });
+});
+
 describe("ConnectionStringParser P2P", () => {
     it("should serialize and parse P2P settings including enabled and TURN fields", () => {
         const uri = ConnectionStringParser.serialize({


### PR DESCRIPTION
## Problem

`ConnectionStringParser` uses `sls+http://` and `sls+https://` as URI schemes for the new multi-remote configuration list. These are **non-special schemes** per the WHATWG URL spec, which means `URL.host`, `URL.username`, and `URL.password` cannot be read or written — setters are silently ignored and the entire authority is folded into `pathname`.

Concretely:

```js
const u = new URL("sls+https://user:pass@host/?db=vault");
u.host;     // ""
u.username; // ""
u.password; // ""
u.pathname; // "//user:pass@host/"
```

As a result, going through the Setup wizard for a CouchDB remote could persist a connection string with **no credentials at all**, e.g.:

```
sls+https://example.com/?db=obsidiannotes
```

…and on the parse side the URI was mangled back to `https:////example.com/` while user/password came back as empty strings.

The plugin then issued requests with no `Authorization` header (`Basic Og==`, i.e. `:`), and CouchDB responded with 401 `Name or password is incorrect.` even
though the credentials the user typed into the wizard were perfectly valid.

This is independent of the trailing-slash issue tracked in vrtmrz/obsidian-livesync#859 — the two bugs both produced 401 in the field but have different root
causes. Tracked as vrtmrz/obsidian-livesync#865.

## Fix

Parse and build URLs against a special-scheme proxy (`https`) and swap the prefix in/out via string manipulation. The non-special-scheme `sls+xxx://` only ever appears in the serialized output, never inside `new URL(...)`, so `host` / `username` / `password` accessors all behave correctly.

- `parse()`: regex-extract the subscheme, then construct `new URL("https:" + rest)` (a special URL).
- `serializeCouchDB()` / `serializeS3()`: build with `https://` so the username/password setters take effect, then string-prefix-swap to `sls+http(s)://` / `sls+s3://`.
- `parseCouchDB()` now takes the original subscheme (`http` vs `https`) as a parameter, since it can no longer be derived from the URL object's `protocol`.
- P2P keeps the original non-special-scheme handling because the room ID may contain characters a special-scheme URL host disallows (covered by the existing `room 123` test).

## Testing

### Static checks

| Check | Result |
| --- | --- |
| `npm run lint` (eslint) | ✅ clean |
| `npm run test:unit` | ✅ 39 files / 891 tests passed (was 889; +2 new) |

### New tests

Added round-trip assertions for CouchDB user/password in `ConnectionString.unit.spec.ts`. The existing JWT test covered URI/DBNAME/JWT fields but never asserted that `couchDB_USER` / `couchDB_PASSWORD` survive `serialize → parse`, which is why this regression went unnoticed.

### End-to-end

Reproduced and validated in a real Obsidian vault against a generic HTTPS CouchDB endpoint:

1. Unfixed plugin: Setup wizard with valid URL/username/password → `Authorization: Basic Og==` (empty user:pass) → 401 `Name or password is incorrect.`.
2. Fixed plugin built from this branch: same Setup wizard input → `Connected to obsidiannotes successfully`, sync proceeds normally.

Closes vrtmrz/obsidian-livesync#865
Ref: vrtmrz/obsidian-livesync#859