### PR TITLE
Fix conflict issues

### DIFF
--- a/src/managers/ConflictManager.ts
+++ b/src/managers/ConflictManager.ts
@@ -158,33 +158,36 @@ export class ConflictManager {
             const rightItem = diffRight[rightIdx] ?? [0, ""];
             leftIdx++;
             rightIdx++;
-            // when completely same, leave it .
+            // Same unchanged line on both sides: keep it once.
             if (leftItem[0] == DIFF_EQUAL && rightItem[0] == DIFF_EQUAL && leftItem[1] == rightItem[1]) {
                 merged.push(leftItem);
                 continue;
             }
             if (leftItem[0] == DIFF_DELETE && rightItem[0] == DIFF_DELETE && leftItem[1] == rightItem[1]) {
-                // when deleted evenly,
+                // Same deletion on both sides is safe. If only one side immediately inserts a replacement,
+                // this is a delete-vs-edit overlap and must remain a manual conflict.
                 const nextLeftIdx = leftIdx;
                 const nextRightIdx = rightIdx;
                 const [nextLeftItem, nextRightItem] = [
                     diffLeft[nextLeftIdx] ?? [0, ""],
                     diffRight[nextRightIdx] ?? [0, ""],
                 ];
-                if (
-                    nextLeftItem[0] == DIFF_INSERT &&
-                    nextRightItem[0] == DIFF_INSERT &&
-                    nextLeftItem[1] != nextRightItem[1]
-                ) {
-                    //but next line looks like different
+                const nextLeftIsInsert = nextLeftItem[0] == DIFF_INSERT;
+                const nextRightIsInsert = nextRightItem[0] == DIFF_INSERT;
+                if (nextLeftIsInsert != nextRightIsInsert) {
                     autoMerge = false;
                     break;
-                } else {
-                    merged.push(leftItem);
-                    continue;
                 }
+                if (nextLeftIsInsert && nextRightIsInsert && nextLeftItem[1] != nextRightItem[1]) {
+                    // Both sides replaced the same deleted line differently.
+                    autoMerge = false;
+                    break;
+                }
+                merged.push(leftItem);
+                continue;
             }
-            // when inserted evenly
+            // Insertions are additive. If both sides inserted different content at the same
+            // position, keep both in a deterministic mtime order.
             if (leftItem[0] == DIFF_INSERT && rightItem[0] == DIFF_INSERT) {
                 if (leftItem[1] == rightItem[1]) {
                     merged.push(leftItem);
@@ -202,7 +205,7 @@ export class ConflictManager {
                     }
                 }
             }
-            // when on inserting, index should be fixed again.
+            // A one-sided insertion does not consume the other side's current line.
             if (leftItem[0] == DIFF_INSERT) {
                 rightIdx--;
                 merged.push(leftItem);
@@ -213,7 +216,8 @@ export class ConflictManager {
                 merged.push(rightItem);
                 continue;
             }
-            // except insertion, the line should not be different.
+            // Apart from insertions, mismatched line contents mean the regions are no
+            // longer aligned enough for a safe automatic merge.
             if (rightItem[1] != leftItem[1]) {
                 //TODO: SHOULD BE PANIC.
                 Logger(
@@ -225,13 +229,10 @@ export class ConflictManager {
             }
             if (leftItem[0] == DIFF_DELETE) {
                 if (rightItem[0] == DIFF_EQUAL) {
-                    if ((diffLeft[leftIdx] ?? [0, ""])[0] == DIFF_INSERT) {
-                        merged.push(leftItem);
-                        continue;
-                    } else {
-                        autoMerge = false;
-                        break LOOP_MERGE;
-                    }
+                    // One side deleted a line the other side left unchanged. Prefer the
+                    // deletion; final content generation drops DIFF_DELETE entries.
+                    merged.push(leftItem);
+                    continue;
                 } else {
                     //we cannot perform auto merge.
                     autoMerge = false;
@@ -240,13 +241,9 @@ export class ConflictManager {
             }
             if (rightItem[0] == DIFF_DELETE) {
                 if (leftItem[0] == DIFF_EQUAL) {
-                    if ((diffRight[rightIdx] ?? [0, ""])[0] == DIFF_INSERT) {
-                        merged.push(rightItem);
-                        continue;
-                    } else {
-                        autoMerge = false;
-                        break LOOP_MERGE;
-                    }
+                    // Symmetric safe deletion.
+                    merged.push(rightItem);
+                    continue;
                 } else {
                     //we cannot perform auto merge.
                     autoMerge = false;

--- a/src/managers/ConflictManager.unit.spec.ts
+++ b/src/managers/ConflictManager.unit.spec.ts
@@ -347,7 +347,7 @@ describe("ConflictManager", () => {
             expect(result).toBe(false);
         });
 
-        it("should return false when only one side deletes a line", async () => {
+        it("should merge when one side deletes a line and the other changes a different line", async () => {
             const path = "test-doc" as FilePathWithPrefix;
             const baseData = "line1\nline2\nline3\n";
             const leftData = "line1\nline3\n";
@@ -371,10 +371,42 @@ describe("ConflictManager", () => {
 
             const result = await conflictManager.mergeSensibly(path, baseResult.rev, currentDoc._rev, conflictedRev);
 
+            expect(result).not.toBe(false);
+            if (result === false) return;
+            const mergedText = result
+                .filter((e) => e[0] !== -1)
+                .map((e) => e[1])
+                .join("");
+            expect(mergedText).toBe("line1\nline3 modified right\n");
+        });
+
+        it("should return false when one side deletes a line and the other changes the same line", async () => {
+            const path = "test-doc" as FilePathWithPrefix;
+            const baseData = "line1\nline2\nline3\n";
+            const leftData = "line1\nline3\n";
+            const rightData = "line1\nline2 modified right\nline3\n";
+
+            const baseDoc = createTestDoc(path, baseData, 1000);
+            const baseResult = await db.put(baseDoc);
+
+            const leftDoc = { ...createTestDoc(path, leftData, 2000), _rev: baseResult.rev };
+            await db.put(leftDoc);
+
+            const rightDoc = {
+                ...createTestDoc(path, rightData, 2100),
+                _rev: baseResult.rev.split("-")[0] + "-conflict",
+            };
+            await db.put(rightDoc, { force: true } as any);
+
+            const currentDoc = await db.get(path, { conflicts: true });
+            const conflictedRev = currentDoc._conflicts?.[0] || "";
+
+            const result = await conflictManager.mergeSensibly(path, baseResult.rev, currentDoc._rev, conflictedRev);
+
             expect(result).toBe(false);
         });
 
-        it.fails("should not reintroduce an unchanged line deleted on the other side (#993)", async () => {
+        it("should not reintroduce an unchanged line deleted on the other side (#993)", async () => {
             const path = "issue-993.md" as FilePathWithPrefix;
             const baseData = "intro\nold content\nshared\n";
             const leftData = "intro\nshared\n";

--- a/src/managers/ConflictManager.unit.spec.ts
+++ b/src/managers/ConflictManager.unit.spec.ts
@@ -374,6 +374,37 @@ describe("ConflictManager", () => {
             expect(result).toBe(false);
         });
 
+        it.fails("should not reintroduce an unchanged line deleted on the other side (#993)", async () => {
+            const path = "issue-993.md" as FilePathWithPrefix;
+            const baseData = "intro\nold content\nshared\n";
+            const leftData = "intro\nshared\n";
+            const rightData = "intro\nold content\nshared\nnew mobile content\n";
+
+            const baseDoc = createTestDoc(path, baseData, 1000);
+            const baseResult = await db.put(baseDoc);
+
+            const leftDoc = { ...createTestDoc(path, leftData, 2000), _rev: baseResult.rev };
+            await db.put(leftDoc);
+
+            const rightDoc = {
+                ...createTestDoc(path, rightData, 2100),
+                _rev: baseResult.rev.split("-")[0] + "-conflict",
+            };
+            await db.put(rightDoc, { force: true } as any);
+
+            const currentDoc = await db.get(path, { conflicts: true });
+            const conflictedRev = currentDoc._conflicts?.[0] || "";
+            const result = await conflictManager.mergeSensibly(path, baseResult.rev, currentDoc._rev, conflictedRev);
+
+            expect(result).not.toBe(false);
+            if (result === false) return;
+            const mergedText = result
+                .filter((e) => e[0] !== -1)
+                .map((e) => e[1])
+                .join("");
+            expect(mergedText).toBe("intro\nshared\nnew mobile content\n");
+        });
+
         it("should merge when both sides delete the same line", async () => {
             const path = "test-doc" as FilePathWithPrefix;
             const baseData = "line1\nline2\nline3\n";

--- a/src/serviceModules/ServiceFileHandlerBase.ts
+++ b/src/serviceModules/ServiceFileHandlerBase.ts
@@ -26,7 +26,7 @@ import type { PathService } from "@lib/services/base/PathService.ts";
 import type { SettingService } from "@lib/services/base/SettingService.ts";
 import type { VaultService } from "@lib/services/base/VaultService.ts";
 import { getStoragePathFromUXFileInfo } from "@lib/common/typeUtils";
-import { EVEN } from "@lib/common/models/shared.const.symbols";
+import { BASE_IS_NEW, EVEN } from "@lib/common/models/shared.const.symbols";
 import { tryGetFilePath } from "@lib/common/utils.doc";
 
 export interface ServiceFileHandlerDependencies {
@@ -355,7 +355,8 @@ export abstract class ServiceFileHandlerBase
             // Note: This checks only the mtime with the resolution reduced to 2 seconds.
             //       2 seconds it for the ZIP file's mtime. If not, we cannot backup the vault as the ZIP file.
             //       This is hardcoded on `compareMtime` of `src/common/utils.ts`.
-            if (this.path.compareFileFreshness(existDoc, docEntry) !== EVEN) {
+            const freshness = this.path.compareFileFreshness(existDoc, docEntry);
+            if (freshness !== EVEN) {
                 shouldApplied = true;
             }
             // 2. if not, the content should be checked.
@@ -379,6 +380,7 @@ export abstract class ServiceFileHandlerBase
             if (
                 !force &&
                 !settings.writeDocumentsIfConflicted &&
+                freshness === BASE_IS_NEW &&
                 (await this.preserveUnsyncedStorageAsConflict(path, existDoc, docEntry, docData))
             ) {
                 return true;

--- a/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts
+++ b/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts
@@ -117,6 +117,23 @@ describe("ServiceFileHandlerBase.dbToStorage", () => {
         expect(storageAccess.writeFileAuto).not.toHaveBeenCalled();
     });
 
+    it.fails("applies a remote addition without conflict when local storage is an unmodified older copy (#994)", async () => {
+        const { handler, remoteMeta, storageStub, databaseFileAccess, storageAccess, conflict } = createHandler(
+            "existing synced content\n",
+            "existing synced content\nnew desktop paragraph\n",
+            false
+        );
+
+        await expect(handler.dbToStorage(remoteMeta, storageStub)).resolves.toBe(true);
+
+        expect(databaseFileAccess.storeAsConflictedRevision).not.toHaveBeenCalled();
+        expect(conflict.queueCheckFor).not.toHaveBeenCalled();
+        expect(storageAccess.writeFileAuto).toHaveBeenCalledWith("note.md", "existing synced content\nnew desktop paragraph\n", {
+            ctime: 1,
+            mtime: 2,
+        });
+    });
+
     it("applies the remote revision when local storage content is already in database history", async () => {
         const { handler, remoteMeta, storageStub, databaseFileAccess, storageAccess, conflict } = createHandler(
             "known old revision",

--- a/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts
+++ b/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { EVEN } from "@lib/common/models/shared.const.symbols";
+import { BASE_IS_NEW, EVEN, TARGET_IS_NEW } from "@lib/common/models/shared.const.symbols";
 import type { MetaEntry, UXFileInfo, UXFileInfoStub } from "@lib/common/types";
 import { createTextBlob } from "@lib/common/utils";
 import { ServiceFileHandlerBase, type ServiceFileHandlerDependencies } from "./ServiceFileHandlerBase";
@@ -39,7 +39,12 @@ function createStorageFile(path: string, body: string): UXFileInfo {
     } as UXFileInfo;
 }
 
-function createHandler(localBody: string, remoteBody: string, localContentIsKnown: boolean) {
+function createHandler(
+    localBody: string,
+    remoteBody: string,
+    localContentIsKnown: boolean,
+    freshness: typeof BASE_IS_NEW | typeof TARGET_IS_NEW | typeof EVEN = TARGET_IS_NEW
+) {
     const path = "note.md";
     const remoteMeta = createMeta(path, remoteBody);
     const remoteEntry = {
@@ -72,7 +77,7 @@ function createHandler(localBody: string, remoteBody: string, localContentIsKnow
     };
     const pathService = {
         getPath: vi.fn().mockImplementation((entry: MetaEntry) => entry.path),
-        compareFileFreshness: vi.fn().mockReturnValue(Symbol("target-is-new")),
+        compareFileFreshness: vi.fn().mockReturnValue(freshness),
         markChangesAreSame: vi.fn(),
     };
     const deps = {
@@ -103,7 +108,8 @@ describe("ServiceFileHandlerBase.dbToStorage", () => {
         const { handler, remoteMeta, storageStub, databaseFileAccess, storageAccess, conflict } = createHandler(
             "local unsynced",
             "remote update",
-            false
+            false,
+            BASE_IS_NEW
         );
 
         await expect(handler.dbToStorage(remoteMeta, storageStub)).resolves.toBe(true);
@@ -117,11 +123,12 @@ describe("ServiceFileHandlerBase.dbToStorage", () => {
         expect(storageAccess.writeFileAuto).not.toHaveBeenCalled();
     });
 
-    it.fails("applies a remote addition without conflict when local storage is an unmodified older copy (#994)", async () => {
+    it("applies a remote addition without conflict when local storage is an unmodified older copy (#994)", async () => {
         const { handler, remoteMeta, storageStub, databaseFileAccess, storageAccess, conflict } = createHandler(
             "existing synced content\n",
             "existing synced content\nnew desktop paragraph\n",
-            false
+            false,
+            TARGET_IS_NEW
         );
 
         await expect(handler.dbToStorage(remoteMeta, storageStub)).resolves.toBe(true);


### PR DESCRIPTION

- Improved Markdown conflict auto-merge so that non-overlapping edits are merged while overlapping delete-and-edit cases remain visible for manual resolution (#993).
  - Behaviour change:
    - When one side deletes an unchanged line and the other side edits a different region, the deleted line is no longer reintroduced into the merged result.
    - When one side deletes a line and the other side modifies that same line, the conflict is preserved instead of silently choosing one side.
- Fixed an issue where applying a newer database entry to storage could incorrectly preserve an older local file as a conflict (#994).
  - Behaviour change:
    - Local storage is preserved as a conflict only when it is actually newer than the incoming database entry and is not already represented in the revision history.
