### PR TITLE
Enhance fix p2p

### DIFF
--- a/src/replication/trystero/LiveSyncTrysteroReplicator.ts
+++ b/src/replication/trystero/LiveSyncTrysteroReplicator.ts
@@ -92,11 +92,13 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
     }
 
     async open() {
-        if (this._replicator && this._p2pHost?.isServing) {
+        if (!this.env.services.setting.currentSettings().P2P_Enabled) {
+            Logger($msg("P2P.NotEnabled"), LOG_LEVEL_NOTICE);
+            // Nothing to do.
             return;
         }
-        if (!this.env.services.setting.currentSettings().P2P_Enabled) {
-            // Nothing to do.
+        if (this._replicator && this._p2pHost?.isServing) {
+            Logger("P2P replicator is already open.");
             return;
         }
         try {

--- a/src/replication/trystero/LiveSyncTrysteroReplicator.ts
+++ b/src/replication/trystero/LiveSyncTrysteroReplicator.ts
@@ -36,6 +36,11 @@ export interface LiveSyncTrysteroReplicatorEnv extends LiveSyncReplicatorEnv {
      * When not set, openReplication falls back to replicateFromCommand (CLI-safe).
      */
     openReplicationUI?: (showResult: boolean) => Promise<boolean | void>;
+    /**
+     * Injected by the host platform to show a UI for selecting a peer to rebuild from.
+     * When not set, replicateAllFromServer falls back to the headless selectPeer dialog.
+     */
+    openRebuildUI?: (showResult: boolean) => Promise<boolean | void>;
 }
 
 export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
@@ -189,6 +194,14 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
         return await this._replicator.sync(peerId, showNotice);
     }
 
+    setOnSetup() {
+        this._replicator?.setOnSetup();
+    }
+
+    clearOnSetup() {
+        this._replicator?.clearOnSetup();
+    }
+
     async makeDecision(decision: AcceptanceDecision) {
         await this._replicator?.server?.makeDecision(decision);
     }
@@ -309,13 +322,20 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
             return this.replicateAllFromServer(setting, showingNotice);
         }
         await this.open();
-        await eventHub.waitFor(EVENT_P2P_CONNECTED);
 
-        const peerFrom = setting.P2P_RebuildFrom;
         if (!this._replicator) {
             Logger("Failed to get replicator instance.", logLevel);
             return false;
         }
+
+        // If a rebuild UI handler was injected (e.g. Obsidian modal), use it.
+        if (this.env.openRebuildUI) {
+            return (await this.env.openRebuildUI(showingNotice ?? false)) !== false;
+        }
+
+        // Fallback: headless peer-selection flow (CLI / non-Obsidian).
+        await eventHub.waitFor(EVENT_P2P_CONNECTED);
+        const peerFrom = setting.P2P_RebuildFrom;
         this._replicator.setOnSetup();
         try {
             const r = await this.tryUntilSuccess(

--- a/src/replication/trystero/LiveSyncTrysteroReplicator.ts
+++ b/src/replication/trystero/LiveSyncTrysteroReplicator.ts
@@ -31,11 +31,20 @@ import type { Advertisement } from "./types";
 
 export interface LiveSyncTrysteroReplicatorEnv extends LiveSyncReplicatorEnv {
     services: IServiceHub;
+    /**
+     * Injected by the host platform (e.g. Obsidian) to show a UI for peer selection.
+     * When not set, openReplication falls back to replicateFromCommand (CLI-safe).
+     */
+    openReplicationUI?: (showResult: boolean) => Promise<boolean | void>;
 }
 
 export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
     private _p2pHost?: P2PHost;
     private _replicator?: TrysteroReplicator;
+
+    get openReplicationUI() {
+        return this.env.openReplicationUI;
+    }
 
     get rawReplicator() {
         return this._replicator;
@@ -198,12 +207,18 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
         showResult: boolean,
         _ignoreCleanLock: boolean
     ): Promise<void | boolean> {
+        // If a UI handler was injected (e.g. Obsidian modal), use it.
+        if (this.openReplicationUI) {
+            return this.openReplicationUI(showResult);
+        }
+        // Fallback: CLI or headless environment — run non-interactive replication.
         const logLevel = showResult ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO;
+
+        await this.makeSureOpened();
         if (!this._replicator) {
             Logger($msg("P2P.ReplicatorInstanceMissing"), logLevel);
             return false;
         }
-        await this._replicator.makeSureOpened();
         await this._replicator.replicateFromCommand(showResult);
     }
 
@@ -260,7 +275,7 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
         const confirm = this.env.services.UI.confirm;
         if (!confirm) {
             Logger("Cannot find confirm instance.", logLevel);
-            return Promise.reject("Cannot find confirm instance.");
+            return Promise.reject(new Error("Cannot find confirm instance."));
         }
         let result;
         while (!result) {
@@ -269,7 +284,7 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
                     result = await func();
                     if (result) break;
                 } catch (e) {
-                    Logger("Error: " + e, logLevel);
+                    Logger(`Error: ${e instanceof Error ? e.message : String(e)}`, logLevel);
                     result = false;
                 }
                 await delay(1000);

--- a/src/replication/trystero/P2PReplicatorCore.ts
+++ b/src/replication/trystero/P2PReplicatorCore.ts
@@ -80,7 +80,11 @@ export function useP2PReplicator(
     // Suspend extra sync handler
     host.services.setting.suspendExtraSync.addHandler(() => {
         const s = host.services.setting.currentSettings();
-        s.P2P_Enabled = false;
+        // When P2P is the primary remote type, do not disable P2P_Enabled —
+        // the rebuild/fetch flows depend on it to replicate from a peer.
+        if (s.remoteType !== REMOTE_P2P) {
+            s.P2P_Enabled = false;
+        }
         s.P2P_AutoAccepting = AutoAccepting.NONE;
         s.P2P_AutoBroadcast = false;
         s.P2P_AutoStart = false;

--- a/src/replication/trystero/TrysteroReplicator.ts
+++ b/src/replication/trystero/TrysteroReplicator.ts
@@ -322,22 +322,22 @@ export class TrysteroReplicator {
         }
     }
 
-    async selectPeer() {
-        if (!this.server) return false;
-        const knownPeers = this.server.knownAdvertisements;
-        if (knownPeers.length === 0) {
-            Logger("No known peers", LOG_LEVEL_VERBOSE);
-            return false;
-        }
+    // async selectPeer() {
+    //     if (!this.server) return false;
+    //     const knownPeers = this.server.knownAdvertisements;
+    //     if (knownPeers.length === 0) {
+    //         Logger("No known peers", LOG_LEVEL_VERBOSE);
+    //         return false;
+    //     }
 
-        const peers = [...Object.entries(knownPeers)].map(([peerId, info]) => {
-            return `${info.peerId}\u2001: (${info.name})`;
-        });
+    //     const peers = [...Object.entries(knownPeers)].map(([peerId, info]) => {
+    //         return `${info.peerId}\u2001: (${info.name})`;
+    //     });
 
-        const selectedPeer = await this.confirm.askSelectString("Select a peer to replicate", peers);
-        if (selectedPeer) return selectedPeer.split("\u2001")[0];
-        return false;
-    }
+    //     const selectedPeer = await this.confirm.askSelectString("Select a peer to replicate", peers);
+    //     if (selectedPeer) return selectedPeer.split("\u2001")[0];
+    //     return false;
+    // }
 
     lastSeq = "" as string | number;
     async requestSynchroniseToPeer(
@@ -456,27 +456,27 @@ export class TrysteroReplicator {
     }
 
     _replicateToPeers = new Set<string>();
-    async replicateTo() {
-        await this.makeSureOpened();
-        const remotePeer = await this.selectPeer();
-        if (!remotePeer) {
-            Logger("No peer selected", LOG_LEVEL_VERBOSE);
-            return;
-        }
-        Logger(`P2P Replicating to ${remotePeer}`, LOG_LEVEL_INFO);
-        try {
-            if (this._replicateToPeers.has(remotePeer)) {
-                Logger(`Replication to ${remotePeer} is already in progress`, LOG_LEVEL_VERBOSE);
-                return;
-            }
-            this._replicateToPeers.add(remotePeer);
-            this.dispatchStatus();
-            return await this.requestSynchroniseToPeer(remotePeer);
-        } finally {
-            this._replicateToPeers.delete(remotePeer);
-            this.dispatchStatus();
-        }
-    }
+    // async replicateTo() {
+    //     await this.makeSureOpened();
+    //     const remotePeer = await this.selectPeer();
+    //     if (!remotePeer) {
+    //         Logger("No peer selected", LOG_LEVEL_VERBOSE);
+    //         return;
+    //     }
+    //     Logger(`P2P Replicating to ${remotePeer}`, LOG_LEVEL_INFO);
+    //     try {
+    //         if (this._replicateToPeers.has(remotePeer)) {
+    //             Logger(`Replication to ${remotePeer} is already in progress`, LOG_LEVEL_VERBOSE);
+    //             return;
+    //         }
+    //         this._replicateToPeers.add(remotePeer);
+    //         this.dispatchStatus();
+    //         return await this.requestSynchroniseToPeer(remotePeer);
+    //     } finally {
+    //         this._replicateToPeers.delete(remotePeer);
+    //         this.dispatchStatus();
+    //     }
+    // }
 
     _replicateFromPeers = new Set<string>();
 

--- a/src/replication/trystero/TrysteroReplicator.ts
+++ b/src/replication/trystero/TrysteroReplicator.ts
@@ -1,3 +1,4 @@
+import type PouchDB from "pouchdb-core";
 import { TweakValuesShouldMatchedTemplate, type EntryDoc, type ObsidianLiveSyncSettings } from "../../common/types";
 import { LOG_LEVEL_INFO, LOG_LEVEL_NOTICE, LOG_LEVEL_VERBOSE, Logger } from "octagonal-wheels/common/logger";
 import { replicateShim, type PouchDBShim, type ProgressInfo } from "../../pouchdb/ReplicatorShim";
@@ -753,7 +754,7 @@ export class TrysteroReplicator {
                 .map((e) => e.trim())
                 .filter((e) => e);
             if (peers.length == 0) {
-                Logger($msg("P2P.NoAutoSyncPeers"), logLevel);
+                Logger($msg("P2P.NoAutoSyncPeers"), LOG_LEVEL_NOTICE);
                 return Promise.resolve(false);
             }
 

--- a/src/replication/trystero/TrysteroReplicatorP2PServer.ts
+++ b/src/replication/trystero/TrysteroReplicatorP2PServer.ts
@@ -30,6 +30,7 @@ import { $msg } from "../../common/i18n";
 import { shareRunningResult } from "octagonal-wheels/concurrency/lock_v2";
 import { Computed } from "octagonal-wheels/dataobject/Computed";
 import { RpcRoom, type RpcWireMessage, type TransportAdapter } from "@lib/rpc";
+import { TRYSTERO_RPC_DEFAULTS } from "@lib/rpc/transports/TrysteroTransport";
 import { toRpcMethodName } from "./rpcCompat";
 
 export type PeerInfo = Advertisement & {
@@ -413,6 +414,7 @@ You can chose as follows:
         };
         this._rpcRoom?.close();
         this._rpcRoom = new RpcRoom({
+            ...TRYSTERO_RPC_DEFAULTS,
             transport,
             canAcceptRequest: async (peerId, method) => {
                 if (method === toRpcMethodName("!reqAuth")) return true;

--- a/src/replication/trystero/useP2PReplicatorCommands.ts
+++ b/src/replication/trystero/useP2PReplicatorCommands.ts
@@ -1,5 +1,4 @@
 import { Logger, LOG_LEVEL_NOTICE } from "octagonal-wheels/common/logger";
-import { REMOTE_P2P } from "../../common/types";
 import type { NecessaryServices } from "../../interfaces/ServiceModule";
 import type { UseP2PReplicatorResult } from "./UseP2PReplicatorResult";
 
@@ -30,30 +29,30 @@ export function useP2PReplicatorCommands(
             void replicator.close();
         },
     });
-    host.services.API.addCommand({
-        id: "replicate-now-by-p2p",
-        name: "Replicate now by P2P",
-        checkCallback: (isChecking: boolean) => {
-            if (!replicator) return false;
-            const settings = host.services.setting.currentSettings();
-            if (isChecking) {
-                if (settings.remoteType == REMOTE_P2P) return false;
-                return replicator.server?.isServing ?? false;
-            }
-            void replicator.replicateFromCommand(false);
-        },
-    });
-    host.services.API.addCommand({
-        id: "force-replicate-now-by-p2p",
-        name: "P2P Sync: Select peer to replicate with",
-        checkCallback: (isChecking: boolean) => {
-            if (!replicator) return false;
-            const settings = host.services.setting.currentSettings();
-            if (isChecking) {
-                if (settings.remoteType == REMOTE_P2P) return false;
-                return replicator.server?.isServing ?? false;
-            }
-            void replicator.rawReplicator?.replicateTo();
-        },
-    });
+    // host.services.API.addCommand({
+    //     id: "replicate-now-by-p2p",
+    //     name: "Replicate now by P2P",
+    //     checkCallback: (isChecking: boolean) => {
+    //         if (!replicator) return false;
+    //         const settings = host.services.setting.currentSettings();
+    //         if (isChecking) {
+    //             if (settings.remoteType == REMOTE_P2P) return false;
+    //             return replicator.server?.isServing ?? false;
+    //         }
+    //         void replicator.replicateFromCommand(false);
+    //     },
+    // });
+    // host.services.API.addCommand({
+    //     id: "force-replicate-now-by-p2p",
+    //     name: "P2P Sync: Select peer to replicate with",
+    //     checkCallback: (isChecking: boolean) => {
+    //         if (!replicator) return false;
+    //         const settings = host.services.setting.currentSettings();
+    //         if (isChecking) {
+    //             if (settings.remoteType == REMOTE_P2P) return false;
+    //             return replicator.server?.isServing ?? false;
+    //         }
+    //         void replicator.rawReplicator?.replicateTo();
+    //     },
+    // });
 }

--- a/src/replication/trystero/useP2PReplicatorFeature.ts
+++ b/src/replication/trystero/useP2PReplicatorFeature.ts
@@ -14,6 +14,9 @@ export type OpenReplicationUIFactory = (
     replicator: LiveSyncTrysteroReplicator
 ) => (showResult: boolean) => Promise<boolean | void>;
 
+/** Same shape as OpenReplicationUIFactory, used for the rebuild/replicateAllFromServer flow. */
+export type OpenRebuildUIFactory = OpenReplicationUIFactory;
+
 /**
  * ServiceFeature: P2P Replicator integration and lifecycle management.
  * Registers a LiveSyncTrysteroReplicator instance as the active replicator when P2P is enabled in settings,
@@ -23,7 +26,8 @@ export type OpenReplicationUIFactory = (
 
 export function useP2PReplicatorFeature(
     host: NecessaryServices<"API" | "setting" | "replicator" | "appLifecycle" | "databaseEvents", never>,
-    openReplicationUIFactory?: OpenReplicationUIFactory
+    openReplicationUIFactory?: OpenReplicationUIFactory,
+    openRebuildUIFactory?: OpenRebuildUIFactory
 ): UseP2PReplicatorResult {
     // Replicator instance should be single and shared across the plug-in.
     let replicator: LiveSyncTrysteroReplicator = new LiveSyncTrysteroReplicator({
@@ -31,6 +35,9 @@ export function useP2PReplicatorFeature(
     });
     if (openReplicationUIFactory) {
         replicator.env.openReplicationUI = openReplicationUIFactory(replicator);
+    }
+    if (openRebuildUIFactory) {
+        replicator.env.openRebuildUI = openRebuildUIFactory(replicator);
     }
     const activeReplicator = {
         get replicator() {
@@ -51,6 +58,9 @@ export function useP2PReplicatorFeature(
             const newReplicator = new LiveSyncTrysteroReplicator({ services: host.services as unknown as IServiceHub });
             if (openReplicationUIFactory) {
                 newReplicator.env.openReplicationUI = openReplicationUIFactory(newReplicator);
+            }
+            if (openRebuildUIFactory) {
+                newReplicator.env.openRebuildUI = openRebuildUIFactory(newReplicator);
             }
             replicator = newReplicator; // Update the replicator reference for lifecycle handlers
             return replicator;
@@ -87,7 +97,11 @@ export function useP2PReplicatorFeature(
     // Suspend extra sync handler
     host.services.setting.suspendExtraSync.addHandler(() => {
         const s = host.services.setting.currentSettings();
-        s.P2P_Enabled = false;
+        // When P2P is the primary remote type, do not disable P2P_Enabled —
+        // the rebuild/fetch flows depend on it to replicate from a peer.
+        if (s.remoteType !== REMOTE_P2P) {
+            s.P2P_Enabled = false;
+        }
         s.P2P_AutoAccepting = AutoAccepting.NONE;
         s.P2P_AutoBroadcast = false;
         s.P2P_AutoStart = false;

--- a/src/replication/trystero/useP2PReplicatorFeature.ts
+++ b/src/replication/trystero/useP2PReplicatorFeature.ts
@@ -1,9 +1,18 @@
+import type { IServiceHub } from "@lib/services/base/IService";
 import { Logger, LOG_LEVEL_VERBOSE } from "octagonal-wheels/common/logger";
 import { AutoAccepting, REMOTE_P2P } from "../../common/types";
 import type { NecessaryServices } from "../../interfaces/ServiceModule";
 import { LiveSyncTrysteroReplicator } from "./LiveSyncTrysteroReplicator";
 import { type UseP2PReplicatorResult } from "./UseP2PReplicatorResult";
 import { addP2PEventHandlers } from "./addP2PEventHandlers";
+
+/**
+ * Factory type: given a replicator instance, returns the openReplicationUI callback for that instance.
+ * Injected by the host platform (e.g. Obsidian). CLI/headless environments omit this.
+ */
+export type OpenReplicationUIFactory = (
+    replicator: LiveSyncTrysteroReplicator
+) => (showResult: boolean) => Promise<boolean | void>;
 
 /**
  * ServiceFeature: P2P Replicator integration and lifecycle management.
@@ -13,17 +22,22 @@ import { addP2PEventHandlers } from "./addP2PEventHandlers";
  */
 
 export function useP2PReplicatorFeature(
-    host: NecessaryServices<"API" | "setting" | "replicator" | "appLifecycle" | "databaseEvents", never>
+    host: NecessaryServices<"API" | "setting" | "replicator" | "appLifecycle" | "databaseEvents", never>,
+    openReplicationUIFactory?: OpenReplicationUIFactory
 ): UseP2PReplicatorResult {
     // Replicator instance should be single and shared across the plug-in.
-    let replicator: LiveSyncTrysteroReplicator = new LiveSyncTrysteroReplicator({ services: host.services as any });
+    let replicator: LiveSyncTrysteroReplicator = new LiveSyncTrysteroReplicator({
+        services: host.services as unknown as IServiceHub,
+    });
+    if (openReplicationUIFactory) {
+        replicator.env.openReplicationUI = openReplicationUIFactory(replicator);
+    }
     const activeReplicator = {
         get replicator() {
             return replicator;
         },
     };
     addP2PEventHandlers(activeReplicator.replicator);
-
     host.services.replicator.getNewReplicator.addHandler(async (settingOverride: Partial<any> = {}) => {
         const settings = { ...host.services.setting.currentSettings(), ...settingOverride };
         if (settings.remoteType == REMOTE_P2P) {
@@ -34,7 +48,10 @@ export function useP2PReplicatorFeature(
                 Logger(`Error closing existing p2p replicator`);
                 Logger(e, LOG_LEVEL_VERBOSE);
             }
-            const newReplicator = new LiveSyncTrysteroReplicator({ services: host.services as any });
+            const newReplicator = new LiveSyncTrysteroReplicator({ services: host.services as unknown as IServiceHub });
+            if (openReplicationUIFactory) {
+                newReplicator.env.openReplicationUI = openReplicationUIFactory(newReplicator);
+            }
             replicator = newReplicator; // Update the replicator reference for lifecycle handlers
             return replicator;
         }
@@ -62,7 +79,7 @@ export function useP2PReplicatorFeature(
     host.services.appLifecycle.onResumed.addHandler(() => {
         const settings = host.services.setting.currentSettings();
         if (settings.P2P_Enabled && settings.P2P_AutoStart) {
-            setTimeout(() => void replicator?.open(), 100);
+            window.setTimeout(() => void replicator?.open(), 100);
         }
         return Promise.resolve(true);
     });

--- a/src/rpc/transports/TrysteroTransport.ts
+++ b/src/rpc/transports/TrysteroTransport.ts
@@ -107,8 +107,28 @@ export function attachAdvertisement(
  * Options forwarded to the `RpcRoom` constructor when creating a room through
  * the high-level helpers (`serveTrysteroDB`, `connectTrysteroDBClient`, or by
  * calling `joinTrysteroRoom` and then constructing `RpcRoom` manually).
+ *
+ * Trystero internally chunks at ~16 348 bytes (16 KiB minus a 36-byte header).
+ * Setting `maxWirePayloadBytes` above that threshold causes double-chunking.
+ * The Trystero-appropriate default is therefore **15 360 bytes** (15 KiB),
+ * which leaves ~1 KiB of headroom for the JSON wrapper overhead.
+ *
+ * Trystero uses WebRTC SCTP data channels which guarantee delivery and order,
+ * so missing-chunk retransmission virtually never triggers.  `chunkMissingRetryMs`
+ * can safely be lowered from the generic default of 350 ms to **150 ms**.
  */
-export type TrysteroRoomOptions = Pick<RpcRoomOptions, "canAcceptRequest" | "onProtocolWarning">;
+export type TrysteroRoomOptions = Pick<RpcRoomOptions, "canAcceptRequest" | "onProtocolWarning"> & {
+    maxWirePayloadBytes?: number;
+    chunkMissingRetryMs?: number;
+};
+
+/** Trystero-appropriate defaults for `RpcRoom`. */
+export const TRYSTERO_RPC_DEFAULTS = {
+    /** Stay below Trystero's internal ~16 348-byte chunk boundary. */
+    maxWirePayloadBytes: 15 * 1024,
+    /** SCTP guarantees delivery; retransmission is a last-resort safety net. */
+    chunkMissingRetryMs: 150,
+} as const;
 
 // ---------------------------------------------------------------------------
 // Low-level: wrap an already-joined Trystero Room
@@ -299,7 +319,7 @@ export function serveTrysteroDB(
     options?: TrysteroRoomOptions
 ): TrysteroDBServerHandle {
     const roomHandle = joinTrysteroRoom(settings);
-    const rpcRoom = new RpcRoom({ transport: roomHandle.transport, ...options });
+    const rpcRoom = new RpcRoom({ ...TRYSTERO_RPC_DEFAULTS, transport: roomHandle.transport, ...options });
     exposeDB(rpcRoom, db, ns);
 
     return {
@@ -355,7 +375,7 @@ export function connectTrysteroDBClient(
     options?: TrysteroRoomOptions
 ): TrysteroDBClientHandle {
     const roomHandle = joinTrysteroRoom(settings);
-    const rpcRoom = new RpcRoom({ transport: roomHandle.transport, ...options });
+    const rpcRoom = new RpcRoom({ ...TRYSTERO_RPC_DEFAULTS, transport: roomHandle.transport, ...options });
     const proxy = new RpcPouchDBProxy(rpcRoom.session(serverPeerId), dbName, ns);
 
     return {

--- a/src/services/base/APIService.ts
+++ b/src/services/base/APIService.ts
@@ -37,6 +37,14 @@ export abstract class APIService<T extends ServiceContext = ServiceContext>
     abstract showWindow(type: string): Promise<void>;
 
     /**
+     * Show a window on the right sidebar when supported.
+     * Platforms that do not support sidebars can fall back to showWindow.
+     */
+    showWindowOnRight(type: string): Promise<void> {
+        return this.showWindow(type);
+    }
+
+    /**
      * returns App ID. In Obsidian, it is vault ID.
      */
     abstract getAppID(): string;

--- a/src/services/base/IService.ts
+++ b/src/services/base/IService.ts
@@ -56,6 +56,7 @@ export interface IAPIService {
     isMobile(): boolean;
 
     showWindow(type: string): Promise<void>;
+    showWindowOnRight?(type: string): Promise<void>;
 
     getAppID(): string;
 

--- a/src/services/base/ReplicatorService.ts
+++ b/src/services/base/ReplicatorService.ts
@@ -69,7 +69,7 @@ export abstract class ReplicatorService<T extends ServiceContext = ServiceContex
     private async disposeReplicator() {
         this._log("Detect database reset, closing active replicator if exists.");
         if (this._activeReplicator) {
-            await this._activeReplicator.closeReplication();
+            await Promise.resolve(this._activeReplicator.closeReplication());
         }
         // To flush e2ee salts, device id, and other information kept in the replicator instance, to avoid potential database corruption after reset.
 
@@ -90,11 +90,14 @@ export abstract class ReplicatorService<T extends ServiceContext = ServiceContex
             return true;
         }
         const replicatorType = setting.remoteType;
-        const hasReplicatorConfig =
-            (replicatorType === RemoteTypes.REMOTE_COUCHDB &&
-                !!setting.couchDB_URI?.trim() &&
-                !!setting.couchDB_DBNAME?.trim()) ||
-            (replicatorType === RemoteTypes.REMOTE_MINIO && !!setting.endpoint?.trim() && !!setting.bucket?.trim());
+        const isCouchDBConfigured =
+            replicatorType === RemoteTypes.REMOTE_COUCHDB &&
+            !!setting.couchDB_URI?.trim() &&
+            !!setting.couchDB_DBNAME?.trim();
+        const isMinioConfigured =
+            replicatorType === RemoteTypes.REMOTE_MINIO && !!setting.endpoint?.trim() && !!setting.bucket?.trim();
+        const isP2PEnabled = replicatorType === RemoteTypes.REMOTE_P2P && setting.P2P_Enabled;
+        const hasReplicatorConfig = isCouchDBConfigured || isMinioConfigured || isP2PEnabled;
 
         if (!hasReplicatorConfig) {
             this._activeReplicator = undefined;
@@ -118,7 +121,7 @@ export abstract class ReplicatorService<T extends ServiceContext = ServiceContex
             }
             // Check existing replicator and close it if exists.
             if (this._activeReplicator) {
-                await this._activeReplicator.closeReplication();
+                await Promise.resolve(this._activeReplicator.closeReplication());
                 this._log("Active replicator closed", LOG_LEVEL_VERBOSE);
             }
             this._activeReplicator = newReplicator;


### PR DESCRIPTION
for 0.25.63

### Fixed
- The issue which cannot synchronise in Only-P2P mode has been fixed.
- Fixed an issue where "Failed to connect to the remote server" was shown during the redFlag rebuild flow when P2P was the primary remote type. Remote configuration fetch is now skipped for P2P.

### P2P Replication UI Improvements
- Brand-new P2P Server Status pane has been added to provide real-time visibility into your connection status and peer network.