### PR TITLE
fix: preserve unsynced local changes as conflicts

### DIFF
--- a/src/interfaces/DatabaseFileAccess.ts
+++ b/src/interfaces/DatabaseFileAccess.ts
@@ -3,8 +3,14 @@ import type { FilePathWithPrefix, LoadedEntry, MetaEntry, UXFileInfo, UXFileInfo
 export interface DatabaseFileAccess {
     delete: (file: UXFileInfoStub | FilePathWithPrefix, rev?: string) => Promise<boolean>;
     store: (file: UXFileInfo, force?: boolean, skipCheck?: boolean) => Promise<boolean>;
+    storeAsConflictedRevision: (file: UXFileInfo, currentRev: string, skipCheck?: boolean) => Promise<boolean>;
     storeContent(path: FilePathWithPrefix, content: string): Promise<boolean>;
     createChunks: (file: UXFileInfo, force?: boolean, skipCheck?: boolean) => Promise<boolean>;
+    hasContentInRevisionHistory: (
+        file: UXFileInfoStub | FilePathWithPrefix,
+        content: string | string[] | Blob | ArrayBuffer,
+        currentRev?: string
+    ) => Promise<boolean>;
     fetch: (
         file: UXFileInfoStub | FilePathWithPrefix,
         rev?: string,

--- a/src/managers/EntryManager/EntryManager.ts
+++ b/src/managers/EntryManager/EntryManager.ts
@@ -107,7 +107,7 @@ export class EntryManager {
         return await deleteDBEntryByPath(this.serviceHost, this, path, opt);
     }
 
-    async putDBEntry(note: SavingEntry, onlyChunks?: boolean) {
-        return await putDBEntry(this.serviceHost, this, note, onlyChunks);
+    async putDBEntry(note: SavingEntry, onlyChunks?: boolean, conflictBaseRev?: string) {
+        return await putDBEntry(this.serviceHost, this, note, onlyChunks, conflictBaseRev);
     }
 }

--- a/src/managers/EntryManager/EntryManagerImpls.ts
+++ b/src/managers/EntryManager/EntryManagerImpls.ts
@@ -156,7 +156,8 @@ export async function putDBEntry(
     host: NecessaryServicesInterfaces<"path" | "setting", any>,
     managers: NecessaryManagers<"localDatabase" | "chunkManager" | "hashManager" | "splitter">,
     note: SavingEntry,
-    onlyChunks?: boolean
+    onlyChunks?: boolean,
+    conflictBaseRev?: string
 ) {
     const { localDatabase, chunkManager, splitter } = managers;
 
@@ -207,14 +208,18 @@ export async function putDBEntry(
 
         return (
             (await serialized("file:" + filename, async () => {
-                try {
-                    const old = await localDatabase.get(newDoc._id);
-                    newDoc._rev = old._rev;
-                } catch (ex: any) {
-                    if (isErrorOfMissingDoc(ex)) {
-                        // NO OP/
-                    } else {
-                        throw ex;
+                if (conflictBaseRev) {
+                    newDoc._rev = conflictBaseRev;
+                } else {
+                    try {
+                        const old = await localDatabase.get(newDoc._id);
+                        newDoc._rev = old._rev;
+                    } catch (ex: any) {
+                        if (isErrorOfMissingDoc(ex)) {
+                            // NO OP/
+                        } else {
+                            throw ex;
+                        }
                     }
                 }
                 const r = await localDatabase.put<PlainEntry | NewEntry>(newDoc, { force: true });

--- a/src/pouchdb/LiveSyncLocalDB.ts
+++ b/src/pouchdb/LiveSyncLocalDB.ts
@@ -518,8 +518,8 @@ export class LiveSyncLocalDB {
     async deleteDBEntry(path: FilePathWithPrefix | FilePath, opt?: PouchDB.Core.GetOptions): Promise<boolean> {
         return await this.managers.entryManager.deleteDBEntry(path, opt);
     }
-    async putDBEntry(note: SavingEntry, onlyChunks?: boolean) {
-        return await this.managers.entryManager.putDBEntry(note, onlyChunks);
+    async putDBEntry(note: SavingEntry, onlyChunks?: boolean, conflictBaseRev?: string) {
+        return await this.managers.entryManager.putDBEntry(note, onlyChunks, conflictBaseRev);
     }
 
     async getConflictedDoc(path: FilePathWithPrefix, rev: string): Promise<false | diff_result_leaf> {

--- a/src/serviceModules/ServiceDatabaseFileAccessBase.ts
+++ b/src/serviceModules/ServiceDatabaseFileAccessBase.ts
@@ -83,6 +83,14 @@ export class ServiceDatabaseFileAccessBase
     async store(file: UXFileInfo, force: boolean = false, skipCheck?: boolean): Promise<boolean> {
         return await this.__store(file, force, skipCheck, false);
     }
+    async storeAsConflictedRevision(file: UXFileInfo, currentRev: string, skipCheck?: boolean): Promise<boolean> {
+        const conflictBaseRev = await this.getParentRev(file, currentRev);
+        if (!conflictBaseRev) {
+            this._log(`Could not find parent revision for ${file.path} (${currentRev})`, LOG_LEVEL_VERBOSE);
+            return false;
+        }
+        return await this.__store(file, true, skipCheck, false, conflictBaseRev);
+    }
     async storeContent(path: FilePathWithPrefix, content: string): Promise<boolean> {
         const blob = createTextBlob(content);
         const bytes = (await blob.arrayBuffer()).byteLength;
@@ -106,7 +114,8 @@ export class ServiceDatabaseFileAccessBase
         file: UXFileInfo,
         force: boolean = false,
         skipCheck?: boolean,
-        onlyChunks?: boolean
+        onlyChunks?: boolean,
+        conflictBaseRev?: string
     ): Promise<boolean> {
         if (!skipCheck) {
             if (!(await this.checkIsTargetFile(file))) {
@@ -170,6 +179,9 @@ export class ServiceDatabaseFileAccessBase
         //upsert should locked
         const msg = `STORAGE -> DB (${datatype}) `;
         const isNotChanged = await serialized("file-" + fullPath, async () => {
+            if (conflictBaseRev) {
+                return false;
+            }
             if (force) {
                 this._log(msg + "Force writing " + fullPath, LOG_LEVEL_VERBOSE);
                 return false;
@@ -211,12 +223,67 @@ export class ServiceDatabaseFileAccessBase
             this._log(msg + " Skip " + fullPath, LOG_LEVEL_VERBOSE);
             return true;
         }
-        const ret = await this.database.localDatabase.putDBEntry(d, onlyChunks);
+        const ret = await this.database.localDatabase.putDBEntry(d, onlyChunks, conflictBaseRev);
         if (ret !== false) {
             this._log(msg + fullPath);
             eventHub.emitEvent(EVENT_FILE_SAVED);
         }
         return ret != false;
+    }
+
+    private async getParentRev(file: UXFileInfoStub | FilePathWithPrefix, rev: string): Promise<string | false> {
+        const filename = getDatabasePathFromUXFileInfo(file);
+        try {
+            const doc = await this.database.localDatabase.getDBEntryMeta(filename, { rev, revs: true }, true);
+            if (doc === false) {
+                return false;
+            }
+            const revisions = (doc as { _revisions?: { start: number; ids: string[] } })._revisions;
+            if (!revisions || revisions.ids.length < 2) {
+                return false;
+            }
+            return `${revisions.start - 1}-${revisions.ids[1]}`;
+        } catch (ex) {
+            this._log(`Could not read revision history for ${filename} (${rev})`, LOG_LEVEL_VERBOSE);
+            this._log(ex, LOG_LEVEL_VERBOSE);
+            return false;
+        }
+    }
+
+    async hasContentInRevisionHistory(
+        file: UXFileInfoStub | FilePathWithPrefix,
+        content: string | string[] | Blob | ArrayBuffer,
+        currentRev?: string
+    ): Promise<boolean> {
+        if (!(await this.checkIsTargetFile(file))) {
+            return true;
+        }
+        const filename = getDatabasePathFromUXFileInfo(file);
+        try {
+            const doc = await this.database.localDatabase.getDBEntryMeta(
+                filename,
+                { rev: currentRev, revs_info: true },
+                true
+            );
+            if (doc === false) {
+                return false;
+            }
+            const revisions = (doc as LoadedEntry & { _revs_info?: { rev: string; status: string }[] })._revs_info;
+            const availableRevs = new Set((revisions || []).filter((e) => e.status === "available").map((e) => e.rev));
+            if (currentRev) {
+                availableRevs.add(currentRev);
+            }
+            for (const rev of availableRevs) {
+                const entry = await this.database.localDatabase.getDBEntry(filename, { rev }, false, true, true);
+                if (entry !== false && (await isDocContentSame(readContent(entry), content))) {
+                    return true;
+                }
+            }
+        } catch (ex) {
+            this._log(`Could not check revision history for ${filename}`, LOG_LEVEL_VERBOSE);
+            this._log(ex, LOG_LEVEL_VERBOSE);
+        }
+        return false;
     }
 
     async getConflictedRevs(file: UXFileInfoStub | FilePathWithPrefix): Promise<string[]> {

--- a/src/serviceModules/ServiceFileHandlerBase.ts
+++ b/src/serviceModules/ServiceFileHandlerBase.ts
@@ -292,6 +292,9 @@ export abstract class ServiceFileHandlerBase
             return true;
         }
         if (!existOnDB && existOnStorage) {
+            if (!force && (await this.preserveUnsyncedStorageAsConflict(path, existDoc, docEntry))) {
+                return true;
+            }
             // Deletion has been Transferred. Storage files will be deleted.
             // Note: If the folder becomes empty, the folder will be deleted if not configured to keep it.
             // And it does not care actually deleted.
@@ -349,6 +352,9 @@ export abstract class ServiceFileHandlerBase
                 this._log(`File ${docRead.path} is not changed`, LOG_LEVEL_VERBOSE);
                 return true;
             }
+            if (await this.preserveUnsyncedStorageAsConflict(path, existDoc, docEntry, docData)) {
+                return true;
+            }
             // Let's apply the changes.
         } else {
             this._log(
@@ -361,6 +367,32 @@ export abstract class ServiceFileHandlerBase
         await this.storage.touched(path);
         this.storage.triggerFileEvent(mode, path);
         return ret;
+    }
+
+    private async preserveUnsyncedStorageAsConflict(
+        path: FilePathWithPrefix,
+        existDoc: UXFileInfoStub,
+        incomingEntry: MetaEntry,
+        incomingContent?: string | string[] | Blob | ArrayBuffer
+    ): Promise<boolean> {
+        const readFile = await this.readFileFromStub(existDoc);
+        if (incomingContent && (await isDocContentSame(incomingContent, readFile.body))) {
+            return false;
+        }
+        if (!incomingEntry._rev) {
+            return false;
+        }
+        if (await this.db.hasContentInRevisionHistory(path, readFile.body, incomingEntry._rev)) {
+            return false;
+        }
+        const stored = await this.db.storeAsConflictedRevision(readFile, incomingEntry._rev, true);
+        if (!stored) {
+            this._log(`Prevented overwriting unsynchronised local changes for ${path}`, LOG_LEVEL_NOTICE);
+            return true;
+        }
+        this._log(`Preserved unsynchronised local changes as a conflict for ${path}`, LOG_LEVEL_NOTICE);
+        await this.conflict.queueCheckFor(path);
+        return true;
     }
 
     private async _anyHandlerProcessesFileEvent(item: FileEventItem): Promise<boolean> {

--- a/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts
+++ b/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { EVEN } from "@lib/common/models/shared.const.symbols";
+import type { MetaEntry, UXFileInfo, UXFileInfoStub } from "@lib/common/types";
+import { createTextBlob } from "@lib/common/utils";
+import { ServiceFileHandlerBase, type ServiceFileHandlerDependencies } from "./ServiceFileHandlerBase";
+
+class TestFileHandler extends ServiceFileHandlerBase {}
+
+function byteLength(text: string) {
+    return new Blob([text]).size;
+}
+
+function createMeta(path: string, body: string, rev = "2-remote"): MetaEntry {
+    return {
+        _id: "doc-id",
+        _rev: rev,
+        path,
+        ctime: 1,
+        mtime: 2,
+        size: byteLength(body),
+        children: [],
+        datatype: "plain",
+        type: "plain",
+        eden: {},
+    } as unknown as MetaEntry;
+}
+
+function createStorageFile(path: string, body: string): UXFileInfo {
+    return {
+        name: path.split("/").pop() || path,
+        path,
+        stat: {
+            ctime: 1,
+            mtime: 3,
+            size: byteLength(body),
+            type: "file",
+        },
+        body: createTextBlob(body),
+    } as UXFileInfo;
+}
+
+function createHandler(localBody: string, remoteBody: string, localContentIsKnown: boolean) {
+    const path = "note.md";
+    const remoteMeta = createMeta(path, remoteBody);
+    const remoteEntry = {
+        ...remoteMeta,
+        data: remoteBody,
+    };
+    const storageFile = createStorageFile(path, localBody);
+    const storageStub = { ...storageFile };
+    delete (storageStub as Partial<UXFileInfo>).body;
+
+    const databaseFileAccess = {
+        fetchEntryMeta: vi.fn().mockResolvedValue(remoteMeta),
+        getConflictedRevs: vi.fn().mockResolvedValue([]),
+        fetchEntryFromMeta: vi.fn().mockResolvedValue(remoteEntry),
+        hasContentInRevisionHistory: vi.fn().mockResolvedValue(localContentIsKnown),
+        storeAsConflictedRevision: vi.fn().mockResolvedValue(true),
+    };
+    const storageAccess = {
+        getFileStub: vi.fn().mockResolvedValue(storageStub),
+        getStub: vi.fn().mockResolvedValue(storageStub),
+        readStubContent: vi.fn().mockResolvedValue(storageFile),
+        ensureDir: vi.fn().mockResolvedValue(undefined),
+        writeFileAuto: vi.fn().mockResolvedValue(true),
+        touched: vi.fn().mockResolvedValue(undefined),
+        triggerFileEvent: vi.fn(),
+    };
+    const conflict = {
+        queueCheckFor: vi.fn().mockResolvedValue(undefined),
+        queueCheckForIfOpen: vi.fn().mockResolvedValue(undefined),
+    };
+    const pathService = {
+        getPath: vi.fn().mockImplementation((entry: MetaEntry) => entry.path),
+        compareFileFreshness: vi.fn().mockReturnValue(Symbol("target-is-new")),
+        markChangesAreSame: vi.fn(),
+    };
+    const deps = {
+        API: { addLog: vi.fn() },
+        databaseFileAccess,
+        storageAccess,
+        fileProcessing: { processFileEvent: { addHandler: vi.fn() } },
+        replication: { processSynchroniseResult: { addHandler: vi.fn() } },
+        conflict,
+        path: pathService,
+        setting: { currentSettings: vi.fn().mockReturnValue({ writeDocumentsIfConflicted: false }) },
+        vault: {},
+    } as unknown as ServiceFileHandlerDependencies;
+
+    return {
+        handler: new TestFileHandler(deps),
+        remoteMeta,
+        storageStub: storageStub as UXFileInfoStub,
+        databaseFileAccess,
+        storageAccess,
+        conflict,
+        pathService,
+    };
+}
+
+describe("ServiceFileHandlerBase.dbToStorage", () => {
+    it("preserves unknown local storage content as a conflict before applying a remote revision", async () => {
+        const { handler, remoteMeta, storageStub, databaseFileAccess, storageAccess, conflict } = createHandler(
+            "local unsynced",
+            "remote update",
+            false
+        );
+
+        await expect(handler.dbToStorage(remoteMeta, storageStub)).resolves.toBe(true);
+
+        expect(databaseFileAccess.storeAsConflictedRevision).toHaveBeenCalledWith(
+            expect.objectContaining({ path: "note.md" }),
+            "2-remote",
+            true
+        );
+        expect(conflict.queueCheckFor).toHaveBeenCalledWith("note.md");
+        expect(storageAccess.writeFileAuto).not.toHaveBeenCalled();
+    });
+
+    it("applies the remote revision when local storage content is already in database history", async () => {
+        const { handler, remoteMeta, storageStub, databaseFileAccess, storageAccess, conflict } = createHandler(
+            "known old revision",
+            "remote update",
+            true
+        );
+
+        await expect(handler.dbToStorage(remoteMeta, storageStub)).resolves.toBe(true);
+
+        expect(databaseFileAccess.storeAsConflictedRevision).not.toHaveBeenCalled();
+        expect(conflict.queueCheckFor).not.toHaveBeenCalled();
+        expect(storageAccess.writeFileAuto).toHaveBeenCalledWith("note.md", "remote update", {
+            ctime: 1,
+            mtime: 2,
+        });
+    });
+
+    it("does not run the protection path when the remote content matches storage", async () => {
+        const { handler, remoteMeta, storageStub, databaseFileAccess, storageAccess, pathService } = createHandler(
+            "same body",
+            "same body",
+            false
+        );
+        pathService.compareFileFreshness.mockReturnValue(EVEN);
+
+        await expect(handler.dbToStorage(remoteMeta, storageStub)).resolves.toBe(true);
+
+        expect(databaseFileAccess.hasContentInRevisionHistory).not.toHaveBeenCalled();
+        expect(storageAccess.writeFileAuto).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- Detect storage content that is not present in the local revision history before applying a remote database revision.
- Store that unknown local content as a sibling conflict revision and queue conflict resolution instead of overwriting it.
- Add regression coverage for the remote-apply path.

## Tests
- npm run tsc-check
- npx vitest run --config vitest.config.unit.ts src/lib/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts