### PR TITLE
Refactor storage adapter into focused capabilities

### DIFF
--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -41,6 +41,10 @@ jobs:
         working-directory: obsidian-livesync
         run: npm ci
 
+      - name: Run type checks
+        working-directory: obsidian-livesync
+        run: npm run tsc-check
+
       - name: Run unit tests
         working-directory: obsidian-livesync
         run: npm run test:unit

--- a/src/serviceModules/FileAccessBase.unit.spec.ts
+++ b/src/serviceModules/FileAccessBase.unit.spec.ts
@@ -6,6 +6,7 @@ import type {
     ITypeGuardAdapter,
     IConversionAdapter,
     IStorageAdapter,
+    IStorageBinaryReadAccess,
     IVaultAdapter,
 } from "./adapters";
 import type { FilePath, UXDataWriteOptions, UXFileInfoStub, UXFolderInfo, UXStat } from "@lib/common/types";
@@ -158,6 +159,20 @@ class MockStorageAdapter implements IStorageAdapter<MockStat> {
         return Promise.resolve({ files, folders });
     }
 }
+
+async function readBinaryLength(storage: IStorageBinaryReadAccess, path: string): Promise<number> {
+    return (await storage.readBinary(path)).byteLength;
+}
+
+describe("storage capabilities", () => {
+    it("accepts a binary-read-only consumer implementation", async () => {
+        const storage: IStorageBinaryReadAccess = {
+            readBinary: async () => new Uint8Array([1, 2, 3]).buffer,
+        };
+
+        await expect(readBinaryLength(storage, "binary.dat")).resolves.toBe(3);
+    });
+});
 
 class MockVaultAdapter implements IVaultAdapter<MockFile> {
     private mockFiles = new Map<string, MockFile>();

--- a/src/serviceModules/adapters/IStorageAdapter.ts
+++ b/src/serviceModules/adapters/IStorageAdapter.ts
@@ -1,62 +1,58 @@
 import type { UXDataWriteOptions, UXStat } from "@lib/common/types.ts";
 
+/** File and directory existence and metadata operations. */
+export interface IStorageMetadataAccess<TStat extends UXStat = UXStat> {
+    exists(path: string): Promise<boolean>;
+    trystat(path: string): Promise<TStat | null>;
+    stat(path: string): Promise<TStat | null>;
+}
+
+/** Text-file read operation. */
+export interface IStorageTextReadAccess {
+    read(path: string): Promise<string>;
+}
+
+/** Binary-file read operation. */
+export interface IStorageBinaryReadAccess {
+    readBinary(path: string): Promise<ArrayBuffer>;
+}
+
+/** Text-file write operation. */
+export interface IStorageTextWriteAccess {
+    write(path: string, data: string, options?: UXDataWriteOptions): Promise<void>;
+}
+
+/** Binary-file write operation. */
+export interface IStorageBinaryWriteAccess {
+    writeBinary(path: string, data: ArrayBuffer, options?: UXDataWriteOptions): Promise<void>;
+}
+
+/** Text-file append operation. */
+export interface IStorageTextAppendAccess {
+    append(path: string, data: string, options?: UXDataWriteOptions): Promise<void>;
+}
+
+/** Directory creation and direct-child listing operations. */
+export interface IStorageDirectoryAccess {
+    mkdir(path: string): Promise<void>;
+    list(basePath: string): Promise<{ files: string[]; folders: string[] }>;
+}
+
+/** File or directory removal operation. */
+export interface IStorageRemoveAccess {
+    remove(path: string): Promise<void>;
+}
+
 /**
  * Storage adapter interface
  * Low-level file system operations (adapter level)
  */
-export interface IStorageAdapter<TStat extends UXStat = UXStat> {
-    /**
-     * Check if a file or directory exists
-     */
-    exists(path: string): Promise<boolean>;
-
-    /**
-     * Get file statistics, returns null if file doesn't exist
-     */
-    trystat(path: string): Promise<TStat | null>;
-
-    /**
-     * Get file statistics
-     */
-    stat(path: string): Promise<TStat | null>;
-
-    /**
-     * Create a directory
-     */
-    mkdir(path: string): Promise<void>;
-
-    /**
-     * Remove a file or directory
-     */
-    remove(path: string): Promise<void>;
-
-    /**
-     * Read a file as text
-     */
-    read(path: string): Promise<string>;
-
-    /**
-     * Read a file as binary
-     */
-    readBinary(path: string): Promise<ArrayBuffer>;
-
-    /**
-     * Write text to a file
-     */
-    write(path: string, data: string, options?: UXDataWriteOptions): Promise<void>;
-
-    /**
-     * Write binary data to a file
-     */
-    writeBinary(path: string, data: ArrayBuffer, options?: UXDataWriteOptions): Promise<void>;
-
-    /**
-     * Append text to a file
-     */
-    append(path: string, data: string, options?: UXDataWriteOptions): Promise<void>;
-
-    /**
-     * List files and folders in a directory
-     */
-    list(basePath: string): Promise<{ files: string[]; folders: string[] }>;
-}
+export interface IStorageAdapter<TStat extends UXStat = UXStat>
+    extends IStorageMetadataAccess<TStat>,
+        IStorageTextReadAccess,
+        IStorageBinaryReadAccess,
+        IStorageTextWriteAccess,
+        IStorageBinaryWriteAccess,
+        IStorageTextAppendAccess,
+        IStorageDirectoryAccess,
+        IStorageRemoveAccess {}

--- a/src/serviceModules/adapters/IStorageAdapter.ts
+++ b/src/serviceModules/adapters/IStorageAdapter.ts
@@ -1,3 +1,14 @@
+/**
+ * Focused compatibility views of the existing storage adapter.
+ *
+ * These interfaces allow internal consumers to depend on fewer operations while
+ * retaining the existing `UXStat`, `UXDataWriteOptions`, and method semantics.
+ * They are not a neutral or extraction-ready storage API. Their names, shared
+ * types, and behavioural contracts may change when the cross-platform contract
+ * is designed and stabilised.
+ *
+ * @packageDocumentation
+ */
 import type { UXDataWriteOptions, UXStat } from "@lib/common/types.ts";
 
 /** File and directory existence and metadata operations. */
@@ -45,7 +56,7 @@ export interface IStorageRemoveAccess {
 
 /**
  * Storage adapter interface
- * Low-level file system operations (adapter level)
+ * Backwards-compatible aggregate of the focused storage capability views.
  */
 export interface IStorageAdapter<TStat extends UXStat = UXStat>
     extends IStorageMetadataAccess<TStat>,

--- a/src/serviceModules/adapters/index.ts
+++ b/src/serviceModules/adapters/index.ts
@@ -1,6 +1,16 @@
 export type { IPathAdapter } from "./IPathAdapter.ts";
 export type { ITypeGuardAdapter } from "./ITypeGuardAdapter.ts";
 export type { IConversionAdapter } from "./IConversionAdapter.ts";
-export type { IStorageAdapter } from "./IStorageAdapter.ts";
+export type {
+    IStorageAdapter,
+    IStorageBinaryReadAccess,
+    IStorageBinaryWriteAccess,
+    IStorageDirectoryAccess,
+    IStorageMetadataAccess,
+    IStorageRemoveAccess,
+    IStorageTextAppendAccess,
+    IStorageTextReadAccess,
+    IStorageTextWriteAccess,
+} from "./IStorageAdapter.ts";
 export type { IVaultAdapter } from "./IVaultAdapter.ts";
 export type { IFileSystemAdapter } from "./IFileSystemAdapter.ts";


### PR DESCRIPTION
## Summary

- split the existing `IStorageAdapter` surface into composable metadata, text, binary, directory, append, and removal capabilities;
- keep `IStorageAdapter` as the backward-compatible aggregate of those capabilities;
- export the focused capability types and verify that a binary-read-only consumer needs only one method; and
- identify the focused interfaces as provisional compatibility views rather than a neutral or extraction-ready storage API; and
- run the downstream LiveSync TypeScript checker before its unit suite so the capability fixtures are enforced as type contracts in CI.

## Why

Storage consumers currently depend on an eleven-method interface even when they need one operation. This is the first internal step towards a neutral storage contract without changing existing implementations or prematurely extracting a new package.

The focused views deliberately retain the current `UXStat`, `UXDataWriteOptions`, and method semantics. Their names, shared types, and behavioural contracts may change after cross-platform metadata, error, and destructive-operation semantics have been proven by consumer pilots.

There is no runtime behaviour change.

## Validation

- downstream `npm run tsc-check` and unit-test gates;
- `FileAccessBase.unit.spec.ts`: 57 tests passed; and
- stacked LiveSync unit suite passed with the capability split checked out.
