### PR TITLE
fix(file-handler): delete-db no-ops when the storage file is already gone, resurrecting deleted files

### DIFF
--- a/src/serviceFeatures/offlineScanner.ts
+++ b/src/serviceFeatures/offlineScanner.ts
@@ -526,15 +526,29 @@ async function processFilePair(
                 fileMaps.delete(fileMapKey);
                 saveFileStatus(host);
                 return true;
-            case "delete-db":
+            case "delete-db": {
                 if (!doc) {
                     throw new Error(`Missing database entry for ${path}`);
                 }
                 log(`DELETE DATABASE: ${path}`, LOG_LEVEL_INFO);
-                await host.serviceModules.fileHandler.deleteFileFromDB(stripAllPrefixes(path));
-                fileMaps.delete(fileMapKey);
-                saveFileStatus(host);
+                // deleteFileFromDB returns false when nothing was deleted, but the return
+                // value was ignored and the fileStatusMap last-seen entry was wiped
+                // regardless. The next scan then classified the doc as database-only with
+                // no last-seen record -> update-storage -> the deleted file was resurrected
+                // from the database. Only clear the last-seen record when the database
+                // delete actually succeeded.
+                const dbDeleted = await host.serviceModules.fileHandler.deleteFileFromDB(stripAllPrefixes(path));
+                if (dbDeleted) {
+                    fileMaps.delete(fileMapKey);
+                    saveFileStatus(host);
+                } else {
+                    log(
+                        `DELETE DATABASE did not delete ${path}; keeping last-seen record to avoid resurrecting the file`,
+                        LOG_LEVEL_NOTICE
+                    );
+                }
                 return true;
+            }
             case "skip":
                 log(`SKIP ${options.mode}: ${path} (${state})`, LOG_LEVEL_VERBOSE);
                 return true;

--- a/src/serviceFeatures/offlineScanner.unit.spec.ts
+++ b/src/serviceFeatures/offlineScanner.unit.spec.ts
@@ -1535,6 +1535,79 @@ describe("synchroniseAllFilesBetweenDBandStorage", () => {
         expect(dbToStorageMock).not.toHaveBeenCalled();
     });
 
+    it("should keep the last-seen record when the database delete reports nothing was deleted", async () => {
+        // Regression guard: when deleteFileFromDB returns false (nothing was
+        // tombstoned), the delete-db path must not clear the file's last-seen
+        // record. Otherwise the next scan reclassifies the doc as database-only
+        // and resurrects the deleted file.
+        const deleteFileFromDBMock = vi.fn().mockResolvedValue(false);
+        const dbToStorageMock = vi.fn().mockResolvedValue(true);
+        const kvDBSetMock = vi.fn().mockResolvedValue(undefined);
+        const logSpy = vi.fn();
+
+        async function* mockFindAllNormalDocs() {
+            yield { _id: "d1", path: "gone.md", size: 100, mtime: 10000, type: "newnote", children: [] };
+        }
+
+        const host = {
+            services: {
+                setting: {
+                    currentSettings: () => ({
+                        handleFilenameCaseSensitive: true,
+                    }),
+                },
+                vault: {
+                    isTargetFile: vi.fn().mockResolvedValue(true),
+                    isValidPath: vi.fn().mockReturnValue(true),
+                    isFileSizeTooLarge: vi.fn().mockReturnValue(false),
+                },
+                path: {
+                    getPath: vi.fn((doc: any) => doc.path),
+                },
+                fileProcessing: {},
+                database: {
+                    localDatabase: {
+                        findAllNormalDocs: vi.fn().mockReturnValue(mockFindAllNormalDocs()),
+                    },
+                },
+                keyValueDB: {
+                    kvDB: {
+                        get: vi.fn().mockResolvedValue({ "gone.md": 20000 }),
+                        set: kvDBSetMock,
+                    },
+                },
+            },
+            serviceModules: {
+                storageAccess: {
+                    getFiles: vi.fn().mockResolvedValue([]),
+                    delete: vi.fn(),
+                },
+                fileHandler: {
+                    dbToStorage: dbToStorageMock,
+                    storeFileToDB: vi.fn(),
+                    deleteFileFromDB: deleteFileFromDBMock,
+                },
+            },
+        } as any;
+
+        await synchroniseAllFilesBetweenDBandStorage(host, logSpy as unknown as LogFunction, {} as any, {
+            mode: FullScanModes.NEWER_WINS,
+        });
+
+        expect(deleteFileFromDBMock).toHaveBeenCalledWith("gone.md");
+        // The no-op delete must be reported rather than silently dropping the record.
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("keeping last-seen record"), LOG_LEVEL_NOTICE);
+        // The last-seen record for the still-present document must survive, so any
+        // persisted file-status map continues to include it.
+        for (const call of kvDBSetMock.mock.calls) {
+            if (call[0] === "fileStatusMap") {
+                expect(call[1]).toHaveProperty("gone.md");
+            }
+        }
+        // No resurrection: the file is not written back to storage.
+        expect(dbToStorageMock).not.toHaveBeenCalled();
+    });
+
     it("should keep db-only entry when database mtime is newer than last seen", async () => {
         const deleteFileFromDBMock = vi.fn().mockResolvedValue(true);
         const dbToStorageMock = vi.fn().mockResolvedValue(true);

--- a/src/serviceModules/ServiceFileHandlerBase.ts
+++ b/src/serviceModules/ServiceFileHandlerBase.ts
@@ -178,8 +178,27 @@ export abstract class ServiceFileHandlerBase
     async deleteFileFromDB(info: UXFileInfoStub | UXInternalFileInfoStub | FilePath): Promise<boolean> {
         const file = await this.infoToStub(info);
         if (file == null) {
-            this._log(`File ${tryGetFilePath(info)} is not exist on the storage`, LOG_LEVEL_VERBOSE);
-            return false;
+            // infoToStub -> getFileStub stats the storage, but in the offline-scanner
+            // `delete-db` path the file is by definition already gone from storage, so the
+            // stub is always null and the delete silently no-ops (returns false). No
+            // tombstone ever reaches the database and the next scan resurrects the file.
+            // Fall back to a path-based database delete, the same approach the CLI `rm`
+            // command uses (databaseFileAccess.delete accepts a bare path).
+            const path = typeof info === "string" ? info : tryGetFilePath(info);
+            if (path === undefined) {
+                this._log(`File ${tryGetFilePath(info)} is not exist on the storage`, LOG_LEVEL_VERBOSE);
+                return false;
+            }
+            const entryByPath = await this.db.fetchEntry(path as FilePathWithPrefix, undefined, true, true);
+            if (!entryByPath || entryByPath.deleted || entryByPath._deleted) {
+                this._log(
+                    `File ${path} is not exist on the storage nor the database (or already deleted)`,
+                    LOG_LEVEL_VERBOSE
+                );
+                return false;
+            }
+            this._log(`File ${path} is missing on storage; deleting from the database by path`, LOG_LEVEL_INFO);
+            return await this.db.delete(path as FilePathWithPrefix);
         }
         // const file = item.args.file;
         if (file.isInternal) {


### PR DESCRIPTION
## What
In the offline-scanner `delete-db` path, a file that has already been removed from storage is never tombstoned in the database, so the next scan resurrects it. With headless / CLI synchronisation this shows up as deletions silently reappearing and zero tombstones ever being written (in one reproduction, a delete cycle logged `doc_del_count=0` while the daemon emitted dozens of `DELETE DATABASE` lines — the deletes were attempted but never persisted).

## Why
`ServiceFileHandlerBase.deleteFileFromDB()` calls `infoToStub()` first, which stats storage to build the stub. In the `delete-db` branch the file is by definition already gone from storage, so the stub is always `null` and the method returns `false` without touching the database. Worse, `offlineScanner` ignored that return value and cleared the file's last-seen entry from the status map regardless. On the following scan the document looks database-only with no last-seen record, is classified as `update-storage`, and the deleted file is written back from the database.

## Fix (two small, independent parts)
1. **`deleteFileFromDB`:** when the storage stub is `null`, fall back to a path-based database delete — fetch the entry by path and, if it exists and is not already deleted, delete it by path. This mirrors what the CLI `rm` command already does. It still returns `false` when there is genuinely nothing to delete.
2. **`offlineScanner`:** only clear the `fileStatusMap` last-seen record when the database delete actually succeeded. If it returns `false`, keep the record and log a notice, so a no-op delete can never feed the resurrection path.

Net effect: a real tombstone reaches the database and the file stays deleted across scans.

## Tests
- `npm run tsc-check` and `npm run test:unit` pass (one unrelated, pre-existing `bgWorker` env failure aside).
- Added a focused unit test for the `delete-db` false-return path: the last-seen record is retained, a notice is logged, and the file is not resurrected.
- Manual repro: create + sync a file; delete it from storage; run the offline scanner twice. Pre-fix the file reappears and no tombstone is written; post-fix the first scan deletes by path, the DB entry is tombstoned, and the second scan does not resurrect it. Storage-present deletes (non-null stub) are unchanged.
