### PR TITLE
Improve first fetch and offline file scanning

### DIFF
--- a/src/interfaces/DatabaseRebuilder.ts
+++ b/src/interfaces/DatabaseRebuilder.ts
@@ -6,7 +6,12 @@ export interface Rebuilder {
     $rebuildRemote(): Promise<void>;
     $rebuildEverything(): Promise<void>;
     $fetchLocal(makeLocalChunkBeforeSync?: boolean, preventMakeLocalFilesBeforeSync?: boolean): Promise<void>;
+    $fetchLocalDBFast(autoResume: boolean): Promise<void>;
 
     scheduleRebuild(): Promise<void>;
     scheduleFetch(): Promise<void>;
+    /**
+     * Declares the finish of the rebuild process and unlock remote, resume reflecting the changes.
+     */
+    finishRebuild(): Promise<void>;
 }

--- a/src/pouchdb/StreamingFetch.ts
+++ b/src/pouchdb/StreamingFetch.ts
@@ -1,4 +1,3 @@
-import { PouchDB } from "./pouchdb-browser";
 import { _fetch } from "../common/coreEnvFunctions";
 import { LOG_LEVEL_VERBOSE, Logger } from "octagonal-wheels/common/logger";
 import type { EntryDoc } from "../common/models/db.definition";

--- a/src/pouchdb/StreamingFetch.ts
+++ b/src/pouchdb/StreamingFetch.ts
@@ -1,0 +1,282 @@
+import { PouchDB } from './pouchdb-browser';
+import { _fetch } from '../common/coreEnvFunctions';
+import { LOG_LEVEL_VERBOSE, Logger } from 'octagonal-wheels/common/logger';
+import type { EntryDoc } from '../common/models/db.definition';
+import type { AnyEntry, EntryLeaf } from '../common/models/db.type';
+
+// Type definition for each line from the CouchDB _changes API (feed=continuous).
+interface CouchChangeLine {
+    seq: number | string;
+    id: string;
+    changes: Array<{ rev: string }>;
+    doc?: any; // include_docs=true includes the full document body.
+    deleted?: boolean;
+}
+
+interface AnyDoc {
+    _id: string;
+}
+interface AnyDecryptedDoc {
+    _id: string;
+}
+
+
+function generatePouchDBWriteStream(
+    downloadToDB: PouchDB.Database,
+    decryptFunction: (doc: any) => Promise<any>) {
+    let batchBuffer: AnyDecryptedDoc[] = [];
+    let currentBatchSizeBytes = 0;
+
+    const BATCH_ITEM_LIMIT = 100;
+    const BATCH_SIZE_LIMIT = 2 * 1024 * 1024; // 2MB
+
+    // Flush the current batch to PouchDB and clear the buffer.
+    let flushPromise: Promise<unknown> | null = null; // To track ongoing flush operations and prevent concurrent flushes.
+    const flushToDB = async () => {
+        if (batchBuffer.length === 0) return;
+        if (flushPromise) {
+            // If a flush is already in progress, wait for it to complete before starting a new one.
+            await flushPromise;
+        }
+        try {
+            flushPromise = downloadToDB.bulkDocs(batchBuffer, { new_edits: false });
+            await flushPromise;
+        } catch (error) {
+            Logger('Error bulk writing to PouchDB:', LOG_LEVEL_VERBOSE);
+            Logger(error, LOG_LEVEL_VERBOSE);
+            throw error; // Propagate the error to be handled by the caller.
+        } finally {
+            // Clear the batch buffer and reset the size counter regardless of success or failure to avoid blocking the stream.
+            batchBuffer = [];
+            currentBatchSizeBytes = 0;
+            flushPromise = null;
+        }
+    };
+    return new WritableStream<AnyDoc>({
+        async write(chunk) {
+            try {
+                // 1. Decrypt the document
+                const decryptedDoc = await decryptFunction(chunk);
+
+                // 2. Buffer the decrypted document
+                batchBuffer.push(decryptedDoc);
+                currentBatchSizeBytes += JSON.stringify(decryptedDoc).length;
+
+                // 3. Flush the batch if limits are exceeded
+                if (batchBuffer.length >= BATCH_ITEM_LIMIT || currentBatchSizeBytes >= BATCH_SIZE_LIMIT) {
+                    await flushToDB();
+                }
+            } catch (error) {
+                Logger('Error processing document stream:', LOG_LEVEL_VERBOSE);
+                throw error;
+            }
+        },
+        async close() {
+            // Flush any remaining documents when the stream is closed
+            await flushToDB();
+        },
+        abort(reason) {
+            // Cleanup when the stream is forcibly terminated due to an error or other reasons
+            Logger(`Stream aborted: ${reason}`, LOG_LEVEL_VERBOSE);
+            batchBuffer = [];
+            currentBatchSizeBytes = 0;
+        }
+    });
+}
+
+function setParamsToURL(url: URL, params: Record<string, string>) {
+    for (const [key, value] of Object.entries(params)) {
+        url.searchParams.set(key, value);
+    }
+    return url;
+}
+
+
+export type FetchChangesForInitialSyncProgress = {
+    totalFetched: number; // Total number of changes fetched from CouchDB (including those without doc bodies).
+    totalValidFetched: number; // Total number of changes with valid doc bodies fetched and processed.
+    targetSeq: number | string; // The target sequence ID that we aim to reach for initial sync completion.
+    docsToFetch: number; // Total number of documents that need to be fetched based on the pending count from CouchDB.
+    totalBytes: number; // Total bytes fetched so far.
+}
+/**
+ * Fetches initial data from CouchDB as a stream and writes it into PouchDB.
+ * @param downloadToDB PouchDB instance.
+ * @param remoteDbUrl CouchDB database URL (for example: 'https://xxx.com/mydb').
+ * @param decryptFunction Function to decrypt each document.
+ * @param since Sequence ID to start fetching changes from (default is '0').
+ */
+export async function fetchChangesForInitialSync(
+    downloadToDB: PouchDB.Database,
+    remoteDbUrl: string,
+    authHeader: string,
+    decryptFunction: (doc: EntryDoc) => Promise<AnyEntry | EntryLeaf>,
+    since: number | string = '0',
+    onProgress?: (progress: FetchChangesForInitialSyncProgress) => void
+): Promise<void> {
+
+    let totalFetched = 0;
+    let totalValidFetched = 0;
+    const changesBaseParams = {
+        feed: 'continuous',
+        include_docs: 'true',
+        style: 'all_docs',
+        conflicts: 'true',
+        revs: 'true',
+        since: since.toString(),
+    } as const;
+    const fetchHeaders = {
+        'Accept': 'application/json',
+        'Authorization': authHeader,
+    };
+
+    const fetchURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
+        ...changesBaseParams,
+        limit: '1',
+    });
+
+    const infoRes = await _fetch(fetchURL.toString(), {
+        headers: fetchHeaders
+    });
+    const infoSource = await infoRes.text();
+    const infoLines = infoSource.trim().split('\n').filter(line => line.trim() !== '');
+    const lastLine = infoLines[infoLines.length - 1];
+    if (!lastLine) {
+        throw new Error('Failed to fetch changes from CouchDB. No data received.');
+    }
+    const info = JSON.parse(lastLine) as { update_seq: number | string; pending?: number };
+    const pendingDocs = info.pending || 0;
+    const docsToFetch = pendingDocs + 1; // +1 to include the change we just fetched for getting the target sequence.
+
+    const targetSeq = info.update_seq;
+    Logger(`Starting initial synchronization. Current sequence: ${since}, Target sequence: ${targetSeq}, Total documents to fetch: ${docsToFetch}.`);
+    const controller = new AbortController();
+    const url = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
+        ...changesBaseParams
+    });
+    const response = await _fetch(url.toString(), {
+        method: 'GET',
+        headers: fetchHeaders,
+        signal: controller.signal
+    });
+
+
+    if (!response.body) {
+        throw new Error('ReadableStream is not supported by this browser.');
+    }
+
+    const sizeCaptureStream = new TransformStream({
+        transform(chunk, controller) {
+            const chunkSize = chunk.length || (chunk.byteLength || 0);
+            totalBytes += chunkSize;
+            controller.enqueue(chunk);
+        }
+    });
+    // Convert the byte stream into a text stream.
+    const reader =
+        response.body
+            .pipeThrough(sizeCaptureStream)
+            .pipeThrough(new TextDecoderStream())
+            .getReader();
+    const writeDocStream = generatePouchDBWriteStream(downloadToDB, decryptFunction);
+    const writer = writeDocStream.getWriter();
+    let buffer = '';
+    let lastProgress = 0;
+    let lastReportTime = Date.now();
+    let totalBytes = 0;
+    const reportProgress = () => {
+        if (totalFetched - lastProgress < 25) { // Report progress for every 25 changes fetched to avoid excessive updates.
+            // However, if it's been more than 2 seconds since the last report, we should report progress regardless to keep the UI responsive.
+            if (Date.now() - lastReportTime < 2000) {
+                return;
+            }
+        }
+        lastProgress = totalFetched;
+        lastReportTime = Date.now();
+        onProgress?.({
+            totalFetched,
+            totalValidFetched,
+            targetSeq,
+            docsToFetch,
+            totalBytes,
+        });
+    }
+    try {
+        while (true) {
+            // Read a chunk from the network.
+            reportProgress();
+            const { value, done } = await reader.read();
+            if (value) {
+                totalBytes += value.length;
+            }
+            if (done) {
+                // When the stream ends, process the final line left in the buffer.
+                if (buffer.trim()) {
+                    try {
+                        totalFetched++;
+                        const parsed = JSON.parse(buffer) as CouchChangeLine;
+                        if (parsed.doc) {
+                            await writer.write(parsed.doc);
+                            totalValidFetched++;
+                        }
+                        reportProgress();
+                    } catch (e) {
+                        Logger(`Failed to parse the final line: ${buffer}. Skipping it.`);
+                        Logger(e, LOG_LEVEL_VERBOSE);
+                    }
+                }
+                await writer.close();
+                break; // Exit the loop.
+            }
+
+            buffer += value;
+            const lines = buffer.split('\n');
+
+            // The final line is often incomplete, so carry it over to the next buffer.
+            buffer = lines.pop() || '';
+
+            for (const line of lines) {
+                if (!line.trim()) continue; // Skip empty lines (for example, CouchDB heartbeats).
+
+                try {
+                    const parsed = JSON.parse(line) as CouchChangeLine;
+                    // Add to the batch only when a document body exists.
+                    totalFetched++;
+                    if (parsed.doc) {
+                        await writer.write(parsed.doc);
+                        totalValidFetched++;
+                    }
+                    reportProgress();
+                    if (totalFetched >= docsToFetch) {
+                        Logger(`All documents fetched. Stopping the stream and writing remaining documents to PouchDB...`);
+
+                        // Write any remaining documents to PouchDB before exiting.
+                        await writer.close(); // Close the writer to ensure all documents are flushed to PouchDB.
+                        // Abort the fetch request to stop receiving more data.
+                        controller.abort();
+                        reportProgress();
+                        return; // Exit the function gracefully.
+                    }
+                } catch (e) {
+                    Logger(`JSON parsing failed. Skipping line: ${line}`, LOG_LEVEL_VERBOSE);
+                    Logger(e, LOG_LEVEL_VERBOSE);
+                }
+            }
+            // backpressure is automatically handled by awaiting the writer.write() calls, which will pause reading from the network until the current document is processed and written to PouchDB.
+            // This ensures that we do not read too much data into memory at once, and we can handle large datasets without running into memory issues.
+        }
+        Logger('Initial data synchronisation via stream has completed.');
+        reportProgress();
+    } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+            Logger('Stream has been aborted as the target sequence has been reached. Finalising the synchronising process...');
+            return; // Exit gracefully without treating this as an error.
+        }
+        Logger('An error occurred during synchronisation:', LOG_LEVEL_VERBOSE);
+        Logger(error, LOG_LEVEL_VERBOSE);
+        throw error;
+    } finally {
+        // Always release the lock.
+        reader.releaseLock();
+    }
+}

--- a/src/pouchdb/StreamingFetch.ts
+++ b/src/pouchdb/StreamingFetch.ts
@@ -1,8 +1,8 @@
-import { PouchDB } from './pouchdb-browser';
-import { _fetch } from '../common/coreEnvFunctions';
-import { LOG_LEVEL_VERBOSE, Logger } from 'octagonal-wheels/common/logger';
-import type { EntryDoc } from '../common/models/db.definition';
-import type { AnyEntry, EntryLeaf } from '../common/models/db.type';
+import { PouchDB } from "./pouchdb-browser";
+import { _fetch } from "../common/coreEnvFunctions";
+import { LOG_LEVEL_VERBOSE, Logger } from "octagonal-wheels/common/logger";
+import type { EntryDoc } from "../common/models/db.definition";
+import type { AnyEntry, EntryLeaf } from "../common/models/db.type";
 
 // Type definition for each line from the CouchDB _changes API (feed=continuous).
 interface CouchChangeLine {
@@ -20,10 +20,7 @@ interface AnyDecryptedDoc {
     _id: string;
 }
 
-
-function generatePouchDBWriteStream(
-    downloadToDB: PouchDB.Database,
-    decryptFunction: (doc: any) => Promise<any>) {
+function generatePouchDBWriteStream(downloadToDB: PouchDB.Database, decryptFunction: (doc: any) => Promise<any>) {
     let batchBuffer: AnyDecryptedDoc[] = [];
     let currentBatchSizeBytes = 0;
 
@@ -42,7 +39,7 @@ function generatePouchDBWriteStream(
             flushPromise = downloadToDB.bulkDocs(batchBuffer, { new_edits: false });
             await flushPromise;
         } catch (error) {
-            Logger('Error bulk writing to PouchDB:', LOG_LEVEL_VERBOSE);
+            Logger("Error bulk writing to PouchDB:", LOG_LEVEL_VERBOSE);
             Logger(error, LOG_LEVEL_VERBOSE);
             throw error; // Propagate the error to be handled by the caller.
         } finally {
@@ -67,7 +64,7 @@ function generatePouchDBWriteStream(
                     await flushToDB();
                 }
             } catch (error) {
-                Logger('Error processing document stream:', LOG_LEVEL_VERBOSE);
+                Logger("Error processing document stream:", LOG_LEVEL_VERBOSE);
                 throw error;
             }
         },
@@ -80,7 +77,7 @@ function generatePouchDBWriteStream(
             Logger(`Stream aborted: ${reason}`, LOG_LEVEL_VERBOSE);
             batchBuffer = [];
             currentBatchSizeBytes = 0;
-        }
+        },
     });
 }
 
@@ -91,14 +88,13 @@ function setParamsToURL(url: URL, params: Record<string, string>) {
     return url;
 }
 
-
 export type FetchChangesForInitialSyncProgress = {
     totalFetched: number; // Total number of changes fetched from CouchDB (including those without doc bodies).
     totalValidFetched: number; // Total number of changes with valid doc bodies fetched and processed.
     targetSeq: number | string; // The target sequence ID that we aim to reach for initial sync completion.
     docsToFetch: number; // Total number of documents that need to be fetched based on the pending count from CouchDB.
     totalBytes: number; // Total bytes fetched so far.
-}
+};
 /**
  * Fetches initial data from CouchDB as a stream and writes it into PouchDB.
  * @param downloadToDB PouchDB instance.
@@ -111,81 +107,81 @@ export async function fetchChangesForInitialSync(
     remoteDbUrl: string,
     authHeader: string,
     decryptFunction: (doc: EntryDoc) => Promise<AnyEntry | EntryLeaf>,
-    since: number | string = '0',
+    since: number | string = "0",
     onProgress?: (progress: FetchChangesForInitialSyncProgress) => void
 ): Promise<void> {
-
     let totalFetched = 0;
     let totalValidFetched = 0;
     const changesBaseParams = {
-        feed: 'continuous',
-        include_docs: 'true',
-        style: 'all_docs',
-        conflicts: 'true',
-        revs: 'true',
+        feed: "continuous",
+        include_docs: "true",
+        style: "all_docs",
+        conflicts: "true",
+        revs: "true",
         since: since.toString(),
     } as const;
     const fetchHeaders = {
-        'Accept': 'application/json',
-        'Authorization': authHeader,
+        Accept: "application/json",
+        Authorization: authHeader,
     };
 
     const fetchURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
         ...changesBaseParams,
-        limit: '1',
+        limit: "1",
     });
 
     const infoRes = await _fetch(fetchURL.toString(), {
-        headers: fetchHeaders
+        headers: fetchHeaders,
     });
     const infoSource = await infoRes.text();
-    const infoLines = infoSource.trim().split('\n').filter(line => line.trim() !== '');
+    const infoLines = infoSource
+        .trim()
+        .split("\n")
+        .filter((line) => line.trim() !== "");
     const lastLine = infoLines[infoLines.length - 1];
     if (!lastLine) {
-        throw new Error('Failed to fetch changes from CouchDB. No data received.');
+        throw new Error("Failed to fetch changes from CouchDB. No data received.");
     }
     const info = JSON.parse(lastLine) as { update_seq: number | string; pending?: number };
     const pendingDocs = info.pending || 0;
     const docsToFetch = pendingDocs + 1; // +1 to include the change we just fetched for getting the target sequence.
 
     const targetSeq = info.update_seq;
-    Logger(`Starting initial synchronization. Current sequence: ${since}, Target sequence: ${targetSeq}, Total documents to fetch: ${docsToFetch}.`);
+    Logger(
+        `Starting initial synchronization. Current sequence: ${since}, Target sequence: ${targetSeq}, Total documents to fetch: ${docsToFetch}.`
+    );
     const controller = new AbortController();
     const url = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
-        ...changesBaseParams
+        ...changesBaseParams,
     });
     const response = await _fetch(url.toString(), {
-        method: 'GET',
+        method: "GET",
         headers: fetchHeaders,
-        signal: controller.signal
+        signal: controller.signal,
     });
 
-
     if (!response.body) {
-        throw new Error('ReadableStream is not supported by this browser.');
+        throw new Error("ReadableStream is not supported by this browser.");
     }
 
     const sizeCaptureStream = new TransformStream({
         transform(chunk, controller) {
-            const chunkSize = chunk.length || (chunk.byteLength || 0);
+            const chunkSize = chunk.length || chunk.byteLength || 0;
             totalBytes += chunkSize;
             controller.enqueue(chunk);
-        }
+        },
     });
     // Convert the byte stream into a text stream.
-    const reader =
-        response.body
-            .pipeThrough(sizeCaptureStream)
-            .pipeThrough(new TextDecoderStream())
-            .getReader();
+    const reader = response.body.pipeThrough(sizeCaptureStream).pipeThrough(new TextDecoderStream()).getReader();
     const writeDocStream = generatePouchDBWriteStream(downloadToDB, decryptFunction);
     const writer = writeDocStream.getWriter();
-    let buffer = '';
+    let buffer = "";
     let lastProgress = 0;
     let lastReportTime = Date.now();
     let totalBytes = 0;
     const reportProgress = () => {
-        if (totalFetched - lastProgress < 25) { // Report progress for every 25 changes fetched to avoid excessive updates.
+        if (totalFetched - lastProgress < 25) {
+            // Report progress for every 25 changes fetched to avoid excessive updates.
             // However, if it's been more than 2 seconds since the last report, we should report progress regardless to keep the UI responsive.
             if (Date.now() - lastReportTime < 2000) {
                 return;
@@ -200,7 +196,7 @@ export async function fetchChangesForInitialSync(
             docsToFetch,
             totalBytes,
         });
-    }
+    };
     try {
         while (true) {
             // Read a chunk from the network.
@@ -230,10 +226,10 @@ export async function fetchChangesForInitialSync(
             }
 
             buffer += value;
-            const lines = buffer.split('\n');
+            const lines = buffer.split("\n");
 
             // The final line is often incomplete, so carry it over to the next buffer.
-            buffer = lines.pop() || '';
+            buffer = lines.pop() || "";
 
             for (const line of lines) {
                 if (!line.trim()) continue; // Skip empty lines (for example, CouchDB heartbeats).
@@ -248,7 +244,9 @@ export async function fetchChangesForInitialSync(
                     }
                     reportProgress();
                     if (totalFetched >= docsToFetch) {
-                        Logger(`All documents fetched. Stopping the stream and writing remaining documents to PouchDB...`);
+                        Logger(
+                            `All documents fetched. Stopping the stream and writing remaining documents to PouchDB...`
+                        );
 
                         // Write any remaining documents to PouchDB before exiting.
                         await writer.close(); // Close the writer to ensure all documents are flushed to PouchDB.
@@ -265,14 +263,16 @@ export async function fetchChangesForInitialSync(
             // backpressure is automatically handled by awaiting the writer.write() calls, which will pause reading from the network until the current document is processed and written to PouchDB.
             // This ensures that we do not read too much data into memory at once, and we can handle large datasets without running into memory issues.
         }
-        Logger('Initial data synchronisation via stream has completed.');
+        Logger("Initial data synchronisation via stream has completed.");
         reportProgress();
     } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-            Logger('Stream has been aborted as the target sequence has been reached. Finalising the synchronising process...');
+        if (error instanceof DOMException && error.name === "AbortError") {
+            Logger(
+                "Stream has been aborted as the target sequence has been reached. Finalising the synchronising process..."
+            );
             return; // Exit gracefully without treating this as an error.
         }
-        Logger('An error occurred during synchronisation:', LOG_LEVEL_VERBOSE);
+        Logger("An error occurred during synchronisation:", LOG_LEVEL_VERBOSE);
         Logger(error, LOG_LEVEL_VERBOSE);
         throw error;
     } finally {

--- a/src/pouchdb/encryption.ts
+++ b/src/pouchdb/encryption.ts
@@ -473,7 +473,14 @@ export function getConfiguredFunctionsForEncryption(
     // If unless specified algorithm is ForceV1, then use HKDF decryption for forward compatibility.
     const outgoing = (doc: EntryDoc) =>
         algorithm !== E2EEAlgorithms.ForceV1
-            ? outgoingDecryptHKDF(doc, migrationDecrypt, decryptedCache, passphrase, useDynamicIterationCount, getPBKDF2Salt)
+            ? outgoingDecryptHKDF(
+                  doc,
+                  migrationDecrypt,
+                  decryptedCache,
+                  passphrase,
+                  useDynamicIterationCount,
+                  getPBKDF2Salt
+              )
             : outgoingDecryptV1(doc, migrationDecrypt, decryptedCache, passphrase, useDynamicIterationCount);
     return {
         incoming,

--- a/src/pouchdb/encryption.ts
+++ b/src/pouchdb/encryption.ts
@@ -455,6 +455,32 @@ export let preprocessIncoming: (doc: EntryDoc) => Promise<EntryDoc> = async (doc
     return await Promise.resolve(doc);
 };
 
+export function getConfiguredFunctionsForEncryption(
+    passphrase: string,
+    useDynamicIterationCount: boolean,
+    migrationDecrypt: boolean,
+    getPBKDF2Salt: () => Promise<Uint8Array<ArrayBuffer>>,
+    algorithm: E2EEAlgorithm
+): {
+    incoming: (doc: AnyEntry | EntryLeaf) => Promise<AnyEntry | EntryLeaf>;
+    outgoing: (doc: EntryDoc) => Promise<AnyEntry | EntryLeaf>;
+} {
+    const decryptedCache = new Map();
+    const incoming = (doc: AnyEntry | EntryLeaf) =>
+        algorithm === E2EEAlgorithms.V2
+            ? incomingEncryptHKDF(doc, passphrase, useDynamicIterationCount, getPBKDF2Salt)
+            : incomingEncryptV1(doc, passphrase, useDynamicIterationCount);
+    // If unless specified algorithm is ForceV1, then use HKDF decryption for forward compatibility.
+    const outgoing = (doc: EntryDoc) =>
+        algorithm !== E2EEAlgorithms.ForceV1
+            ? outgoingDecryptHKDF(doc, migrationDecrypt, decryptedCache, passphrase, useDynamicIterationCount, getPBKDF2Salt)
+            : outgoingDecryptV1(doc, migrationDecrypt, decryptedCache, passphrase, useDynamicIterationCount);
+    return {
+        incoming,
+        outgoing,
+    };
+}
+
 export const enableEncryption = (
     db: PouchDB.Database<EntryDoc>,
     passphrase: string,
@@ -463,19 +489,13 @@ export const enableEncryption = (
     getPBKDF2Salt: () => Promise<Uint8Array<ArrayBuffer>>,
     algorithm: E2EEAlgorithm
 ) => {
-    const decrypted = new Map();
-
-    const incoming = (doc: AnyEntry | EntryLeaf) =>
-        algorithm === E2EEAlgorithms.V2
-            ? incomingEncryptHKDF(doc, passphrase, useDynamicIterationCount, getPBKDF2Salt)
-            : incomingEncryptV1(doc, passphrase, useDynamicIterationCount);
-    // If unless specified algorithm is ForceV1, then use HKDF decryption for forward compatibility.
-    const outgoing = (doc: EntryDoc) =>
-        algorithm !== E2EEAlgorithms.ForceV1
-            ? outgoingDecryptHKDF(doc, migrationDecrypt, decrypted, passphrase, useDynamicIterationCount, getPBKDF2Salt)
-            : outgoingDecryptV1(doc, migrationDecrypt, decrypted, passphrase, useDynamicIterationCount);
-    preprocessOutgoing = incoming;
-    preprocessIncoming = outgoing;
+    const { incoming, outgoing } = getConfiguredFunctionsForEncryption(
+        passphrase,
+        useDynamicIterationCount,
+        migrationDecrypt,
+        getPBKDF2Salt,
+        algorithm
+    );
     //@ts-ignore
     db.transform({
         incoming,

--- a/src/serviceFeatures/offlineScanner.ts
+++ b/src/serviceFeatures/offlineScanner.ts
@@ -1,6 +1,5 @@
 import type PouchDB from "pouchdb-core";
 import { unique } from "octagonal-wheels/collection";
-import { throttle } from "octagonal-wheels/function";
 import { withConcurrency } from "octagonal-wheels/iterable/map";
 import {
     LOG_LEVEL_DEBUG,
@@ -17,13 +16,14 @@ import {
     type LOG_LEVEL,
 } from "@lib/common/types";
 
-import { isAnyNote } from "@lib/common/utils";
+import { compareMTime, isAnyNote } from "@lib/common/utils";
 import { stripAllPrefixes } from "@lib/string_and_binary/path";
 import { createInstanceLogFunction, type LogFunction } from "@lib/services/lib/logUtils";
 import type { NecessaryServices } from "@lib/interfaces/ServiceModule";
 import { eventHub } from "@lib/hub/hub";
 import { BASE_IS_NEW, EVEN, TARGET_IS_NEW } from "@lib/common/models/shared.const.symbols";
 import { UnresolvedErrorManager } from "@lib/services/base/UnresolvedErrorManager";
+import { compatGlobal } from "../common/coreEnvFunctions";
 
 /**
  * Collect deleted files that have expired according to retention policy.
@@ -99,14 +99,6 @@ export async function syncFileBetweenDBandStorage(
     if (!doc) {
         throw new Error(`Missing doc:${docPath}`);
     }
-    if ("path" in file) {
-        const w = await host.serviceModules.storageAccess.getFileStub(docPath);
-        if (w) {
-            file = w;
-        } else {
-            throw new Error(`Missing file:${docPath}`);
-        }
-    }
 
     // const settings = host.services.setting.currentSettings();
     const compareResult = host.services.path.compareFileFreshness(file, doc);
@@ -125,7 +117,7 @@ export async function syncFileBetweenDBandStorage(
         case TARGET_IS_NEW:
             if (!host.services.vault.isFileSizeTooLarge(doc.size)) {
                 log("STORAGE <- DB :" + docPath);
-                if (await host.serviceModules.fileHandler.dbToStorage(doc, stripAllPrefixes(docPath), true)) {
+                if (await host.serviceModules.fileHandler.dbToStorage(doc, stripAllPrefixes(docPath), false)) {
                     eventHub.emitEvent("event-file-changed", {
                         file: file.path,
                         automated: true,
@@ -347,6 +339,357 @@ export async function syncStorageAndDatabase(
     }
 }
 
+export const FullScanModes = {
+    // SAFE: "safe",
+    DB_APPLY: "db-apply",
+    NEWER_WINS: "newer-wins",
+    // STORAGE_ONLY: "local-only",
+} as const;
+
+export const ExtraOnRemote = {
+    /**
+     * Delete database entries if they are missing on storage.
+     */
+    DELETE_LOCAL_MISSING: "delete-local-missing",
+    /**
+     * Apply changes from database to storage.
+     */
+    // APPEND_DB_ONLY: "append-db-only",
+} as const;
+export const ExtraOnLocal = {
+    /**
+     * Delete local files if they were deleted on database.
+     */
+    DELETE_DB_DELETED: "delete-db-deleted",
+    /**
+     * Delete local files if they are missing on database or were deleted on database.
+     */
+    DELETE_DB_MISSING: "delete-db-missing",
+    /**
+     * Merge local files to database
+     */
+    APPEND_STORAGE_ONLY: "append-storage-only",
+} as const;
+
+export interface FullScanOptions {
+    mode: FullScanMode;
+    extraOnLocal?: (typeof ExtraOnLocal)[keyof typeof ExtraOnLocal];
+    extraOnRemote?: (typeof ExtraOnRemote)[keyof typeof ExtraOnRemote];
+    omitEvents?: boolean;
+    showingNotice?: boolean;
+    ignoreSuspending?: boolean;
+}
+
+export type FullScanMode = (typeof FullScanModes)[keyof typeof FullScanModes];
+type FilePair =
+    | { file: UXFileInfoStub; doc: MetaEntry }
+    | { file: undefined; doc: MetaEntry }
+    | { file: UXFileInfoStub; doc: undefined };
+type FilePairState = "storage-only" | "db-only" | "db-only-deleted" | "both" | "both-db-deleted";
+
+type FilePairAction = "update-db" | "update-storage" | "sync-newer" | "delete-local" | "delete-db" | "skip";
+
+function isDeletedEntry(entry: MetaEntry): boolean {
+    return entry.deleted || entry._deleted || false;
+}
+
+export function getFilePairState(pair: FilePair): FilePairState {
+    const { file, doc } = pair;
+    if (file && doc) {
+        return isDeletedEntry(doc) ? "both-db-deleted" : "both";
+    }
+    if (file) {
+        return "storage-only";
+    }
+    if (doc) {
+        return isDeletedEntry(doc) ? "db-only-deleted" : "db-only";
+    }
+    throw new Error("Corrupted file pair");
+}
+
+function shouldDeleteLocalWhenRemoteMissing(options: FullScanOptions): boolean {
+    return (
+        options.extraOnRemote === ExtraOnRemote.DELETE_LOCAL_MISSING ||
+        options.extraOnLocal === ExtraOnLocal.DELETE_DB_MISSING
+    );
+}
+
+function shouldDeleteLocalWhenRemoteDeleted(options: FullScanOptions): boolean {
+    return (
+        options.extraOnRemote === ExtraOnRemote.DELETE_LOCAL_MISSING ||
+        options.extraOnLocal === ExtraOnLocal.DELETE_DB_DELETED ||
+        options.extraOnLocal === ExtraOnLocal.DELETE_DB_MISSING
+    );
+}
+
+/**
+ * Determine the action to be taken for a file pair based on its state and the selected scan options.
+ */
+export function resolveFilePairAction(state: FilePairState, options: FullScanOptions): FilePairAction {
+    switch (options.mode) {
+        case FullScanModes.DB_APPLY:
+            switch (state) {
+                case "both":
+                case "db-only":
+                    return "update-storage";
+                case "storage-only":
+                    return shouldDeleteLocalWhenRemoteMissing(options) ? "delete-local" : "skip";
+                case "both-db-deleted":
+                    return shouldDeleteLocalWhenRemoteDeleted(options) ? "delete-local" : "skip";
+                case "db-only-deleted":
+                    return "skip";
+            }
+            break;
+        case FullScanModes.NEWER_WINS:
+            switch (state) {
+                case "both":
+                    return "sync-newer";
+                case "storage-only":
+                    return shouldDeleteLocalWhenRemoteMissing(options) ? "delete-local" : "update-db";
+                case "db-only":
+                    return "update-storage";
+                case "both-db-deleted":
+                    if (shouldDeleteLocalWhenRemoteDeleted(options)) {
+                        return "delete-local";
+                    }
+                    return options.extraOnLocal === ExtraOnLocal.APPEND_STORAGE_ONLY ? "update-db" : "skip";
+                case "db-only-deleted":
+                    return "skip";
+            }
+            break;
+    }
+    return "skip";
+}
+
+/**
+ * Process a single file pair based on the determined action from the file pair state and scan options.
+ */
+async function processFilePair(
+    host: NecessaryServices<"setting" | "vault" | "path" | "keyValueDB", "storageAccess" | "fileHandler">,
+    log: LogFunction,
+    pair: FilePair,
+    options: FullScanOptions
+) {
+    const { file, doc } = pair;
+    const canonicalPath = doc ? getPathFromEntry(host, doc) : file?.path;
+    if (!canonicalPath) {
+        throw new Error("Corrupted file pair");
+    }
+    const path = canonicalPath;
+    const fileMapKey = convertCase(host.services.setting.currentSettings(), canonicalPath);
+
+    if (file) {
+        updateFileMTimeInMap(host, fileMapKey, file.stat.mtime);
+    }
+
+    if (doc && (doc._conflicts?.length ?? 0) > 0) {
+        log(`SKIP ${options.mode}: ${path} has conflicts`, LOG_LEVEL_INFO);
+        return true;
+    }
+    const state = getFilePairState(pair);
+    let action = resolveFilePairAction(state, options);
+
+    // If the file existed locally on a previous run and is now missing while DB-only,
+    // treat it as an offline local deletion when local mtime is not older than DB mtime.
+    if (options.mode === FullScanModes.NEWER_WINS && state === "db-only" && doc) {
+        const lastSeenMTime = getFileMTimeFromMap(fileMapKey);
+        if (lastSeenMTime !== undefined) {
+            const recency = compareMTime(lastSeenMTime, doc.mtime);
+            if (recency === BASE_IS_NEW || recency === EVEN) {
+                action = "delete-db";
+                log(`NEWER_WINS: Treating missing local file as deletion (${path})`, LOG_LEVEL_VERBOSE);
+            }
+        }
+    }
+
+    try {
+        switch (action) {
+            case "update-db":
+                if (!file) {
+                    throw new Error(`Missing storage file for ${path}`);
+                }
+                await updateToDatabase(host, log, LOG_LEVEL_INFO, file);
+                return true;
+            case "update-storage":
+                if (!doc) {
+                    throw new Error(`Missing database entry for ${path}`);
+                }
+                await updateToStorage(host, log, LOG_LEVEL_INFO, doc);
+                updateFileMTimeInMap(host, fileMapKey, doc.mtime);
+                return true;
+            case "sync-newer":
+                if (!file || !doc) {
+                    throw new Error(`Cannot compare freshness for ${path}`);
+                }
+                await syncStorageAndDatabase(host, log, file, LOG_LEVEL_INFO, doc);
+                updateFileMTimeInMap(host, fileMapKey, Math.max(file.stat.mtime, doc.mtime));
+                return true;
+            case "delete-local":
+                if (!file) {
+                    log(`DELETE LOCAL: ${path} is already absent from storage`, LOG_LEVEL_VERBOSE);
+                    return true;
+                }
+                log(`DELETE LOCAL: ${file.path}`, LOG_LEVEL_INFO);
+                await host.serviceModules.storageAccess.delete(file.path, true);
+                fileMaps.delete(fileMapKey);
+                saveFileStatus(host);
+                return true;
+            case "delete-db":
+                if (!doc) {
+                    throw new Error(`Missing database entry for ${path}`);
+                }
+                log(`DELETE DATABASE: ${path}`, LOG_LEVEL_INFO);
+                await host.serviceModules.fileHandler.deleteFileFromDB(stripAllPrefixes(path));
+                fileMaps.delete(fileMapKey);
+                saveFileStatus(host);
+                return true;
+            case "skip":
+                log(`SKIP ${options.mode}: ${path} (${state})`, LOG_LEVEL_VERBOSE);
+                return true;
+        }
+    } catch (ex) {
+        log(`Error processing ${path} with action ${action}`, LOG_LEVEL_NOTICE);
+        log(ex, LOG_LEVEL_VERBOSE);
+        return false;
+    }
+}
+/**
+ * Synchronise all files between database and storage based on the selected mode and options.
+ * @param host Core
+ * @param log Logging function
+ * @param errorManager Error manager
+ * @param options Full scan options
+ */
+export async function synchroniseAllFilesBetweenDBandStorage(
+    host: NecessaryServices<
+        "setting" | "vault" | "path" | "fileProcessing" | "database" | "keyValueDB",
+        "storageAccess" | "fileHandler"
+    >,
+    log: LogFunction,
+    errorManager: UnresolvedErrorManager,
+    options: FullScanOptions
+) {
+    const settings = host.services.setting.currentSettings();
+    const showingNotice = options.showingNotice ?? false;
+    await loadFileStatus(host);
+    const { storageFileNameMap, storageFileNameCI2CS } = await collectFilesOnStorage(host, settings, log);
+    const { databaseFileNameMap, databaseFileNameCI2CS } = await collectDatabaseFiles(
+        host,
+        settings,
+        log,
+        showingNotice
+    );
+
+    const pairs: FilePair[] = [];
+    for (const fileNameLC of unique([
+        ...Object.keys(storageFileNameCI2CS),
+        ...Object.keys(databaseFileNameCI2CS),
+    ] as FilePathWithPrefixLC[])) {
+        const fileName = fileNameLC in storageFileNameCI2CS ? storageFileNameCI2CS[fileNameLC] : undefined;
+        const file = fileName ? storageFileNameMap[fileName] : undefined;
+        const databaseName = fileNameLC in databaseFileNameCI2CS ? databaseFileNameCI2CS[fileNameLC] : undefined;
+        const doc = databaseName ? databaseFileNameMap[databaseName] : undefined;
+        const pair: FilePair = { file, doc } as FilePair;
+        pairs.push(pair);
+    }
+
+    log(`Total files to synchronise: ${pairs.length}`, LOG_LEVEL_VERBOSE, "syncAll");
+    let successCount = 0;
+    let processedCount = 0;
+    for await (const result of withConcurrency(
+        pairs,
+        async (e) => {
+            try {
+                return await processFilePair(host, log, e, options);
+            } catch (ex) {
+                log(`Error while synchronising files`, LOG_LEVEL_NOTICE);
+                log(ex, LOG_LEVEL_VERBOSE);
+                return false;
+            }
+        },
+        10
+    )) {
+        processedCount++;
+        if (result) {
+            successCount++;
+        }
+        if (processedCount % 25 === 0) {
+            log(
+                `Processing: ${processedCount}/${pairs.length}`,
+                showingNotice ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO,
+                "syncAll"
+            );
+        }
+    }
+    log(
+        `Synchronisation completed: ${successCount}/${processedCount} files processed successfully`,
+        showingNotice ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO,
+        "syncAll"
+    );
+    return successCount === processedCount;
+}
+
+export function normaliseFullScanOptions(
+    showingNoticeOrOptions: Partial<FullScanOptions> | boolean | undefined,
+    ignoreSuspending: boolean = false
+): FullScanOptions {
+    if (typeof showingNoticeOrOptions === "object") {
+        return {
+            mode: FullScanModes.NEWER_WINS,
+            ...showingNoticeOrOptions,
+        };
+    }
+    return {
+        mode: FullScanModes.NEWER_WINS,
+        showingNotice: showingNoticeOrOptions ?? false,
+        ignoreSuspending,
+    };
+}
+// In-memory map to track file modification times for offline scanning.
+let fileMaps = new Map<string, number>();
+// Load file modification times from the key-value database into the in-memory map.
+async function loadFileStatus(host: NecessaryServices<"keyValueDB", never>) {
+    const kvDB = host.services.keyValueDB.kvDB as
+        | { get?: <T = unknown>(key: string) => Promise<T | undefined> }
+        | undefined;
+    if (!kvDB?.get) {
+        fileMaps = new Map();
+        return;
+    }
+    const mapItems = (await kvDB.get<Record<string, number>>("fileStatusMap")) || {};
+    fileMaps = new Map(Object.entries(mapItems));
+}
+// Save the current state of file modification times from the in-memory map to the key-value database.
+async function _saveFileStatus(host: NecessaryServices<"keyValueDB", never>) {
+    const kvDB = host.services.keyValueDB.kvDB as
+        | { set?: (key: string, value: unknown) => Promise<unknown> }
+        | undefined;
+    if (!kvDB?.set) {
+        return;
+    }
+    await kvDB.set("fileStatusMap", Object.fromEntries(fileMaps));
+}
+
+let saveFileStatusTimeout: number | null = null;
+// Schedule saving file status with debouncing to prevent excessive writes during rapid changes.
+function saveFileStatus(host: NecessaryServices<"keyValueDB", never>) {
+    if (saveFileStatusTimeout !== null) {
+        compatGlobal.clearTimeout(saveFileStatusTimeout);
+    }
+    saveFileStatusTimeout = compatGlobal.setTimeout(() => {
+        void _saveFileStatus(host).then(() => {
+            saveFileStatusTimeout = null;
+        });
+    }, 1000);
+}
+function updateFileMTimeInMap(host: NecessaryServices<"keyValueDB", never>, key: string, mtime: number) {
+    fileMaps.set(key, mtime);
+    saveFileStatus(host);
+}
+function getFileMTimeFromMap(key: string): number | undefined {
+    return fileMaps.get(key);
+}
+
 /**
  * Perform a full scan and synchronisation between database and storage.
  * @param host Services container
@@ -363,17 +706,37 @@ export async function performFullScan(
     >,
     log: LogFunction,
     errorManager: UnresolvedErrorManager,
-    showingNotice: boolean = false,
+    options?: Partial<FullScanOptions>
+): Promise<boolean>;
+export async function performFullScan(
+    host: NecessaryServices<
+        "setting" | "vault" | "path" | "fileProcessing" | "database" | "keyValueDB",
+        "storageAccess" | "fileHandler"
+    >,
+    log: LogFunction,
+    errorManager: UnresolvedErrorManager,
+    showingNotice?: boolean,
+    ignoreSuspending?: boolean
+): Promise<boolean>;
+export async function performFullScan(
+    host: NecessaryServices<
+        "setting" | "vault" | "path" | "fileProcessing" | "database" | "keyValueDB",
+        "storageAccess" | "fileHandler"
+    >,
+    log: LogFunction,
+    errorManager: UnresolvedErrorManager,
+    showingNoticeOrOptions: Partial<FullScanOptions> | boolean = false,
     ignoreSuspending: boolean = false
 ): Promise<boolean> {
-    if (!canProceedScan(host, errorManager, log, showingNotice, ignoreSuspending)) {
+    const options = normaliseFullScanOptions(showingNoticeOrOptions, ignoreSuspending);
+    const showingNotice = options.showingNotice ?? false;
+    const shouldIgnoreSuspending = options.ignoreSuspending ?? false;
+
+    if (!canProceedScan(host, errorManager, log, showingNotice, shouldIgnoreSuspending)) {
         return false;
     }
-
     log("Opening the key-value database", LOG_LEVEL_VERBOSE);
     const isInitialized = (await host.services.keyValueDB.kvDB.get("initialized")) || false;
-
-    const settings = host.services.setting.currentSettings();
 
     if (showingNotice) {
         log("Initializing", LOG_LEVEL_NOTICE, "syncAll");
@@ -382,123 +745,12 @@ export async function performFullScan(
         log("Restoring storage state", LOG_LEVEL_VERBOSE);
         await host.serviceModules.storageAccess.restoreState();
     }
+    await loadFileStatus(host);
 
     log("Initialize and checking database files");
     log("Checking deleted files");
     await collectDeletedFiles(host, log);
-
-    const { storageFileNameMap, storageFileNames, storageFileNameCI2CS } = await collectFilesOnStorage(
-        host,
-        settings,
-        log
-    );
-    const { databaseFileNameMap, databaseFileNames, databaseFileNameCI2CS } = await collectDatabaseFiles(
-        host,
-        settings,
-        log,
-        showingNotice
-    );
-
-    const allFiles = unique([
-        ...Object.keys(databaseFileNameCI2CS),
-        ...Object.keys(storageFileNameCI2CS),
-    ]) as FilePathWithPrefixLC[];
-
-    log(`Total files in the database: ${databaseFileNames.length}`, LOG_LEVEL_VERBOSE, "syncAll");
-    log(`Total files in the storage: ${storageFileNames.length}`, LOG_LEVEL_VERBOSE, "syncAll");
-    log(`Total files: ${allFiles.length}`, LOG_LEVEL_VERBOSE, "syncAll");
-
-    const filesExistOnlyInStorage = allFiles.filter((e) => !databaseFileNameCI2CS[e]);
-    const filesExistOnlyInDatabase = allFiles.filter((e) => !storageFileNameCI2CS[e]);
-    const filesExistBoth = allFiles.filter((e) => databaseFileNameCI2CS[e] && storageFileNameCI2CS[e]);
-    const fileMap = filesExistBoth.map((path) => {
-        const file = storageFileNameMap[storageFileNameCI2CS[path]];
-        const doc = databaseFileNameMap[databaseFileNameCI2CS[path]];
-        return { file, doc };
-    });
-    log(`Files exist only in storage: ${filesExistOnlyInStorage.length}`, LOG_LEVEL_VERBOSE, "syncAll");
-    log(`Files exist only in database: ${filesExistOnlyInDatabase.length}`, LOG_LEVEL_VERBOSE, "syncAll");
-    log(`Files exist both in storage and database: ${filesExistBoth.length}`, LOG_LEVEL_VERBOSE, "syncAll");
-
-    log("Synchronising...");
-    const processStatus: Record<string, string> = {};
-    const logLevel = showingNotice ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO;
-    const updateLog = throttle((key: string, msg: string) => {
-        processStatus[key] = msg;
-        const logMsg = Object.values(processStatus).join("\n");
-        log(logMsg, logLevel, "syncAll");
-    }, 25);
-
-    const initProcess: Promise<void>[] = [];
-    type FileWithDoc = { file: UXFileInfoStub; doc: MetaEntry };
-    type ProcedureParameter = FileWithDoc | FilePathWithPrefixLC;
-    async function runAll<T extends ProcedureParameter>(
-        procedureName: string,
-        objects: T[],
-        callback: (arg: T) => Promise<void>
-    ) {
-        if (objects.length === 0) {
-            log(`${procedureName}: Nothing to do`, LOG_LEVEL_VERBOSE);
-            return;
-        }
-        log(`${procedureName} (Total: ${objects.length})`);
-        if (!host.services.database.localDatabase.isReady) throw Error("Database is not ready!");
-        let success = 0;
-        let failed = 0;
-        let total = 0;
-        for await (const result of withConcurrency(
-            objects,
-            async (e) => {
-                try {
-                    await callback(e);
-                    return true;
-                } catch (ex) {
-                    log(`Error while ${procedureName}`, LOG_LEVEL_NOTICE);
-                    const parameterDetails =
-                        typeof e === "string" ? e : `file:${e.file.path}, doc:${getPathFromEntry(host, e.doc)}`;
-                    log(`Parameter: ${parameterDetails}`, LOG_LEVEL_INFO);
-                    log(ex, LOG_LEVEL_VERBOSE);
-                    return false;
-                }
-            },
-            10
-        )) {
-            if (result) {
-                success++;
-            } else {
-                failed++;
-            }
-            total++;
-            const msg = `${procedureName}: DONE:${success}, FAILED:${failed}, LAST:${objects.length - total}`;
-            updateLog(procedureName, msg);
-        }
-        const msg = `${procedureName} All done: DONE:${success}, FAILED:${failed}`;
-        updateLog(procedureName, msg);
-    }
-
-    initProcess.push(
-        runAll("UPDATE DATABASE", filesExistOnlyInStorage, async (e: FilePathWithPrefixLC) => {
-            // Exists in storage but not in database.
-            const file = storageFileNameMap[storageFileNameCI2CS[e]];
-            await updateToDatabase(host, log, logLevel, file);
-        })
-    );
-
-    initProcess.push(
-        runAll("UPDATE STORAGE", filesExistOnlyInDatabase, async (e: FilePathWithPrefixLC) => {
-            const w = databaseFileNameMap[databaseFileNameCI2CS[e]];
-            // Exists in database but not in storage.
-            await updateToStorage(host, log, logLevel, w);
-        })
-    );
-
-    initProcess.push(
-        runAll("SYNC DATABASE AND STORAGE", fileMap, async (e: { file: UXFileInfoStub; doc: MetaEntry }) => {
-            const { file, doc } = e;
-            await syncStorageAndDatabase(host, log, file, logLevel, doc);
-        })
-    );
-    await Promise.all(initProcess);
+    await synchroniseAllFilesBetweenDBandStorage(host, log, errorManager, options);
 
     log("Initialized, NOW TRACKING!");
     if (!isInitialized) {

--- a/src/serviceFeatures/offlineScanner.unit.spec.ts
+++ b/src/serviceFeatures/offlineScanner.unit.spec.ts
@@ -2,8 +2,15 @@ import { describe, it, expect, beforeAll, vi } from "vitest";
 
 import {
     collectDeletedFiles,
+    ExtraOnLocal,
+    ExtraOnRemote,
+    FullScanModes,
+    normaliseFullScanOptions,
+    getFilePairState,
     getPathFromEntry,
+    resolveFilePairAction,
     syncFileBetweenDBandStorage,
+    synchroniseAllFilesBetweenDBandStorage,
     canProceedScan,
     convertCase,
     collectFilesOnStorage,
@@ -734,7 +741,7 @@ describe("syncFileBetweenDBandStorage", () => {
 
         await syncFileBetweenDBandStorage(host, logger, file, doc);
 
-        expect(dbToStorageMock).toHaveBeenCalled();
+        expect(dbToStorageMock).toHaveBeenCalledWith(doc, "test.md", false);
     });
 
     it("should do nothing when files are equal", async () => {
@@ -824,10 +831,11 @@ describe("syncFileBetweenDBandStorage", () => {
 
         await expect(syncFileBetweenDBandStorage(host, logger, file, undefined!)).rejects.toThrow();
     });
-    it("should handle if file cannot be found in storage", async () => {
+    it("should not require refetching file stub from storage", async () => {
         const storeFileToDBMock = vi.fn();
         const dbToStorageMock = vi.fn();
         const getPathMock = vi.fn().mockReturnValue("test.md");
+        const compareFileFreshnessMock = vi.fn().mockReturnValue(EVEN);
 
         const host = {
             services: {
@@ -835,7 +843,7 @@ describe("syncFileBetweenDBandStorage", () => {
                     isFileSizeTooLarge: vi.fn().mockReturnValue(false),
                 },
                 path: {
-                    compareFileFreshness: vi.fn().mockReturnValue(EVEN),
+                    compareFileFreshness: compareFileFreshnessMock,
                     getPath: getPathMock,
                 },
                 setting: {
@@ -862,7 +870,8 @@ describe("syncFileBetweenDBandStorage", () => {
             path: "test.md",
             size: 100,
         } as MetaEntry;
-        await expect(syncFileBetweenDBandStorage(host, logger, file, doc)).rejects.toThrow();
+        await expect(syncFileBetweenDBandStorage(host, logger, file, doc)).resolves.toBeUndefined();
+        expect(compareFileFreshnessMock).toHaveBeenCalledWith(file, doc);
     });
     it("should handle if storage file is too large", async () => {
         const storeFileToDBMock = vi.fn();
@@ -1063,6 +1072,588 @@ describe("syncStorageAndDatabase", () => {
     });
 });
 
+describe("getFilePairState", () => {
+    it("should classify storage-only pairs", () => {
+        const result = getFilePairState({
+            file: { path: "local.md", stat: { size: 10, mtime: 100 } } as UXFileInfoStub,
+            doc: undefined,
+        });
+
+        expect(result).toBe("storage-only");
+    });
+
+    it("should classify deleted database pairs that exist on both sides", () => {
+        const result = getFilePairState({
+            file: { path: "local.md", stat: { size: 10, mtime: 100 } } as UXFileInfoStub,
+            doc: { path: "local.md", mtime: 50, deleted: true } as MetaEntry,
+        });
+
+        expect(result).toBe("both-db-deleted");
+    });
+
+    it("should classify database-only pairs", () => {
+        const result = getFilePairState({
+            file: undefined,
+            doc: { path: "remote.md", mtime: 50, deleted: false } as MetaEntry,
+        });
+
+        expect(result).toBe("db-only");
+    });
+
+    it("should classify deleted database-only pairs", () => {
+        const result = getFilePairState({
+            file: undefined,
+            doc: { path: "remote.md", mtime: 50, _deleted: true } as MetaEntry,
+        });
+
+        expect(result).toBe("db-only-deleted");
+    });
+
+    it("should throw when pair is corrupted", () => {
+        expect(() => getFilePairState({ file: undefined, doc: undefined } as any)).toThrow("Corrupted file pair");
+    });
+});
+
+describe("resolveFilePairAction", () => {
+    const states = ["storage-only", "db-only", "db-only-deleted", "both", "both-db-deleted"] as const;
+    const modes = [FullScanModes.DB_APPLY, FullScanModes.NEWER_WINS] as const;
+    const extraOnRemoteValues = [undefined, ExtraOnRemote.DELETE_LOCAL_MISSING] as const;
+    const extraOnLocalValues = [
+        undefined,
+        ExtraOnLocal.DELETE_DB_DELETED,
+        ExtraOnLocal.DELETE_DB_MISSING,
+        ExtraOnLocal.APPEND_STORAGE_ONLY,
+    ] as const;
+
+    function expectedAction(
+        state: (typeof states)[number],
+        mode: (typeof modes)[number],
+        extraOnRemote: (typeof extraOnRemoteValues)[number],
+        extraOnLocal: (typeof extraOnLocalValues)[number]
+    ) {
+        const deleteWhenRemoteMissing =
+            extraOnRemote === ExtraOnRemote.DELETE_LOCAL_MISSING || extraOnLocal === ExtraOnLocal.DELETE_DB_MISSING;
+        const deleteWhenRemoteDeleted =
+            extraOnRemote === ExtraOnRemote.DELETE_LOCAL_MISSING ||
+            extraOnLocal === ExtraOnLocal.DELETE_DB_DELETED ||
+            extraOnLocal === ExtraOnLocal.DELETE_DB_MISSING;
+
+        if (mode === FullScanModes.DB_APPLY) {
+            if (state === "both" || state === "db-only") return "update-storage";
+            if (state === "storage-only") return deleteWhenRemoteMissing ? "delete-local" : "skip";
+            if (state === "both-db-deleted") return deleteWhenRemoteDeleted ? "delete-local" : "skip";
+            return "skip";
+        }
+
+        if (state === "both") return "sync-newer";
+        if (state === "storage-only") return deleteWhenRemoteMissing ? "delete-local" : "update-db";
+        if (state === "db-only") return "update-storage";
+        if (state === "both-db-deleted") {
+            if (deleteWhenRemoteDeleted) return "delete-local";
+            return extraOnLocal === ExtraOnLocal.APPEND_STORAGE_ONLY ? "update-db" : "skip";
+        }
+        return "skip";
+    }
+
+    for (const mode of modes) {
+        for (const state of states) {
+            for (const extraOnRemote of extraOnRemoteValues) {
+                for (const extraOnLocal of extraOnLocalValues) {
+                    it(`should resolve mode=${mode}, state=${state}, remote=${extraOnRemote ?? "none"}, local=${extraOnLocal ?? "none"}`, () => {
+                        const result = resolveFilePairAction(state, {
+                            mode,
+                            extraOnRemote,
+                            extraOnLocal,
+                        });
+
+                        expect(result).toBe(expectedAction(state, mode, extraOnRemote, extraOnLocal));
+                    });
+                }
+            }
+        }
+    }
+});
+
+describe("normaliseFullScanOptions", () => {
+    it("should default to newer-wins and inherit object options", () => {
+        const options = normaliseFullScanOptions({
+            showingNotice: true,
+            extraOnLocal: ExtraOnLocal.DELETE_DB_MISSING,
+        });
+
+        expect(options.mode).toBe(FullScanModes.NEWER_WINS);
+        expect(options.showingNotice).toBe(true);
+        expect(options.extraOnLocal).toBe(ExtraOnLocal.DELETE_DB_MISSING);
+    });
+
+    it("should map boolean arguments into options", () => {
+        const options = normaliseFullScanOptions(true, true);
+
+        expect(options.mode).toBe(FullScanModes.NEWER_WINS);
+        expect(options.showingNotice).toBe(true);
+        expect(options.ignoreSuspending).toBe(true);
+    });
+});
+
+describe("synchroniseAllFilesBetweenDBandStorage", () => {
+    let logger: LogFunction;
+
+    beforeAll(() => {
+        logger = createLogger("TestLogger");
+    });
+
+    it("should process mixed file-set actions in db-apply mode", async () => {
+        const deleteMock = vi.fn().mockResolvedValue(undefined);
+        const dbToStorageMock = vi.fn().mockResolvedValue(true);
+
+        const storageFiles = [
+            { path: "local-only.md", stat: { size: 10, mtime: 20 } },
+            { path: "both.md", stat: { size: 11, mtime: 21 } },
+            { path: "both-deleted.md", stat: { size: 12, mtime: 22 } },
+        ];
+
+        async function* mockFindAllNormalDocs() {
+            yield { _id: "d1", path: "both.md", size: 11, mtime: 10, type: "newnote", children: [] };
+            yield { _id: "d2", path: "db-only.md", size: 13, mtime: 10, type: "newnote", children: [] };
+            yield {
+                _id: "d3",
+                path: "both-deleted.md",
+                size: 12,
+                mtime: 10,
+                deleted: true,
+                type: "newnote",
+                children: [],
+            };
+            yield {
+                _id: "d4",
+                path: "db-only-deleted.md",
+                size: 12,
+                mtime: 10,
+                _deleted: true,
+                type: "newnote",
+                children: [],
+            };
+        }
+
+        const host = {
+            services: {
+                setting: {
+                    currentSettings: () => ({
+                        handleFilenameCaseSensitive: true,
+                    }),
+                },
+                vault: {
+                    isTargetFile: vi.fn().mockResolvedValue(true),
+                    isValidPath: vi.fn().mockReturnValue(true),
+                    isFileSizeTooLarge: vi.fn().mockReturnValue(false),
+                },
+                path: {
+                    getPath: vi.fn((doc: any) => doc.path),
+                },
+                fileProcessing: {},
+                database: {
+                    localDatabase: {
+                        findAllNormalDocs: vi.fn().mockReturnValue(mockFindAllNormalDocs()),
+                    },
+                },
+                keyValueDB: {},
+            },
+            serviceModules: {
+                storageAccess: {
+                    getFiles: vi.fn().mockResolvedValue(storageFiles),
+                    delete: deleteMock,
+                },
+                fileHandler: {
+                    dbToStorage: dbToStorageMock,
+                    storeFileToDB: vi.fn(),
+                },
+            },
+        } as any;
+
+        await synchroniseAllFilesBetweenDBandStorage(host, logger, {} as any, {
+            mode: FullScanModes.DB_APPLY,
+            extraOnRemote: ExtraOnRemote.DELETE_LOCAL_MISSING,
+        });
+
+        expect(deleteMock).toHaveBeenCalledTimes(2);
+        expect(deleteMock).toHaveBeenCalledWith("local-only.md", true);
+        expect(deleteMock).toHaveBeenCalledWith("both-deleted.md", true);
+        expect(dbToStorageMock).toHaveBeenCalledTimes(2);
+        expect(dbToStorageMock).toHaveBeenCalledWith("both.md", null, true);
+        expect(dbToStorageMock).toHaveBeenCalledWith("db-only.md", null, true);
+    });
+
+    it("should continue even if one pair processing fails", async () => {
+        const xLogger = vi.fn(logger);
+        const deleteMock = vi.fn().mockRejectedValueOnce(new Error("delete failed")).mockResolvedValueOnce(undefined);
+        const dbToStorageMock = vi.fn().mockResolvedValue(true);
+
+        const storageFiles = [
+            { path: "local-only.md", stat: { size: 10, mtime: 20 } },
+            { path: "both-deleted.md", stat: { size: 12, mtime: 22 } },
+        ];
+
+        async function* mockFindAllNormalDocs() {
+            yield {
+                _id: "d3",
+                path: "both-deleted.md",
+                size: 12,
+                mtime: 10,
+                deleted: true,
+                type: "newnote",
+                children: [],
+            };
+            yield { _id: "d2", path: "db-only.md", size: 13, mtime: 10, type: "newnote", children: [] };
+        }
+
+        const host = {
+            services: {
+                setting: {
+                    currentSettings: () => ({
+                        handleFilenameCaseSensitive: true,
+                    }),
+                },
+                vault: {
+                    isTargetFile: vi.fn().mockResolvedValue(true),
+                    isValidPath: vi.fn().mockReturnValue(true),
+                    isFileSizeTooLarge: vi.fn().mockReturnValue(false),
+                },
+                path: {
+                    getPath: vi.fn((doc: any) => doc.path),
+                },
+                fileProcessing: {},
+                database: {
+                    localDatabase: {
+                        findAllNormalDocs: vi.fn().mockReturnValue(mockFindAllNormalDocs()),
+                    },
+                },
+                keyValueDB: {},
+            },
+            serviceModules: {
+                storageAccess: {
+                    getFiles: vi.fn().mockResolvedValue(storageFiles),
+                    delete: deleteMock,
+                },
+                fileHandler: {
+                    dbToStorage: dbToStorageMock,
+                    storeFileToDB: vi.fn(),
+                },
+            },
+        } as any;
+
+        await expect(
+            synchroniseAllFilesBetweenDBandStorage(host, xLogger, {} as any, {
+                mode: FullScanModes.DB_APPLY,
+                extraOnRemote: ExtraOnRemote.DELETE_LOCAL_MISSING,
+            })
+        ).resolves.not.toThrow();
+
+        expect(dbToStorageMock).toHaveBeenCalledWith("db-only.md", null, true);
+        expect(xLogger).toHaveBeenCalledWith(expect.stringContaining("Error processing"), LOG_LEVEL_NOTICE);
+    });
+
+    it("should skip conflicted entries before delete-local action", async () => {
+        const deleteMock = vi.fn().mockResolvedValue(undefined);
+
+        const storageFiles = [{ path: "both-deleted.md", stat: { size: 12, mtime: 22 } }];
+
+        async function* mockFindAllNormalDocs() {
+            yield {
+                _id: "d3",
+                path: "both-deleted.md",
+                size: 12,
+                mtime: 10,
+                deleted: true,
+                _conflicts: ["conflicted-rev"],
+                type: "newnote",
+                children: [],
+            };
+        }
+
+        const host = {
+            services: {
+                setting: {
+                    currentSettings: () => ({
+                        handleFilenameCaseSensitive: true,
+                    }),
+                },
+                vault: {
+                    isTargetFile: vi.fn().mockResolvedValue(true),
+                    isValidPath: vi.fn().mockReturnValue(true),
+                    isFileSizeTooLarge: vi.fn().mockReturnValue(false),
+                },
+                path: {
+                    getPath: vi.fn((doc: any) => doc.path),
+                },
+                fileProcessing: {},
+                database: {
+                    localDatabase: {
+                        findAllNormalDocs: vi.fn().mockReturnValue(mockFindAllNormalDocs()),
+                    },
+                },
+                keyValueDB: {},
+            },
+            serviceModules: {
+                storageAccess: {
+                    getFiles: vi.fn().mockResolvedValue(storageFiles),
+                    delete: deleteMock,
+                },
+                fileHandler: {
+                    dbToStorage: vi.fn().mockResolvedValue(true),
+                    storeFileToDB: vi.fn(),
+                },
+            },
+        } as any;
+
+        await synchroniseAllFilesBetweenDBandStorage(host, logger, {} as any, {
+            mode: FullScanModes.DB_APPLY,
+            extraOnRemote: ExtraOnRemote.DELETE_LOCAL_MISSING,
+        });
+
+        expect(deleteMock).not.toHaveBeenCalled();
+    });
+
+    it("should skip oversize entries inside mixed newer-wins file-set", async () => {
+        const storeFileToDBMock = vi.fn();
+        const dbToStorageMock = vi.fn().mockResolvedValue(true);
+
+        const storageFiles = [
+            { path: "storage-too-large.md", stat: { size: 5000, mtime: 20 } },
+            { path: "both-too-large.md", stat: { size: 5000, mtime: 20 } },
+            { path: "both-normal.md", stat: { size: 100, mtime: 20 } },
+        ];
+
+        async function* mockFindAllNormalDocs() {
+            yield { _id: "d1", path: "db-too-large.md", size: 5000, mtime: 10, type: "newnote", children: [] };
+            yield { _id: "d2", path: "both-too-large.md", size: 100, mtime: 10, type: "newnote", children: [] };
+            yield { _id: "d3", path: "both-normal.md", size: 50, mtime: 10, type: "newnote", children: [] };
+        }
+
+        const host = {
+            services: {
+                setting: {
+                    currentSettings: () => ({
+                        handleFilenameCaseSensitive: true,
+                    }),
+                },
+                vault: {
+                    isTargetFile: vi.fn().mockResolvedValue(true),
+                    isValidPath: vi.fn().mockReturnValue(true),
+                    isFileSizeTooLarge: vi.fn((size: number) => size > 1000),
+                },
+                path: {
+                    getPath: vi.fn((doc: any) => doc.path),
+                    compareFileFreshness: vi.fn((file: UXFileInfoStub) =>
+                        file.path === "both-normal.md" ? BASE_IS_NEW : EVEN
+                    ),
+                },
+                fileProcessing: {},
+                database: {
+                    localDatabase: {
+                        findAllNormalDocs: vi.fn().mockReturnValue(mockFindAllNormalDocs()),
+                    },
+                },
+                keyValueDB: {},
+            },
+            serviceModules: {
+                storageAccess: {
+                    getFiles: vi.fn().mockResolvedValue(storageFiles),
+                    getFileStub: vi.fn((path: string) => storageFiles.find((e) => e.path === path)),
+                    delete: vi.fn(),
+                },
+                fileHandler: {
+                    dbToStorage: dbToStorageMock,
+                    storeFileToDB: storeFileToDBMock,
+                },
+            },
+        } as any;
+
+        await synchroniseAllFilesBetweenDBandStorage(host, logger, {} as any, {
+            mode: FullScanModes.NEWER_WINS,
+        });
+
+        expect(storeFileToDBMock).toHaveBeenCalledTimes(1);
+        expect(storeFileToDBMock).toHaveBeenCalledWith(expect.objectContaining({ path: "both-normal.md" }));
+        expect(storeFileToDBMock).not.toHaveBeenCalledWith(expect.objectContaining({ path: "storage-too-large.md" }));
+        expect(dbToStorageMock).not.toHaveBeenCalledWith("db-too-large.md", null, true);
+    });
+
+    it("should treat db-only entry as offline local deletion when last seen mtime is newer", async () => {
+        const deleteFileFromDBMock = vi.fn().mockResolvedValue(true);
+        const dbToStorageMock = vi.fn().mockResolvedValue(true);
+
+        async function* mockFindAllNormalDocs() {
+            yield { _id: "d1", path: "gone.md", size: 100, mtime: 10000, type: "newnote", children: [] };
+        }
+
+        const host = {
+            services: {
+                setting: {
+                    currentSettings: () => ({
+                        handleFilenameCaseSensitive: true,
+                    }),
+                },
+                vault: {
+                    isTargetFile: vi.fn().mockResolvedValue(true),
+                    isValidPath: vi.fn().mockReturnValue(true),
+                    isFileSizeTooLarge: vi.fn().mockReturnValue(false),
+                },
+                path: {
+                    getPath: vi.fn((doc: any) => doc.path),
+                },
+                fileProcessing: {},
+                database: {
+                    localDatabase: {
+                        findAllNormalDocs: vi.fn().mockReturnValue(mockFindAllNormalDocs()),
+                    },
+                },
+                keyValueDB: {
+                    kvDB: {
+                        get: vi.fn().mockResolvedValue({ "gone.md": 20000 }),
+                        set: vi.fn().mockResolvedValue(undefined),
+                    },
+                },
+            },
+            serviceModules: {
+                storageAccess: {
+                    getFiles: vi.fn().mockResolvedValue([]),
+                    delete: vi.fn(),
+                },
+                fileHandler: {
+                    dbToStorage: dbToStorageMock,
+                    storeFileToDB: vi.fn(),
+                    deleteFileFromDB: deleteFileFromDBMock,
+                },
+            },
+        } as any;
+
+        await synchroniseAllFilesBetweenDBandStorage(host, logger, {} as any, {
+            mode: FullScanModes.NEWER_WINS,
+        });
+
+        expect(deleteFileFromDBMock).toHaveBeenCalledWith("gone.md");
+        expect(dbToStorageMock).not.toHaveBeenCalled();
+    });
+
+    it("should keep db-only entry when database mtime is newer than last seen", async () => {
+        const deleteFileFromDBMock = vi.fn().mockResolvedValue(true);
+        const dbToStorageMock = vi.fn().mockResolvedValue(true);
+
+        async function* mockFindAllNormalDocs() {
+            yield { _id: "d1", path: "remote-new.md", size: 100, mtime: 50000, type: "newnote", children: [] };
+        }
+
+        const host = {
+            services: {
+                setting: {
+                    currentSettings: () => ({
+                        handleFilenameCaseSensitive: true,
+                    }),
+                },
+                vault: {
+                    isTargetFile: vi.fn().mockResolvedValue(true),
+                    isValidPath: vi.fn().mockReturnValue(true),
+                    isFileSizeTooLarge: vi.fn().mockReturnValue(false),
+                },
+                path: {
+                    getPath: vi.fn((doc: any) => doc.path),
+                },
+                fileProcessing: {},
+                database: {
+                    localDatabase: {
+                        findAllNormalDocs: vi.fn().mockReturnValue(mockFindAllNormalDocs()),
+                    },
+                },
+                keyValueDB: {
+                    kvDB: {
+                        get: vi.fn().mockResolvedValue({ "remote-new.md": 10000 }),
+                        set: vi.fn().mockResolvedValue(undefined),
+                    },
+                },
+            },
+            serviceModules: {
+                storageAccess: {
+                    getFiles: vi.fn().mockResolvedValue([]),
+                    delete: vi.fn(),
+                },
+                fileHandler: {
+                    dbToStorage: dbToStorageMock,
+                    storeFileToDB: vi.fn(),
+                    deleteFileFromDB: deleteFileFromDBMock,
+                },
+            },
+        } as any;
+
+        await synchroniseAllFilesBetweenDBandStorage(host, logger, {} as any, {
+            mode: FullScanModes.NEWER_WINS,
+        });
+
+        expect(dbToStorageMock).toHaveBeenCalledWith("remote-new.md", null, true);
+        expect(deleteFileFromDBMock).not.toHaveBeenCalled();
+    });
+
+    it("should persist file status map after deferred save", async () => {
+        vi.useFakeTimers();
+        const kvDBSetMock = vi.fn().mockResolvedValue(undefined);
+
+        try {
+            async function* mockFindAllNormalDocs() {
+                // no db docs
+            }
+
+            const host = {
+                services: {
+                    setting: {
+                        currentSettings: () => ({
+                            handleFilenameCaseSensitive: true,
+                        }),
+                    },
+                    vault: {
+                        isTargetFile: vi.fn().mockResolvedValue(true),
+                        isValidPath: vi.fn().mockReturnValue(true),
+                        isFileSizeTooLarge: vi.fn().mockReturnValue(false),
+                    },
+                    path: {
+                        getPath: vi.fn((doc: any) => doc.path),
+                    },
+                    fileProcessing: {},
+                    database: {
+                        localDatabase: {
+                            findAllNormalDocs: vi.fn().mockReturnValue(mockFindAllNormalDocs()),
+                        },
+                    },
+                    keyValueDB: {
+                        kvDB: {
+                            get: vi.fn().mockResolvedValue({}),
+                            set: kvDBSetMock,
+                        },
+                    },
+                },
+                serviceModules: {
+                    storageAccess: {
+                        getFiles: vi.fn().mockResolvedValue([{ path: "local.md", stat: { size: 10, mtime: 123 } }]),
+                        delete: vi.fn(),
+                    },
+                    fileHandler: {
+                        dbToStorage: vi.fn().mockResolvedValue(true),
+                        storeFileToDB: vi.fn().mockResolvedValue(true),
+                        deleteFileFromDB: vi.fn().mockResolvedValue(true),
+                    },
+                },
+            } as any;
+
+            await synchroniseAllFilesBetweenDBandStorage(host, logger, {} as any, {
+                mode: FullScanModes.NEWER_WINS,
+            });
+
+            await vi.advanceTimersByTimeAsync(1100);
+            expect(kvDBSetMock).toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
 describe("performFullScan", () => {
     let logger: LogFunction;
 
@@ -1162,6 +1753,83 @@ describe("performFullScan", () => {
         } as any;
 
         const result = await performFullScan(host, logger, errorManager as any, false, false);
+
+        expect(result).toBe(true);
+        expect(host.serviceModules.storageAccess.restoreState).toHaveBeenCalled();
+    });
+
+    it("should accept the options object form", async () => {
+        const errorManager = {
+            showError: vi.fn(),
+            clearError: vi.fn(),
+        };
+
+        async function* mockFindAllDocs() {
+            // Empty
+        }
+
+        async function* mockFindAllNormalDocs() {
+            yield {
+                _id: "doc1",
+                path: "file1.md",
+                size: 100,
+                type: "newnote",
+            };
+            await Promise.resolve();
+        }
+
+        const host = {
+            services: {
+                setting: {
+                    currentSettings: () => ({
+                        isConfigured: true,
+                        suspendFileWatching: false,
+                        maxMTimeForReflectEvents: 0,
+                        handleFilenameCaseSensitive: true,
+                        automaticallyDeleteMetadataOfDeletedFiles: 0,
+                    }),
+                },
+                keyValueDB: {
+                    kvDB: {
+                        get: vi.fn().mockResolvedValue(true),
+                        set: vi.fn(),
+                    },
+                },
+                vault: {
+                    isTargetFile: vi.fn().mockResolvedValue(true),
+                    isValidPath: vi.fn().mockReturnValue(true),
+                    isFileSizeTooLarge: vi.fn().mockReturnValue(false),
+                },
+                database: {
+                    localDatabase: {
+                        findAllDocs: vi.fn().mockReturnValue(mockFindAllDocs()),
+                        findAllNormalDocs: vi.fn().mockReturnValue(mockFindAllNormalDocs()),
+                        isReady: true,
+                    },
+                },
+                path: {
+                    getPath: vi.fn((doc: any) => doc.path),
+                    compareFileFreshness: vi.fn().mockReturnValue(EVEN),
+                },
+                fileProcessing: {},
+            },
+            serviceModules: {
+                storageAccess: {
+                    getFiles: vi.fn().mockReturnValue([{ path: "file1.md", stat: { size: 100, mtime: 100 } }]),
+                    restoreState: vi.fn(),
+                    getFileStub: vi.fn().mockResolvedValue({ path: "file1.md", stat: { size: 100, mtime: 100 } }),
+                },
+                fileHandler: {
+                    storeFileToDB: vi.fn(),
+                    dbToStorage: vi.fn(),
+                },
+            },
+        } as any;
+
+        const result = await performFullScan(host, logger, errorManager as any, {
+            mode: FullScanModes.NEWER_WINS,
+            showingNotice: true,
+        });
 
         expect(result).toBe(true);
         expect(host.serviceModules.storageAccess.restoreState).toHaveBeenCalled();

--- a/src/serviceModules/Rebuilder.ts
+++ b/src/serviceModules/Rebuilder.ts
@@ -1,5 +1,5 @@
 import { FlagFilesHumanReadable } from "@lib/common/models/redflag.const";
-import { REMOTE_MINIO } from "@lib/common/models/setting.const";
+import { REMOTE_COUCHDB, REMOTE_MINIO } from "@lib/common/models/setting.const";
 import { DEFAULT_SETTINGS } from "@lib/common/models/setting.const.defaults";
 import type { IFileHandler } from "@lib/interfaces/FileHandler";
 import type { APIService } from "@lib/services/base/APIService";
@@ -20,6 +20,10 @@ import { eventHub } from "@lib/hub/hub";
 import { EVENT_DATABASE_REBUILT } from "@lib/events/coreEvents";
 import { ServiceModuleBase } from "@lib/serviceModules/ServiceModuleBase";
 import type { ControlService } from "../services/base/ControlService";
+import { fetchChangesForInitialSync } from "@lib/pouchdb/StreamingFetch";
+import { getConfiguredFunctionsForEncryption } from "@lib/pouchdb/encryption";
+import { AuthorizationHeaderGenerator, generateCredentialObject } from "@lib/replication/httplib";
+import { sizeToHumanReadable } from "octagonal-wheels/number";
 
 export interface ServiceRebuilderDependencies {
     appLifecycle: AppLifecycleService;
@@ -164,6 +168,10 @@ Please enable them from the settings screen after setup is complete.`,
         return this.fetchLocal(makeLocalChunkBeforeSync, preventMakeLocalFilesBeforeSync);
     }
 
+    $fetchLocalDBFast(autoResume: boolean): Promise<void> {
+        return this.fetchLocalDBFast(autoResume);
+    }
+
     async scheduleRebuild(): Promise<void> {
         try {
             await this.storageAccess.writeFileAuto(FlagFilesHumanReadable.REBUILD_ALL, "");
@@ -248,7 +256,7 @@ Please enable them from the settings screen after setup is complete.`,
         await this.setting.saveSettingData();
     }
 
-    async fetchLocal(makeLocalChunkBeforeSync?: boolean, preventMakeLocalFilesBeforeSync?: boolean) {
+    async fetchLocal(makeLocalChunkBeforeSync?: boolean, preventMakeLocalFilesBeforeSync?: boolean, autoResume = true) {
         await this.setting.suspendExtraSync();
         // await this.askUseNewAdapter();
         await this.setting.applyPartial({
@@ -304,11 +312,83 @@ Are you sure you wish to proceed?`;
         await this.replication.replicateAllFromRemote(true);
         await delay(1000);
         await this.replication.replicateAllFromRemote(true);
-        await this.resumeReflectingDatabase();
-        await this.informOptionalFeatures();
-        // No longer enable
-        // await this.askUsingOptionalFeature({ enableFetch: true });
+        if (autoResume) {
+            await this.finishRebuild();
+        }
     }
+
+    async fetchLocalDBFast(autoResume: boolean) {
+        await this.setting.suspendExtraSync();
+        await this.setting.applyPartial({
+            isConfigured: true,
+            notifyThresholdOfRemoteStorageSize: DEFAULT_SETTINGS.notifyThresholdOfRemoteStorageSize,
+        });
+        const settings = this.setting.currentSettings();
+        if (settings.remoteType !== REMOTE_COUCHDB) {
+            this._log(
+                "Fast database fetch is available only for CouchDB remote. Falling back to standard fetch.",
+                LOG_LEVEL_NOTICE
+            );
+            await this.fetchLocal(false, true, autoResume);
+            return;
+        }
+
+        await this.suspendReflectingDatabase();
+        await this.control.applySettings();
+        await this.resetLocalDatabase();
+        await delay(1000);
+        await this.database.openDatabase({
+            databaseEvents: this.databaseEvents,
+            replicator: this.replicator,
+        });
+        this.appLifecycle.markIsReady();
+
+        const localDB = this.database.localDatabase.localDatabase;
+        const replicator = this.replicator.getActiveReplicator() ?? (await this.replicator.getNewReplicator());
+        if (!replicator) {
+            throw new Error("No active replicator found for fast fetch.");
+        }
+        const salt = () => replicator.getReplicationPBKDF2Salt(settings);
+        const enc = getConfiguredFunctionsForEncryption(
+            settings.passphrase,
+            false,
+            false,
+            salt,
+            settings.E2EEAlgorithm
+        );
+
+        const authHeader = await new AuthorizationHeaderGenerator().getAuthorizationHeader(
+            generateCredentialObject(settings)
+        );
+        const remote =
+            settings.couchDB_URI.replace(/\/+$/, "") +
+            (settings.couchDB_DBNAME == "" ? "" : "/" + settings.couchDB_DBNAME);
+
+        await fetchChangesForInitialSync(localDB, remote, authHeader, enc.outgoing, "0", (progress) => {
+            this._log(
+                `Fast fetch progress: ${progress.totalValidFetched} / ${progress.docsToFetch}\nTotal bytes fetched: ${sizeToHumanReadable(progress.totalBytes)}`,
+                LOG_LEVEL_NOTICE,
+                "fetch-init-progress"
+            );
+        });
+
+        const allDocs = await localDB.allDocs({ include_docs: false });
+        this._log(
+            `Fast database fetch completed. Total documents in local database: ${allDocs.total_rows}`,
+            LOG_LEVEL_NOTICE,
+            "fetch-init-complete"
+        );
+
+        await this.replication.markResolved();
+        if (autoResume) {
+            await this.resumeReflectingDatabase();
+        }
+    }
+
+    async finishRebuild() {
+        await this.resumeReflectingDatabase();
+    }
+
     async fetchLocalWithRebuild() {
         return await this.fetchLocal(true);
     }


### PR DESCRIPTION
- Database fetching (a.k.a. Reset Synchronisation on This Device) on the initialisation now supports streaming and is faster (CouchDB only).
- The database fetching process has been streamlined, and database operations are now suspended until it has been completed.
- The initial synchronisation process has been simplified, making it easier to synchronise files with the remote server.
- We can select the remote database to fetch from during the initialisation, when there are multiple remote databases configured (e.g. multiple CouchDBs or S3 remotes).
- The file change scan at boot sequence has been made more robust. 