### PR TITLE
Reuse compiled ignore matchers

### DIFF
--- a/src/string_and_binary/path.ts
+++ b/src/string_and_binary/path.ts
@@ -1,4 +1,4 @@
-import { minimatch, type MinimatchOptions } from "minimatch";
+import { Minimatch, type MinimatchOptions } from "minimatch";
 import { getWebCrypto } from "@lib/mods.ts";
 import {
     type AnyEntry,
@@ -196,6 +196,21 @@ export function shouldSplitAsPlainText(filename: string): boolean {
 }
 
 const matchOpts: MinimatchOptions = { platform: "linux", dot: true, flipNegate: true, nocase: true };
+const ignoreMatcherCache = new WeakMap<string[], Map<string, Minimatch>>();
+
+function matchesIgnorePattern(path: string, pattern: string, ignore: string[]): boolean {
+    let matchers = ignoreMatcherCache.get(ignore);
+    if (!matchers) {
+        matchers = new Map();
+        ignoreMatcherCache.set(ignore, matchers);
+    }
+    let matcher = matchers.get(pattern);
+    if (!matcher) {
+        matcher = new Minimatch(pattern, matchOpts);
+        matchers.set(pattern, matcher);
+    }
+    return matcher.match(path);
+}
 
 /**
  * returns whether the given path is accepted (not ignored) by the `.gitignore`.
@@ -215,14 +230,14 @@ export function isAccepted(path: string, ignore: string[]): boolean | undefined 
     for (const pattern of patterns) {
         if (pattern.endsWith("/")) {
             // If the path ends with `/` and matched to the path. we do not handle more patterns to negate the result.
-            if (minimatch(path, `${pattern}**`, matchOpts)) {
+            if (matchesIgnorePattern(path, `${pattern}**`, ignore)) {
                 return false;
             }
         }
         const newResult = pattern.startsWith("!");
         const matched =
-            minimatch(path, pattern, matchOpts) ||
-            (!pattern.endsWith("/") && minimatch(path, pattern + "/**", matchOpts));
+            matchesIgnorePattern(path, pattern, ignore) ||
+            (!pattern.endsWith("/") && matchesIgnorePattern(path, pattern + "/**", ignore));
 
         if (matched) {
             result = newResult;

--- a/src/string_and_binary/path.unit.spec.ts
+++ b/src/string_and_binary/path.unit.spec.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const minimatchStats = vi.hoisted(() => ({ constructions: 0 }));
+
+vi.mock("minimatch", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("minimatch")>();
+
+    class CountingMinimatch extends actual.Minimatch {
+        constructor(pattern: string, options?: import("minimatch").MinimatchOptions) {
+            super(pattern, options);
+            minimatchStats.constructions++;
+        }
+    }
+
+    return {
+        ...actual,
+        Minimatch: CountingMinimatch,
+        minimatch: (path: string, pattern: string, options?: import("minimatch").MinimatchOptions) =>
+            new CountingMinimatch(pattern, options).match(path),
+    };
+});
+
+import { isAccepted } from "./path";
+
+describe("isAccepted", () => {
+    beforeEach(() => {
+        minimatchStats.constructions = 0;
+    });
+
+    it("reuses compiled matchers for the same ignore list", () => {
+        const ignore = ["*.tmp"];
+
+        expect(isAccepted("a.md", ignore)).toBeUndefined();
+        expect(isAccepted("a.tmp", ignore)).toBe(false);
+        expect(isAccepted("b.md", ignore)).toBeUndefined();
+        expect(isAccepted("b.tmp", ignore)).toBe(false);
+
+        expect(minimatchStats.constructions).toBe(2);
+    });
+});


### PR DESCRIPTION
## Summary

- cache compiled `Minimatch` instances by ignore-list identity
- preserve the existing `isAccepted()` API and matching behavior
- add a regression test proving repeated checks reuse the two compiled pattern variants

## Why

`isAccepted()` previously called the top-level `minimatch()` function for every path and pattern. That function constructs and parses a new `Minimatch` each time. A heap snapshot from a long-running 60k-file vault showed twelve 64 MB backing tables retained by the bundled minimatch AST private-field WeakMaps, totaling about 768 MB.

The cache is keyed by the existing ignore array with a `WeakMap`, so invalidating an ignore file does not permanently retain its old patterns.

Refs https://github.com/vrtmrz/obsidian-livesync/issues/1006

## Verification

- `vitest run --config vitest.config.unit.ts`: 413 suites, 1368 tests passed
- `npm run tsc-check`
- `npm run lint` (one unrelated existing warning)
- `npm run build` (existing Svelte warnings only)
