### PR TITLE
 bugfix:Avoid creating a new revision when the current and conflicted revisions have identical content.

### DIFF
--- a/src/managers/ConflictManager.ts
+++ b/src/managers/ConflictManager.ts
@@ -377,6 +377,17 @@ export class ConflictManager {
         if (!test._conflicts) return { ok: NOT_CONFLICTED };
         if (test._conflicts.length == 0) return { ok: NOT_CONFLICTED };
         const conflicts = test._conflicts.sort((a, b) => Number(a.split("-")[0]) - Number(b.split("-")[0]));
+        // Resolve identical conflict leaves without creating a new revision.
+        const leftLeaf = await this.getConflictedDoc(path, test._rev!);
+        const rightLeaf = await this.getConflictedDoc(path, conflicts[0]);
+        if (
+            leftLeaf !== false &&
+            rightLeaf !== false &&
+            leftLeaf.data == rightLeaf.data &&
+            leftLeaf.deleted == rightLeaf.deleted
+        ) {
+            return { leftRev: test._rev!, rightRev: conflicts[0], leftLeaf, rightLeaf };
+        }
         if ((isSensibleMargeApplicable(path) || isObjectMargeApplicable(path)) && enableMarkdownAutoMerge) {
             const autoMergeResult = await this.tryAutoMergeSensibly(path, test, conflicts);
             if (autoMergeResult !== false) {
@@ -384,8 +395,6 @@ export class ConflictManager {
             }
         }
         // should be one or more conflicts;
-        const leftLeaf = await this.getConflictedDoc(path, test._rev!);
-        const rightLeaf = await this.getConflictedDoc(path, conflicts[0]);
         return { leftRev: test._rev!, rightRev: conflicts[0], leftLeaf, rightLeaf };
     }
 }


### PR DESCRIPTION
  ## Summary
  Fix a case where identical-content conflicts could repeatedly auto-merge and reappear. (This is hard to reproduce reliably, but I hit it during actual use. )

  ## Details
A conflicted Markdown file with the same content kept going through auto-merge, creating a new revision, syncing, and then appearing as conflicted again.

This change detects identical conflict leaves before sensible/object auto-merge runs, so it resolves them by deleting the conflicted revision instead of storing the same content again.