### PR TITLE
Make Fast Fetch resume from persisted CouchDB sequence

### DIFF
--- a/src/pouchdb/StreamingFetch.ts
+++ b/src/pouchdb/StreamingFetch.ts
@@ -19,12 +19,16 @@ interface AnyDecryptedDoc {
     _id: string;
 }
 
+type DBSequence = number | string;
+
 function generatePouchDBWriteStream(
     downloadToDB: PouchDB.Database,
-    decryptFunction: (doc: EntryDoc) => Promise<AnyEntry | EntryLeaf>
+    decryptFunction: (doc: EntryDoc) => Promise<AnyEntry | EntryLeaf>,
+    onCheckpoint?: (sequence: DBSequence) => void | Promise<void>
 ) {
     let batchBuffer: AnyDecryptedDoc[] = [];
     let currentBatchSizeBytes = 0;
+    let batchLastSequence: DBSequence | undefined;
 
     const BATCH_ITEM_LIMIT = 100;
     const BATCH_SIZE_LIMIT = 2 * 1024 * 1024; // 2MB
@@ -40,6 +44,9 @@ function generatePouchDBWriteStream(
         try {
             flushPromise = downloadToDB.bulkDocs(batchBuffer, { new_edits: false });
             await flushPromise;
+            if (batchLastSequence !== undefined) {
+                await onCheckpoint?.(batchLastSequence);
+            }
         } catch (error) {
             Logger("Error bulk writing to PouchDB:", LOG_LEVEL_VERBOSE);
             Logger(error, LOG_LEVEL_VERBOSE);
@@ -48,18 +55,20 @@ function generatePouchDBWriteStream(
             // Clear the batch buffer and reset the size counter regardless of success or failure to avoid blocking the stream.
             batchBuffer = [];
             currentBatchSizeBytes = 0;
+            batchLastSequence = undefined;
             flushPromise = null;
         }
     };
-    return new WritableStream<EntryDoc>({
+    return new WritableStream<{ doc: EntryDoc; seq: DBSequence }>({
         async write(chunk) {
             try {
                 // 1. Decrypt the document
-                const decryptedDoc = await decryptFunction(chunk);
+                const decryptedDoc = await decryptFunction(chunk.doc);
 
                 // 2. Buffer the decrypted document
                 batchBuffer.push(decryptedDoc);
                 currentBatchSizeBytes += JSON.stringify(decryptedDoc).length;
+                batchLastSequence = chunk.seq;
 
                 // 3. Flush the batch if limits are exceeded
                 if (batchBuffer.length >= BATCH_ITEM_LIMIT || currentBatchSizeBytes >= BATCH_SIZE_LIMIT) {
@@ -98,10 +107,6 @@ export type FetchChangesForInitialSyncProgress = {
     totalBytes: number; // Total bytes fetched so far.
 };
 
-/**
- * Type of the sequence ID used by CouchDB, which can be a number or a string depending on the database configuration and version.
- */
-type DBSequence = number | string;
 type DatabaseSyncStatus = {
     update_seq?: DBSequence;
     last_seq?: DBSequence;
@@ -136,7 +141,8 @@ export async function fetchChangesForInitialSync(
     authHeader: string,
     decryptFunction: (doc: EntryDoc) => Promise<AnyEntry | EntryLeaf>,
     since: number | string = "0",
-    onProgress?: (progress: FetchChangesForInitialSyncProgress) => void
+    onProgress?: (progress: FetchChangesForInitialSyncProgress) => void,
+    onCheckpoint?: (sequence: DBSequence) => void | Promise<void>
 ): Promise<void> {
     let totalFetched = 0;
     let totalValidFetched = 0;
@@ -240,7 +246,7 @@ export async function fetchChangesForInitialSync(
     });
     // Convert the byte stream into a text stream.
     const reader = response.body.pipeThrough(sizeCaptureStream).pipeThrough(new TextDecoderStream()).getReader();
-    const writeDocStream = generatePouchDBWriteStream(downloadToDB, decryptFunction);
+    const writeDocStream = generatePouchDBWriteStream(downloadToDB, decryptFunction, onCheckpoint);
     const writer = writeDocStream.getWriter();
     let buffer = "";
     let lastProgress = 0;
@@ -279,8 +285,10 @@ export async function fetchChangesForInitialSync(
                         totalFetched++;
                         const parsed = JSON.parse(buffer) as CouchChangeLine;
                         if (parsed.doc) {
-                            await writer.write(parsed.doc);
+                            await writer.write({ doc: parsed.doc, seq: parsed.seq });
                             totalValidFetched++;
+                        } else {
+                            await onCheckpoint?.(parsed.seq);
                         }
                         reportProgress();
                     } catch (e) {
@@ -306,8 +314,10 @@ export async function fetchChangesForInitialSync(
                     // Add to the batch only when a document body exists.
                     totalFetched++;
                     if (parsed.doc) {
-                        await writer.write(parsed.doc);
+                        await writer.write({ doc: parsed.doc, seq: parsed.seq });
                         totalValidFetched++;
+                    } else {
+                        await onCheckpoint?.(parsed.seq);
                     }
                     reportProgress();
                     if (totalFetched >= docsToFetch || reachedTargetSequence(parsed.seq, finalTargetSeq)) {

--- a/src/pouchdb/StreamingFetch.unit.spec.ts
+++ b/src/pouchdb/StreamingFetch.unit.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import PouchDB from 'pouchdb-core';
+import MemoryAdapter from 'pouchdb-adapter-memory';
+import { fetchChangesForInitialSync } from './StreamingFetch';
+
+PouchDB.plugin(MemoryAdapter);
+
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@lib/common/coreEnvFunctions', () => ({
+  _fetch: fetchMock,
+}));
+
+function textStream(lines: string[]) {
+  return new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      controller.enqueue(encoder.encode(lines.join('\n') + '\n'));
+      controller.close();
+    },
+  });
+}
+
+describe('fetchChangesForInitialSync', () => {
+  it('reports the last persisted sequence for resumable fast fetch', async () => {
+    const localDB = new PouchDB('streaming-fetch-checkpoint', {
+      adapter: 'memory',
+    });
+    const checkpointSequences: Array<string | number> = [];
+
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ update_seq: 2 })))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ pending: 1, last_seq: 1 }))
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          textStream([
+            JSON.stringify({
+              seq: 1,
+              id: 'doc1',
+              changes: [{ rev: '1-a' }],
+              doc: { _id: 'doc1', _rev: '1-a', value: 'one' },
+            }),
+            JSON.stringify({
+              seq: 2,
+              id: 'doc2',
+              changes: [{ rev: '1-b' }],
+              doc: { _id: 'doc2', _rev: '1-b', value: 'two' },
+            }),
+          ])
+        )
+      );
+
+    await fetchChangesForInitialSync(
+      localDB,
+      'https://example.com/db',
+      'Basic test',
+      (doc) => Promise.resolve(doc as any),
+      '0',
+      undefined,
+      (sequence) => {
+        checkpointSequences.push(sequence);
+      }
+    );
+
+    expect(checkpointSequences[checkpointSequences.length - 1]).toBe(2);
+    await expect(localDB.get('doc2')).resolves.toMatchObject({ value: 'two' });
+
+    await localDB.destroy();
+  });
+});

--- a/src/serviceModules/Rebuilder.ts
+++ b/src/serviceModules/Rebuilder.ts
@@ -25,6 +25,13 @@ import { getConfiguredFunctionsForEncryption } from "@lib/pouchdb/encryption";
 import { AuthorizationHeaderGenerator, generateCredentialObject } from "@lib/replication/httplib";
 import { sizeToHumanReadable } from "octagonal-wheels/number";
 
+const FAST_FETCH_CHECKPOINT_KEY = "fast-fetch-checkpoint";
+
+type FastFetchCheckpoint = {
+    remote: string;
+    sequence: number | string;
+};
+
 export interface ServiceRebuilderDependencies {
     appLifecycle: AppLifecycleService;
     API: APIService;
@@ -334,17 +341,47 @@ Are you sure you wish to proceed?`;
             return;
         }
 
+        const remote =
+            settings.couchDB_URI.replace(/\/+$/, "") +
+            (settings.couchDB_DBNAME == "" ? "" : "/" + settings.couchDB_DBNAME);
+        const checkpoint = this.getFastFetchCheckpoint(remote);
+
         await this.suspendReflectingDatabase();
         await this.control.applySettings();
-        await this.resetLocalDatabase();
-        await delay(1000);
+        let since = checkpoint?.sequence ?? "0";
+        if (checkpoint) {
+            this._log(
+                `Resuming fast database fetch from sequence: ${checkpoint.sequence}`,
+                LOG_LEVEL_NOTICE,
+                "fetch-init-resume"
+            );
+        } else {
+            await this.resetLocalDatabase();
+            await delay(1000);
+        }
         await this.database.openDatabase({
             databaseEvents: this.databaseEvents,
             replicator: this.replicator,
         });
         this.appLifecycle.markIsReady();
 
-        const localDB = this.database.localDatabase.localDatabase;
+        let localDB = this.database.localDatabase.localDatabase;
+        if (checkpoint && (await localDB.info()).doc_count == 0) {
+            this._log(
+                "Fast fetch checkpoint found, but the local database is empty. Starting from the beginning.",
+                LOG_LEVEL_NOTICE,
+                "fetch-init-resume"
+            );
+            this.clearFastFetchCheckpoint();
+            await this.resetLocalDatabase();
+            await delay(1000);
+            await this.database.openDatabase({
+                databaseEvents: this.databaseEvents,
+                replicator: this.replicator,
+            });
+            localDB = this.database.localDatabase.localDatabase;
+            since = "0";
+        }
         const replicator = this.replicator.getActiveReplicator() ?? (await this.replicator.getNewReplicator());
         if (!replicator) {
             throw new Error("No active replicator found for fast fetch.");
@@ -361,17 +398,22 @@ Are you sure you wish to proceed?`;
         const authHeader = await new AuthorizationHeaderGenerator().getAuthorizationHeader(
             generateCredentialObject(settings)
         );
-        const remote =
-            settings.couchDB_URI.replace(/\/+$/, "") +
-            (settings.couchDB_DBNAME == "" ? "" : "/" + settings.couchDB_DBNAME);
 
-        await fetchChangesForInitialSync(localDB, remote, authHeader, enc.outgoing, "0", (progress) => {
-            this._log(
-                `Fast fetch progress: ${progress.totalValidFetched} / ${progress.docsToFetch}\nTotal bytes fetched: ${sizeToHumanReadable(progress.totalBytes)}`,
-                LOG_LEVEL_NOTICE,
-                "fetch-init-progress"
-            );
-        });
+        await fetchChangesForInitialSync(
+            localDB,
+            remote,
+            authHeader,
+            enc.outgoing,
+            since,
+            (progress) => {
+                this._log(
+                    `Fast fetch progress: ${progress.totalValidFetched} / ${progress.docsToFetch}\nTotal bytes fetched: ${sizeToHumanReadable(progress.totalBytes)}`,
+                    LOG_LEVEL_NOTICE,
+                    "fetch-init-progress"
+                );
+            },
+            (sequence) => this.saveFastFetchCheckpoint(remote, sequence)
+        );
 
         const allDocs = await localDB.allDocs({ include_docs: false });
         this._log(
@@ -384,6 +426,7 @@ Are you sure you wish to proceed?`;
         if (autoResume) {
             await this.resumeReflectingDatabase(true);
         }
+        this.clearFastFetchCheckpoint();
     }
 
     /**
@@ -420,5 +463,32 @@ Are you sure you wish to proceed?`;
         await this.setting.applyPartial({ additionalSuffixOfDatabaseName: suffix });
         await this.database.resetDatabase();
         eventHub.emitEvent(EVENT_DATABASE_REBUILT);
+    }
+
+    private getFastFetchCheckpoint(remote: string): FastFetchCheckpoint | undefined {
+        const rawCheckpoint = this.setting.getSmallConfig(FAST_FETCH_CHECKPOINT_KEY);
+        if (!rawCheckpoint) return undefined;
+
+        try {
+            const checkpoint = JSON.parse(rawCheckpoint) as Partial<FastFetchCheckpoint>;
+            if (checkpoint.remote === remote && checkpoint.sequence !== undefined) {
+                return {
+                    remote,
+                    sequence: checkpoint.sequence,
+                };
+            }
+        } catch {
+            // Ignore invalid checkpoints and start cleanly.
+        }
+        this.clearFastFetchCheckpoint();
+        return undefined;
+    }
+
+    private saveFastFetchCheckpoint(remote: string, sequence: number | string) {
+        this.setting.setSmallConfig(FAST_FETCH_CHECKPOINT_KEY, JSON.stringify({ remote, sequence }));
+    }
+
+    private clearFastFetchCheckpoint() {
+        this.setting.deleteSmallConfig(FAST_FETCH_CHECKPOINT_KEY);
     }
 }


### PR DESCRIPTION
## Summary

Make Fast Fetch resumable after interruptions by persisting the last successfully written CouchDB sequence.

## Changes

- Add an optional checkpoint callback to `fetchChangesForInitialSync`.
- Report the last sequence only after a batch has been successfully written to local PouchDB.
- Store Fast Fetch checkpoint state in local small config.
- Resume from the checkpoint when the same remote is fetched again and the local database still contains data.
- Clear stale/invalid checkpoints and fall back to a clean fetch when the local database is empty.
- Add a unit test for checkpoint reporting after persisted writes.

## Context

Refs vrtmrz/obsidian-livesync#972.

## Verification

- `npm test -- --config vitest.config.unit.ts src/lib/src/pouchdb/StreamingFetch.unit.spec.ts`
- `npm run tsc-check`
- `npx eslint src/lib/src/pouchdb/StreamingFetch.ts src/lib/src/serviceModules/Rebuilder.ts`
- `npm run build`
