### PR TITLE
feat(settings): add keepReplicationActiveInBackground option

### DIFF
--- a/src/common/models/setting.const.defaults.ts
+++ b/src/common/models/setting.const.defaults.ts
@@ -116,6 +116,7 @@ export const DEFAULT_SETTINGS: ObsidianLiveSyncSettings = {
     useIgnoreFiles: false,
     ignoreFiles: ".gitignore",
     syncOnEditorSave: false,
+    keepReplicationActiveInBackground: false,
     pluginSyncExtendedSetting: {},
     syncMaxSizeInMB: 50,
     settingSyncFile: "",

--- a/src/common/models/setting.const.qr.ts
+++ b/src/common/models/setting.const.qr.ts
@@ -55,6 +55,7 @@ export const KeyIndexOfSettings: Record<keyof ObsidianLiveSyncSettings, number> 
     syncOnStart: 51,
     syncOnFileOpen: 52,
     syncOnEditorSave: 53,
+    keepReplicationActiveInBackground: -1, // Desktop-only local preference; do not encode into the QR Code.
     syncMinimumInterval: 54,
     showVerboseLog: 55,
     lessInformationInLog: 56,

--- a/src/common/models/setting.type.ts
+++ b/src/common/models/setting.type.ts
@@ -120,6 +120,14 @@ interface SyncMethodSettings {
     syncOnEditorSave: boolean;
 
     /**
+     * Desktop only, opt-in. Keep replication running while the window is hidden or minimised,
+     * instead of suspending it until the window becomes visible again. The trigger is
+     * document.hidden, not window focus. Applies to the background-capable sync modes (LiveSync
+     * and Periodic). Ignored on mobile. Default false.
+     */
+    keepReplicationActiveInBackground: boolean;
+
+    /**
      * The minimum delay between synchronisation operations (in milliseconds).
      * If the operation is triggered before this delay, the operation will be delayed until the delay is over, and executed as a single operation.
      */

--- a/src/common/settingConstants.ts
+++ b/src/common/settingConstants.ts
@@ -131,6 +131,10 @@ export const SettingInformation: Partial<Record<keyof AllSettings, Configuration
         name: "Sync on Editor Save",
         desc: "When you save a file in the editor, start a sync automatically",
     },
+    keepReplicationActiveInBackground: {
+        name: "Keep replication active in the background",
+        desc: "Desktop only; uses more battery and network.",
+    },
     syncOnFileOpen: {
         name: "Sync on File Open",
         desc: "Forces the file to be synced when opened.",


### PR DESCRIPTION
## Summary

Adds the setting definition for an opt-in, desktop-only option, `keepReplicationActiveInBackground` (default `false`). The behaviour, UI, docs and tests live in the companion `obsidian-livesync` PR that bumps this submodule. This PR is only the setting plumbing, so that PR can build against it.

Context: on desktop, replication is suspended when the Obsidian window becomes hidden and resumes when it is shown again. For the modes that maintain a background channel (LiveSync and Periodic) this stalls background sync. The companion plugin change makes window visibility stop driving the suspend/resume lifecycle while this setting is on.

## Changes

- `setting.type.ts`: add `keepReplicationActiveInBackground: boolean`.
- `setting.const.defaults.ts`: default `false`.
- `settingConstants.ts`: pane `name` ("Keep replication active in the background") and `desc` ("Desktop only; uses more battery and network.").
- `setting.const.qr.ts`: key index `-1`, so the value is excluded from setup-URI / QR encoding and is never pushed to other (possibly mobile) devices. It is a local per-desktop preference.

No protocol or data-format change.

## Companion PR

Companion PR: vrtmrz/obsidian-livesync#949. It carries the behaviour, UI, `docs/settings.md`, the unit tests, and the submodule bump to this commit. Suggested order: merge this one first, then repoint that PR's `src/lib` gitlink to the commit merged here. Happy to update the gitlink once this lands.

---

This PR was drafted by Claude Code, directed and reviewed by me (Miguel Ferreira).
