### PR TITLE
fixed: ignore hidden files completely if hidden file sync disabled

### DIFF
--- a/src/managers/EntryManager/EntryManagerImpls.ts
+++ b/src/managers/EntryManager/EntryManagerImpls.ts
@@ -247,6 +247,11 @@ export function isTargetFile(host: NecessaryServicesInterfaces<"setting", any>, 
     if (file.includes(":")) {
         return false;
     }
+    if (!settings.syncInternalFiles) {
+        if (file.startsWith(".")) {
+            return false;
+        }
+    }
     if (settings.syncOnlyRegEx) {
         const syncOnly = getFileRegExp(settings, "syncOnlyRegEx");
         if (syncOnly.length > 0 && !syncOnly.some((e) => e.test(file))) return false;

--- a/src/managers/EntryManager/EntryManagerImpls.unit.spec.ts
+++ b/src/managers/EntryManager/EntryManagerImpls.unit.spec.ts
@@ -180,6 +180,35 @@ describe("EntryManagerImpls", () => {
             expect(isTargetFile(host, "ignored/file.md")).toBe(false);
             expect(isTargetFile(host, "normal/file.md")).toBe(true);
         });
+
+        it("should return false for hidden files when syncInternalFiles is false", () => {
+            const services = createMockServices({
+                syncInternalFiles: false,
+            });
+            const host = createHost(services.mockSettingService);
+            expect(isTargetFile(host, ".hidden.md")).toBe(false);
+            expect(isTargetFile(host, ".obsidian/workspace.json")).toBe(false);
+            expect(isTargetFile(host, "i:.hidden.md")).toBe(false);
+            expect(isTargetFile(host, ".trash/deleted-file.md")).toBe(false);
+        });
+
+        it("should return true for hidden files when syncInternalFiles is true", () => {
+            const services = createMockServices({
+                syncInternalFiles: true,
+            });
+            const host = createHost(services.mockSettingService);
+            expect(isTargetFile(host, ".hidden.md")).toBe(true);
+            expect(isTargetFile(host, ".obsidian/workspace.json")).toBe(true);
+            expect(isTargetFile(host, "i:.hidden.md")).toBe(true);
+        });
+
+        it("should return true for customisation sync files even when syncInternalFiles is false", () => {
+            const services = createMockServices({
+                syncInternalFiles: false,
+            });
+            const host = createHost(services.mockSettingService);
+            expect(isTargetFile(host, "ix:device/CONFIG/app.json.md")).toBe(true);
+        });
     });
 
     describe("prepareChunk", () => {

--- a/src/system/wakelock.ts
+++ b/src/system/wakelock.ts
@@ -55,7 +55,7 @@ export async function withWakeLock<T>(callback: () => Promise<T>): Promise<T> {
         // Re-acquire when the screen becomes active again
         if (compatGlobal.document.visibilityState === "visible" && !lock) {
             Logger(`Document became visible, re-acquiring wake lock`, LOG_LEVEL_VERBOSE);
-            requestLock();
+            void requestLock();
         }
     };
 
@@ -80,7 +80,7 @@ export async function withWakeLock<T>(callback: () => Promise<T>): Promise<T> {
             try {
                 await lock.release();
                 Logger(`Wake lock released manually`, LOG_LEVEL_VERBOSE);
-            } catch (e) {
+            } catch {
                 Logger(`Failed to release wake lock`, LOG_LEVEL_VERBOSE);
             }
         }


### PR DESCRIPTION
### Fixed

- Fixed an issue where disabling hidden file synchronisation did not take effect, allowing non-target hidden files to continue to be processed and synchronised by replication or boot-sequence scan.

This PR includes amendments to the files being prepared.