### PR TITLE
fix(offlineScanner): throttle saveFileStatus calls to fix high CPU usage

### DIFF
--- a/src/serviceFeatures/offlineScanner.ts
+++ b/src/serviceFeatures/offlineScanner.ts
@@ -672,19 +672,23 @@ async function _saveFileStatus(host: NecessaryServices<"keyValueDB", never>) {
 }
 
 let saveFileStatusTimeout: number | null = null;
-// Schedule saving file status with debouncing to prevent excessive writes during rapid changes.
+// Schedule saving file status with throttling to prevent excessive writes and CPU usage.
 function saveFileStatus(host: NecessaryServices<"keyValueDB", never>, immediate = false) {
-    if (saveFileStatusTimeout !== null) {
-        compatGlobal.clearTimeout(saveFileStatusTimeout);
+    if (immediate) {
+        if (saveFileStatusTimeout !== null) compatGlobal.clearTimeout(saveFileStatusTimeout);
+        saveFileStatusTimeout = compatGlobal.setTimeout(() => {
+            saveFileStatusTimeout = null;
+            void _saveFileStatus(host);
+        }, 0);
+        return;
     }
-    saveFileStatusTimeout = compatGlobal.setTimeout(
-        () => {
-            void _saveFileStatus(host).then(() => {
-                saveFileStatusTimeout = null;
-            });
-        },
-        immediate ? 0 : 1000
-    );
+
+    if (saveFileStatusTimeout === null) {
+        saveFileStatusTimeout = compatGlobal.setTimeout(() => {
+            saveFileStatusTimeout = null;
+            void _saveFileStatus(host);
+        }, 1000);
+    }
 }
 function updateFileMTimeInMap(host: NecessaryServices<"keyValueDB", never>, key: string, mtime: number) {
     fileMaps.set(key, mtime);


### PR DESCRIPTION
Replaced the debounce implementation in `offlineScanner.ts` (`saveFileStatus`) with throttling. The previous approach took ~100ms due to `setTimeout`/`clearTimeout` calls scaling with the number of files in the vault, whereas the new throttled version cuts it down to ~1ms.

## Before & After
### Before
<img width="2212" height="1194" alt="image" src="https://github.com/user-attachments/assets/053f2ad3-b4c1-4982-bc64-2830c499b1d8" />

### After
<img width="2230" height="1488" alt="image" src="https://github.com/user-attachments/assets/f952daac-88b7-4c0b-b205-b15338f5c7c3" />

Unrelated to this PR, but while working on `offlineScanner`, I found a spot in the `ModuleLog` file's `clearTimeout` / `setTimeout ` (`__addLog` func) logic that could be improved just like this one 