### PR TITLE
Make Fast Fetch retry transient interruptions

### DIFF
--- a/src/pouchdb/StreamingFetch.ts
+++ b/src/pouchdb/StreamingFetch.ts
@@ -252,6 +252,7 @@ export async function fetchChangesForInitialSync(
     let lastProgress = 0;
     let lastReportTime = Date.now();
     let totalBytes = 0;
+    let abortedAfterTargetReached = false;
     const reportProgress = () => {
         if (totalFetched - lastProgress < 25) {
             // Report progress for every 25 changes fetched to avoid excessive updates.
@@ -328,6 +329,7 @@ export async function fetchChangesForInitialSync(
                         // Write any remaining documents to PouchDB before exiting.
                         await writer.close(); // Close the writer to ensure all documents are flushed to PouchDB.
                         // Abort the fetch request to stop receiving more data.
+                        abortedAfterTargetReached = true;
                         controller.abort();
                         reportProgress();
                         return; // Exit the function gracefully.
@@ -343,7 +345,7 @@ export async function fetchChangesForInitialSync(
         Logger("Initial data synchronisation via stream has completed.");
         reportProgress();
     } catch (error) {
-        if (error instanceof DOMException && error.name === "AbortError") {
+        if (abortedAfterTargetReached && error instanceof DOMException && error.name === "AbortError") {
             Logger(
                 "Stream has been aborted as the target sequence has been reached. Finalising the synchronising process..."
             );

--- a/src/pouchdb/StreamingFetch.unit.spec.ts
+++ b/src/pouchdb/StreamingFetch.unit.spec.ts
@@ -21,6 +21,14 @@ function textStream(lines: string[]) {
     });
 }
 
+function failingStream(error: Error) {
+    return new ReadableStream({
+        start(controller) {
+            controller.error(error);
+        },
+    });
+}
+
 describe("fetchChangesForInitialSync", () => {
     it("reports the last persisted sequence for resumable fast fetch", async () => {
         const localDB = new PouchDB("streaming-fetch-checkpoint", {
@@ -64,6 +72,29 @@ describe("fetchChangesForInitialSync", () => {
 
         expect(checkpointSequences[checkpointSequences.length - 1]).toBe(2);
         await expect(localDB.get("doc2")).resolves.toMatchObject({ value: "two" });
+
+        await localDB.destroy();
+    });
+
+    it("does not treat an external AbortError as successful completion", async () => {
+        const localDB = new PouchDB("streaming-fetch-external-abort", {
+            adapter: "memory",
+        });
+
+        fetchMock
+            .mockResolvedValueOnce(new Response(JSON.stringify({ update_seq: 2 })))
+            .mockResolvedValueOnce(new Response(JSON.stringify({ pending: 1, last_seq: 1 })))
+            .mockResolvedValueOnce(new Response(failingStream(new DOMException("network changed", "AbortError"))));
+
+        await expect(
+            fetchChangesForInitialSync(
+                localDB,
+                "https://example.com/db",
+                "Basic test",
+                (doc) => Promise.resolve(doc as any),
+                "0"
+            )
+        ).rejects.toMatchObject({ name: "AbortError" });
 
         await localDB.destroy();
     });

--- a/src/serviceModules/Rebuilder.ts
+++ b/src/serviceModules/Rebuilder.ts
@@ -26,6 +26,7 @@ import { AuthorizationHeaderGenerator, generateCredentialObject } from "@lib/rep
 import { sizeToHumanReadable } from "octagonal-wheels/number";
 
 const FAST_FETCH_CHECKPOINT_KEY = "fast-fetch-checkpoint";
+const FAST_FETCH_RETRY_DELAYS = [2000, 5000, 10000, 20000];
 
 type FastFetchCheckpoint = {
     remote: string;
@@ -344,7 +345,7 @@ Are you sure you wish to proceed?`;
         const remote =
             settings.couchDB_URI.replace(/\/+$/, "") +
             (settings.couchDB_DBNAME == "" ? "" : "/" + settings.couchDB_DBNAME);
-        const checkpoint = this.getFastFetchCheckpoint(remote);
+        let checkpoint = this.getFastFetchCheckpoint(remote);
 
         await this.suspendReflectingDatabase();
         await this.control.applySettings();
@@ -399,21 +400,36 @@ Are you sure you wish to proceed?`;
             generateCredentialObject(settings)
         );
 
-        await fetchChangesForInitialSync(
-            localDB,
-            remote,
-            authHeader,
-            enc.outgoing,
-            since,
-            (progress) => {
-                this._log(
-                    `Fast fetch progress: ${progress.totalValidFetched} / ${progress.docsToFetch}\nTotal bytes fetched: ${sizeToHumanReadable(progress.totalBytes)}`,
-                    LOG_LEVEL_NOTICE,
-                    "fetch-init-progress"
+        for (let attempt = 0; ; attempt++) {
+            try {
+                await fetchChangesForInitialSync(
+                    localDB,
+                    remote,
+                    authHeader,
+                    enc.outgoing,
+                    since,
+                    (progress) => {
+                        this._log(
+                            `Fast fetch progress: ${progress.totalValidFetched} / ${progress.docsToFetch}\nTotal bytes fetched: ${sizeToHumanReadable(progress.totalBytes)}`,
+                            LOG_LEVEL_NOTICE,
+                            "fetch-init-progress"
+                        );
+                    },
+                    (sequence) => this.saveFastFetchCheckpoint(remote, sequence)
                 );
-            },
-            (sequence) => this.saveFastFetchCheckpoint(remote, sequence)
-        );
+                break;
+            } catch (ex) {
+                if (attempt >= FAST_FETCH_RETRY_DELAYS.length) throw ex;
+                checkpoint = this.getFastFetchCheckpoint(remote);
+                since = checkpoint?.sequence ?? since;
+                this._log(
+                    `Fast fetch interrupted. Retrying from sequence: ${since}`,
+                    LOG_LEVEL_NOTICE,
+                    "fetch-init-resume"
+                );
+                await delay(FAST_FETCH_RETRY_DELAYS[attempt]);
+            }
+        }
 
         const allDocs = await localDB.allDocs({ include_docs: false });
         this._log(

--- a/src/serviceModules/Rebuilder.unit.spec.ts
+++ b/src/serviceModules/Rebuilder.unit.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { REMOTE_COUCHDB } from "@lib/common/models/setting.const";
+import { ServiceRebuilder } from "./Rebuilder";
+
+const fetchChangesForInitialSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@lib/pouchdb/StreamingFetch", () => ({
+    fetchChangesForInitialSync: fetchChangesForInitialSyncMock,
+}));
+
+vi.mock("octagonal-wheels/promises", async (importOriginal) => {
+    const original = (await importOriginal()) as Record<string, unknown>;
+    return {
+        ...original,
+        delay: vi.fn(async () => undefined),
+    };
+});
+
+function createRebuilder() {
+    const smallConfig = new Map<string, string>();
+    const settings = {
+        isConfigured: true,
+        additionalSuffixOfDatabaseName: "",
+        remoteType: REMOTE_COUCHDB,
+        couchDB_URI: "https://example.com",
+        couchDB_DBNAME: "db",
+        couchDB_USER: "user",
+        couchDB_PASSWORD: "pass",
+        useJWT: false,
+        passphrase: "",
+        E2EEAlgorithm: "",
+        doNotSuspendOnFetching: false,
+    } as any;
+    const localDB = {
+        info: vi.fn(async () => ({ doc_count: 1 })),
+        allDocs: vi.fn(async () => ({ total_rows: 1 })),
+    };
+    const services = {
+        API: {
+            addLog: vi.fn(),
+            getAppID: vi.fn(() => "app"),
+        },
+        setting: {
+            currentSettings: vi.fn(() => settings),
+            suspendExtraSync: vi.fn(async () => undefined),
+            suspendAllSync: { addHandler: vi.fn() },
+            applyPartial: vi.fn(async (partial: any) => {
+                Object.assign(settings, partial);
+            }),
+            saveSettingData: vi.fn(async () => undefined),
+            getSmallConfig: vi.fn(
+                (key: string) => smallConfig.get(`${settings.additionalSuffixOfDatabaseName}-${key}`) ?? ""
+            ),
+            setSmallConfig: vi.fn((key: string, value: string) => {
+                smallConfig.set(`${settings.additionalSuffixOfDatabaseName}-${key}`, value);
+            }),
+            deleteSmallConfig: vi.fn((key: string) => {
+                smallConfig.delete(`${settings.additionalSuffixOfDatabaseName}-${key}`);
+            }),
+        },
+        control: {
+            applySettings: vi.fn(async () => undefined),
+        },
+        database: {
+            onDatabaseReset: { addHandler: vi.fn() },
+            resetDatabase: vi.fn(async () => undefined),
+            openDatabase: vi.fn(async () => undefined),
+            localDatabase: { localDatabase: localDB },
+        },
+        databaseEvents: {},
+        replicator: {
+            getActiveReplicator: vi.fn(() => ({
+                getReplicationPBKDF2Salt: vi.fn(async () => "salt"),
+            })),
+            getNewReplicator: vi.fn(),
+        },
+        replication: {
+            markResolved: vi.fn(async () => undefined),
+        },
+        appLifecycle: {
+            markIsReady: vi.fn(),
+        },
+        UI: {},
+        remote: {},
+        storageAccess: {
+            clearTouched: vi.fn(),
+        },
+        vault: {
+            scanVault: vi.fn(async () => undefined),
+        },
+        fileHandler: {},
+    };
+
+    return { rebuilder: new ServiceRebuilder(services as any), services };
+}
+
+describe("ServiceRebuilder fast fetch retry", () => {
+    it("retries from the latest checkpoint after a transient fast fetch failure", async () => {
+        const { rebuilder } = createRebuilder();
+
+        fetchChangesForInitialSyncMock
+            .mockImplementationOnce(async (...args: any[]) => {
+                await args[6]("10-g1");
+                throw new Error("network changed");
+            })
+            .mockResolvedValueOnce(undefined);
+
+        await rebuilder.$fetchLocalDBFast(false);
+
+        expect(fetchChangesForInitialSyncMock).toHaveBeenCalledTimes(2);
+        expect(fetchChangesForInitialSyncMock.mock.calls[0][4]).toBe("0");
+        expect(fetchChangesForInitialSyncMock.mock.calls[1][4]).toBe("10-g1");
+    });
+});


### PR DESCRIPTION
## Summary

Make Fast Fetch retry transient streaming interruptions from the latest persisted checkpoint.

## Context

Follow-up issue: https://github.com/vrtmrz/obsidian-livesync/issues/977

## Changes

- Retry Fast Fetch failures up to 4 times with 2s, 5s, 10s, and 20s delays.
- Re-read the latest Fast Fetch checkpoint before each retry and continue from that sequence.
- Treat only the plug-in's own target-sequence abort as successful completion.
- Propagate external `AbortError`s so the retry layer can handle transient network or platform interruptions.

## Verification

Ran from the top-level plug-in repository:

- `npm test -- --config vitest.config.unit.ts src/serviceFeatures/redFlag.unit.spec.ts src/lib/src/pouchdb/StreamingFetch.unit.spec.ts src/lib/src/serviceModules/Rebuilder.unit.spec.ts`
- `npm run tsc-check`
- `npx eslint --no-warn-ignored src/serviceFeatures/redFlag.simpleFetch.ts src/serviceFeatures/redFlag.unit.spec.ts src/lib/src/pouchdb/StreamingFetch.ts src/lib/src/pouchdb/StreamingFetch.unit.spec.ts src/lib/src/serviceModules/Rebuilder.ts src/lib/src/serviceModules/Rebuilder.unit.spec.ts`
- `npm run build`