### PR TITLE
Avoid recompiling ignore patterns for every path check

### DIFF
--- a/src/string_and_binary/path.ts
+++ b/src/string_and_binary/path.ts
@@ -1,4 +1,4 @@
-import { minimatch, type MinimatchOptions } from "minimatch";
+import { Minimatch, type MinimatchOptions } from "minimatch";
 import { getWebCrypto } from "@lib/mods.ts";
 import {
     type AnyEntry,
@@ -196,6 +196,21 @@ export function shouldSplitAsPlainText(filename: string): boolean {
 }
 
 const matchOpts: MinimatchOptions = { platform: "linux", dot: true, flipNegate: true, nocase: true };
+const matcherCache = new WeakMap<string[], Map<string, Minimatch>>();
+
+function matchIgnoredPath(path: string, pattern: string, ignore: string[]): boolean {
+    let matchers = matcherCache.get(ignore);
+    if (matchers === undefined) {
+        matchers = new Map();
+        matcherCache.set(ignore, matchers);
+    }
+    let matcher = matchers.get(pattern);
+    if (matcher === undefined) {
+        matcher = new Minimatch(pattern, matchOpts);
+        matchers.set(pattern, matcher);
+    }
+    return matcher.match(path);
+}
 
 /**
  * returns whether the given path is accepted (not ignored) by the `.gitignore`.
@@ -215,14 +230,14 @@ export function isAccepted(path: string, ignore: string[]): boolean | undefined 
     for (const pattern of patterns) {
         if (pattern.endsWith("/")) {
             // If the path ends with `/` and matched to the path. we do not handle more patterns to negate the result.
-            if (minimatch(path, `${pattern}**`, matchOpts)) {
+            if (matchIgnoredPath(path, `${pattern}**`, ignore)) {
                 return false;
             }
         }
         const newResult = pattern.startsWith("!");
         const matched =
-            minimatch(path, pattern, matchOpts) ||
-            (!pattern.endsWith("/") && minimatch(path, pattern + "/**", matchOpts));
+            matchIgnoredPath(path, pattern, ignore) ||
+            (!pattern.endsWith("/") && matchIgnoredPath(path, pattern + "/**", ignore));
 
         if (matched) {
             result = newResult;

--- a/src/string_and_binary/path.unit.spec.ts
+++ b/src/string_and_binary/path.unit.spec.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const minimatchStats = vi.hoisted(() => ({ constructions: 0 }));
+
+vi.mock("minimatch", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("minimatch")>();
+
+    class CountingMinimatch extends actual.Minimatch {
+        constructor(pattern: string, options?: import("minimatch").MinimatchOptions) {
+            super(pattern, options);
+            minimatchStats.constructions++;
+        }
+    }
+
+    return {
+        ...actual,
+        Minimatch: CountingMinimatch,
+    };
+});
+
+import { isAccepted } from "./path";
+
+describe("isAccepted matcher cache", () => {
+    beforeEach(() => {
+        minimatchStats.constructions = 0;
+    });
+
+    it("reuses compiled matchers for the same ignore array", () => {
+        const ignore = ["*.tmp"];
+
+        expect(isAccepted("scratch.tmp", ignore)).toBe(false);
+        expect(isAccepted("other.tmp", ignore)).toBe(false);
+
+        expect(minimatchStats.constructions).toBe(1);
+    });
+
+    it("compiles new matchers when the ignore array is replaced", () => {
+        const original = ["*.tmp"];
+        const replacement = ["*.tmp"];
+
+        expect(isAccepted("scratch.tmp", original)).toBe(false);
+        expect(isAccepted("scratch.tmp", replacement)).toBe(false);
+
+        expect(minimatchStats.constructions).toBe(2);
+    });
+});


### PR DESCRIPTION
## Summary

- Cache compiled `Minimatch` instances for each ignore-pattern array.
- Reuse compiled matchers for direct patterns and their directory-expanded variants.
- Add regression tests that verify reuse for the same array and recompilation after the array is replaced.

## Why

`isAccepted()` previously called the top-level `minimatch()` function for every path and pattern check. That API compiles a matcher on each call, so repeated vault scans created avoidable matcher and regular-expression allocations.

This addresses the common-library part of [obsidian-livesync#1006](https://github.com/vrtmrz/obsidian-livesync/issues/1006). The CLI-specific mitigation was handled separately by [obsidian-livesync#1007](https://github.com/vrtmrz/obsidian-livesync/pull/1007).

## Impact

Ignore behaviour is unchanged. A `WeakMap` ties each matcher cache to the identity of its ignore-pattern array. Reusing an array reuses its compiled matchers, while replacing the array creates a fresh cache and allows the old one to be collected.

## Validation

- Focused ignore and target-filter tests: 28 passed.
- Full unit suite in obsidian-livesync: 1,314 tests passed.
- `npm run build`: passed.
- `npm run check`: passed.
- Real Obsidian Playwright smoke test: the built plug-in loaded with no renderer errors.
