### PR TITLE
Skip hidden file events before target filtering

### DIFF
--- a/src/managers/StorageEventManager.ts
+++ b/src/managers/StorageEventManager.ts
@@ -161,6 +161,9 @@ export abstract class StorageEventManagerBase<
             if (shouldBeIgnored(param.file.path)) {
                 continue;
             }
+            if (!settings.syncInternalFiles && param.file.path.startsWith(".")) {
+                continue;
+            }
             const atomicKey = [0, 0, 0, 0, 0, 0].map((e) => `${Math.floor(Math.random() * 100000)}`).join("-");
             const type = param.type;
             const file = param.file;

--- a/src/managers/StorageEventManager.unit.spec.ts
+++ b/src/managers/StorageEventManager.unit.spec.ts
@@ -645,6 +645,15 @@ describe("StorageEventManagerBase", () => {
             expect(enqueueSpy).not.toHaveBeenCalled();
         });
 
+        it("should skip hidden files before target filtering when internal file sync is disabled", async () => {
+            const enqueueSpy = vi.spyOn(manager, "enqueue");
+            const file = createMockFile(".git/objects/aa/example", "example");
+            await manager.testAppendQueue([{ type: "CREATE", file: adapter.converter.toFileInfo(file) }]);
+
+            expect(dependencies.vaultService.isTargetFile).not.toHaveBeenCalled();
+            expect(enqueueSpy).not.toHaveBeenCalled();
+        });
+
         it("should skip recently touched files on CREATE", async () => {
             vi.mocked(dependencies.storageAccessManager.recentlyTouched).mockReturnValue(true);
             const enqueueSpy = vi.spyOn(manager, "enqueue");


### PR DESCRIPTION
## Summary

- skip dot-prefixed storage events before the normal target-file filter when internal file synchronisation is disabled
- add a regression test that verifies hidden files do not call `vaultService.isTargetFile`

## Why

When `syncInternalFiles` is disabled, hidden paths are already non-targets. However, storage events for paths such as `.git/objects/...` still reached later target filtering, which could emit noisy database-backed "not target" logs before being skipped.

## Verification

- `vitest run src/lib/src/managers/StorageEventManager.unit.spec.ts --config vitest.config.unit.ts` (red before fix, green after fix)
- `npm run test:unit`
- `npx tsc --noEmit`
- `npx eslint src/lib/src/managers/StorageEventManager.ts src/lib/src/managers/StorageEventManager.unit.spec.ts` (source file checked; the spec file is ignored by the repository ESLint config and reports a warning only)

`npm run check` did not complete in my local environment because `generate-types.mjs` calls `Deno`, and that command is not installed here. Please run CI tests.
