### PR TITLE
fix: preserve case-only file renames

### DIFF
--- a/src/common/models/fileaccess.type.ts
+++ b/src/common/models/fileaccess.type.ts
@@ -54,7 +54,7 @@ export type UXDataWriteOptions = {
     mtime?: number;
 };
 export type CacheData = string | ArrayBuffer;
-export type FileEventType = "CREATE" | "DELETE" | "CHANGED" | "INTERNAL";
+export type FileEventType = "CREATE" | "DELETE" | "CHANGED" | "RENAME" | "INTERNAL";
 export type FileEventArgs = {
     file: UXFileInfoStub | UXInternalFileInfoStub;
     cache?: CacheData;

--- a/src/interfaces/FileHandler.ts
+++ b/src/interfaces/FileHandler.ts
@@ -12,6 +12,8 @@ export interface IFileHandler {
 
     deleteFileFromDB(info: UXFileInfoStub | UXInternalFileInfoStub | FilePath): Promise<boolean>;
 
+    renameFileInDB(info: UXFileInfoStub | UXFileInfo, oldPath: FilePath | FilePathWithPrefix): Promise<boolean>;
+
     deleteRevisionFromDB(
         info: UXFileInfoStub | FilePath | FilePathWithPrefix,
         rev: string

--- a/src/interfaces/StorageAccess.ts
+++ b/src/interfaces/StorageAccess.ts
@@ -24,6 +24,8 @@ export interface StorageAccess {
 
     deleteVaultItem(file: FilePathWithPrefix | UXFileInfoStub | UXFolderInfo): Promise<void>;
 
+    renameFile(file: UXFileInfoStub | FilePathWithPrefix, newPath: FilePathWithPrefix): Promise<UXFileInfoStub | null>;
+
     writeFileAuto(path: string, data: string | ArrayBuffer, opt?: UXDataWriteOptions): Promise<boolean>;
 
     readFileAuto(path: string): Promise<string | ArrayBuffer>;

--- a/src/managers/StorageEventManager.ts
+++ b/src/managers/StorageEventManager.ts
@@ -158,31 +158,64 @@ export abstract class StorageEventManagerBase<
         this.fileProcessing.onStorageFileEvent();
         // Flag up to be reload
         for (const param of params) {
-            if (shouldBeIgnored(param.file.path)) {
-                continue;
-            }
-            if (!settings.syncInternalFiles && param.file.path.startsWith(".")) {
-                continue;
-            }
             const atomicKey = [0, 0, 0, 0, 0, 0].map((e) => `${Math.floor(Math.random() * 100000)}`).join("-");
-            const type = param.type;
-            const file = param.file;
+            let type = param.type;
+            let file = param.file;
             const oldPath = param.oldPath;
-            if (type !== "INTERNAL") {
-                const size = (file as UXFileInfoStub).stat.size;
-                if (this.vaultService.isFileSizeTooLarge(size) && (type == "CREATE" || type == "CHANGED")) {
-                    this._log(
-                        `The storage file has been changed but exceeds the maximum size. Skipping: ${param.file.path}`,
-                        LOG_LEVEL_NOTICE
-                    );
-                    continue;
-                }
-            }
+
             if (this.isFolder(file)) {
                 this._log(`Folder event skipped: ${file.path}`, LOG_LEVEL_VERBOSE);
                 continue;
             }
-            if (!(await this.vaultService.isTargetFile(file.path))) continue;
+
+            const isTargetPath = async (path: string): Promise<boolean> => {
+                if (shouldBeIgnored(path)) return false;
+                if (!settings.syncInternalFiles && path.startsWith(".")) return false;
+                return await this.vaultService.isTargetFile(path);
+            };
+
+            if (type === "RENAME") {
+                const renamedFile = file as UXFileInfoStub;
+                if (!oldPath || !this.isFile(file) || !renamedFile.stat) {
+                    this._log(`Invalid rename event skipped: ${file.path}`, LOG_LEVEL_VERBOSE);
+                    continue;
+                }
+                const oldPathIsTarget = await isTargetPath(oldPath);
+                let newPathIsTarget = await isTargetPath(file.path);
+                if (newPathIsTarget && this.vaultService.isFileSizeTooLarge(renamedFile.stat.size)) {
+                    this._log(
+                        `The storage file has been changed but exceeds the maximum size. Skipping: ${param.file.path}`,
+                        LOG_LEVEL_NOTICE
+                    );
+                    newPathIsTarget = false;
+                }
+                if (!oldPathIsTarget && !newPathIsTarget) {
+                    continue;
+                }
+                if (oldPathIsTarget && !newPathIsTarget) {
+                    type = "DELETE";
+                    file = {
+                        path: oldPath as FilePath,
+                        name: oldPath.split("/").pop() ?? file.name,
+                        stat: renamedFile.stat,
+                        deleted: true,
+                    };
+                } else if (!oldPathIsTarget && newPathIsTarget) {
+                    type = "CREATE";
+                }
+            } else {
+                if (!(await isTargetPath(file.path))) continue;
+                if (type !== "INTERNAL") {
+                    const size = (file as UXFileInfoStub).stat.size;
+                    if (this.vaultService.isFileSizeTooLarge(size) && (type == "CREATE" || type == "CHANGED")) {
+                        this._log(
+                            `The storage file has been changed but exceeds the maximum size. Skipping: ${param.file.path}`,
+                            LOG_LEVEL_NOTICE
+                        );
+                        continue;
+                    }
+                }
+            }
 
             // Stop cache using to prevent the corruption;
             // let cache: null | string | ArrayBuffer;
@@ -190,7 +223,7 @@ export abstract class StorageEventManagerBase<
             // if (file instanceof TFile && (type == "CREATE" || type == "CHANGED")) {
             // if (file instanceof TFile || !file.isFolder) {
             if (this.isFile(file)) {
-                if (type == "CREATE" || type == "CHANGED") {
+                if (type == "CREATE" || type == "CHANGED" || type == "RENAME") {
                     // Wait for a bit while to let the writer has marked `touched` at the file.
                     await delay(10);
                     if (
@@ -212,7 +245,7 @@ export abstract class StorageEventManagerBase<
                 type,
                 args: {
                     file: file,
-                    oldPath,
+                    oldPath: type === "RENAME" ? oldPath : undefined,
                     cache,
                     ctx,
                 },
@@ -226,8 +259,8 @@ export abstract class StorageEventManagerBase<
     protected bufferedQueuedItems = [] as (FileEventItem | FileEventItemSentinel)[];
 
     enqueue(newItem: FileEventItem) {
-        if (newItem.type == "DELETE") {
-            // If the sentinel pushed, the runQueuedEvents will wait for idle before processing delete.
+        if (newItem.type == "DELETE" || newItem.type == "RENAME") {
+            // If the sentinel pushed, the runQueuedEvents will wait for idle before processing delete or rename.
             this.bufferedQueuedItems.push({
                 type: TYPE_SENTINEL_FLUSH,
             });
@@ -652,16 +685,11 @@ export abstract class StorageEventManagerBase<
             void this.appendQueue(
                 [
                     {
-                        type: "DELETE",
-                        file: {
-                            path: oldPath as FilePath,
-                            name: fileInfo.name,
-                            stat: fileInfo.stat,
-                            deleted: true,
-                        },
+                        type: "RENAME",
+                        file: fileInfo,
+                        oldPath,
                         skipBatchWait: true,
                     },
-                    { type: "CREATE", file: fileInfo, skipBatchWait: true },
                 ],
                 ctx
             );

--- a/src/managers/StorageEventManager.unit.spec.ts
+++ b/src/managers/StorageEventManager.unit.spec.ts
@@ -446,14 +446,26 @@ describe("StorageEventManagerBase", () => {
     });
 
     describe("Event Handlers - Rename", () => {
-        it("should handle file rename event", async () => {
+        it("should enqueue a file rename as one event", async () => {
             const file = createMockFile("renamed.md", "renamed.md");
             const oldPath = "old.md";
+            const enqueueSpy = vi.spyOn(manager, "enqueue");
             manager.testWatchVaultRename(file, oldPath);
             // Wait for async appendQueue
-            await new Promise((resolve) => setTimeout(resolve, 10));
-            // Event should trigger onStorageFileEvent
+            await new Promise((resolve) => setTimeout(resolve, 30));
+
             expect(dependencies.fileProcessing.onStorageFileEvent).toHaveBeenCalled();
+            expect(enqueueSpy).toHaveBeenCalledTimes(1);
+            expect(enqueueSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "RENAME",
+                    args: expect.objectContaining({
+                        oldPath,
+                        file: expect.objectContaining({ path: "renamed.md" }),
+                    }),
+                    skipBatchWait: true,
+                })
+            );
         });
 
         it("should handle folder rename event", () => {
@@ -681,6 +693,48 @@ describe("StorageEventManagerBase", () => {
             expect(enqueueSpy).not.toHaveBeenCalled();
         });
 
+        it("should turn a rename out of the target set into a delete", async () => {
+            vi.mocked(dependencies.vaultService.isTargetFile).mockImplementation(async (path) => path === "old.md");
+            const enqueueSpy = vi.spyOn(manager, "enqueue");
+            const file = createMockFile("excluded.txt", "excluded.txt");
+
+            await manager.testAppendQueue([
+                { type: "RENAME", file: adapter.converter.toFileInfo(file), oldPath: "old.md" },
+            ]);
+
+            expect(enqueueSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "DELETE",
+                    args: expect.objectContaining({
+                        oldPath: undefined,
+                        file: expect.objectContaining({ path: "old.md", deleted: true }),
+                    }),
+                })
+            );
+        });
+
+        it("should turn a rename into the target set into a create", async () => {
+            vi.mocked(dependencies.vaultService.isTargetFile).mockImplementation(
+                async (path) => path === "included.md"
+            );
+            const enqueueSpy = vi.spyOn(manager, "enqueue");
+            const file = createMockFile("included.md", "included.md");
+
+            await manager.testAppendQueue([
+                { type: "RENAME", file: adapter.converter.toFileInfo(file), oldPath: "excluded.txt" },
+            ]);
+
+            expect(enqueueSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "CREATE",
+                    args: expect.objectContaining({
+                        oldPath: undefined,
+                        file: expect.objectContaining({ path: "included.md" }),
+                    }),
+                })
+            );
+        });
+
         it("should handle DELETE events", async () => {
             const file = createMockFile("delete.md", "delete.md");
             const enqueueSpy = vi.spyOn(manager, "enqueue");
@@ -776,7 +830,24 @@ describe("StorageEventManagerBase", () => {
             expect(buffered.some((item) => item.type === "SENTINEL_FLUSH")).toBe(true);
         });
 
-        it("should not add sentinel for non-DELETE events", () => {
+        it("should enqueue items and add sentinel for RENAME", () => {
+            const file = createMockFile("renamed.md", "renamed.md");
+            const item: FileEventItem = {
+                type: "RENAME",
+                args: {
+                    file: adapter.converter.toFileInfo(file),
+                    oldPath: "old.md",
+                },
+                key: "test-key",
+            };
+
+            manager["enqueue"](item);
+
+            const buffered = manager["bufferedQueuedItems"];
+            expect(buffered.some((item) => item.type === "SENTINEL_FLUSH")).toBe(true);
+        });
+
+        it("should not add sentinel for non-destructive events", () => {
             const file = createMockFile("test.md", "test.md");
             const item: FileEventItem = {
                 type: "CREATE",

--- a/src/serviceModules/FileAccessBase.ts
+++ b/src/serviceModules/FileAccessBase.ts
@@ -248,6 +248,10 @@ export class FileAccessBase<TAdapter extends IFileSystemAdapter<any, any, any, a
         }
     }
 
+    async vaultRename(file: ExtractFile<TAdapter>, newPath: string): Promise<ExtractFile<TAdapter>> {
+        return await this._writeOp(file, async () => await this.adapter.renameFile(file, newPath));
+    }
+
     trigger(name: string, ...data: unknown[]) {
         return this.adapter.vault.trigger(name, ...data);
     }

--- a/src/serviceModules/FileAccessBase.unit.spec.ts
+++ b/src/serviceModules/FileAccessBase.unit.spec.ts
@@ -235,6 +235,13 @@ class MockVaultAdapter implements IVaultAdapter<MockFile> {
         return Promise.resolve(file);
     }
 
+    async rename(file: MockFile, newPath: string): Promise<void> {
+        this.mockFiles.delete(file.path);
+        file.path = newPath;
+        file.name = newPath.split("/").pop() || "";
+        this.mockFiles.set(newPath, file);
+    }
+
     async delete(file: any, force?: boolean): Promise<void> {
         // Mock implementation
     }
@@ -296,6 +303,14 @@ class MockFileSystemAdapter implements IFileSystemAdapter<MockAbstractFile, Mock
             }
         }
         return Promise.resolve(result);
+    }
+
+    async renameFile(file: MockFile, newPath: string): Promise<MockFile> {
+        const oldPath = file.path;
+        await this.vault.rename(file, newPath);
+        this.files.delete(oldPath);
+        this.files.set(newPath, file);
+        return file;
     }
 
     statFromNative(file: MockFile): Promise<MockStat> {
@@ -776,6 +791,22 @@ describe("FileAccessBase", () => {
             const data = new Uint8Array([1, 2, 3, 4]);
             const result = await fileAccess.vaultCreate("create.bin", data);
             expect(result.path).toBe("create.bin");
+        });
+
+        it("should rename a file and refresh the adapter lookup", async () => {
+            const file: MockFile = {
+                path: "Calculus.md",
+                name: "Calculus.md",
+                stat: { ctime: 0, mtime: 100, size: 4, type: "file" },
+                content: "body",
+            };
+            adapter.setMockFile(file.path, file);
+
+            const renamedFile = await fileAccess.vaultRename(file, "calculus.md");
+
+            expect(renamedFile.path).toBe("calculus.md");
+            await expect(adapter.getAbstractFileByPath("Calculus.md")).resolves.toBeNull();
+            await expect(adapter.getAbstractFileByPath("calculus.md")).resolves.toBe(renamedFile);
         });
     });
 

--- a/src/serviceModules/ServiceFileAccessBase.ts
+++ b/src/serviceModules/ServiceFileAccessBase.ts
@@ -131,6 +131,21 @@ export class ServiceFileAccessBase<TAdapter extends IFileSystemAdapter<any, any,
     async isExists(path: string): Promise<boolean> {
         return this.vaultAccess.isFile(await this.vaultAccess.getAbstractFileByPath(path));
     }
+    async renameFile(
+        file: UXFileInfoStub | FilePathWithPrefix,
+        newPath: FilePathWithPrefix
+    ): Promise<UXFileInfoStub | null> {
+        const oldPath = typeof file === "string" ? file : file.path;
+        const nativeFile = await this.vaultAccess.getAbstractFileByPath(oldPath);
+        if (!this.vaultAccess.isFile(nativeFile)) {
+            this._log(`Could not rename file (Possibly does not exist): ${oldPath}`, LOG_LEVEL_VERBOSE);
+            return null;
+        }
+        const renamedNativeFile = await this.vaultAccess.vaultRename(nativeFile, newPath);
+        const renamedFile = this.vaultAccess.nativeFileToUXFileInfoStub(renamedNativeFile);
+        await this.touched(renamedFile);
+        return renamedFile;
+    }
     async writeHiddenFileAuto(path: string, data: string | ArrayBuffer, opt?: UXDataWriteOptions): Promise<boolean> {
         try {
             await this.vaultAccess.adapterWrite(path, data, opt);

--- a/src/serviceModules/ServiceFileAccessBase.unit.spec.ts
+++ b/src/serviceModules/ServiceFileAccessBase.unit.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { ServiceFileAccessBase } from "./ServiceFileAccessBase";
-import type { FilePathWithPrefix } from "@lib/common/types";
+import type { FilePath, FilePathWithPrefix } from "@lib/common/types";
 
 type MockFolder = {
     kind: "folder";
@@ -155,5 +155,52 @@ describe("ServiceFileAccessBase readFileAuto", () => {
         expect(result).toBe(expected);
         expect(vaultAccess.vaultReadAuto).toHaveBeenCalledTimes(1);
         expect(vaultAccess.vaultRead).not.toHaveBeenCalled();
+    });
+});
+
+describe("ServiceFileAccessBase renameFile", () => {
+    it("renames through the vault adapter and marks the target as touched", async () => {
+        const nativeFile = {
+            kind: "file",
+            path: "Calculus.md",
+            stat: { ctime: 1, mtime: 2, size: 4, type: "file" },
+        };
+        const vaultAccess = {
+            getAbstractFileByPath: vi.fn().mockResolvedValue(nativeFile),
+            isFile: vi.fn((item: unknown) => !!item && (item as { kind?: string }).kind === "file"),
+            vaultRename: vi.fn(async (file: typeof nativeFile, newPath: string) => {
+                file.path = newPath;
+                return file;
+            }),
+            nativeFileToUXFileInfoStub: vi.fn((file: typeof nativeFile) => ({
+                name: file.path.split("/").pop() ?? file.path,
+                path: file.path as FilePath,
+                stat: file.stat,
+            })),
+            touch: vi.fn().mockResolvedValue(undefined),
+        };
+        const service = new ServiceFileAccessBase<any>({
+            API: { addLog: vi.fn() } as any,
+            appLifecycle: { onFirstInitialise: { addHandler: vi.fn() } } as any,
+            fileProcessing: { commitPendingFileEvents: { addHandler: vi.fn() } } as any,
+            vault: { isTargetFile: vi.fn().mockResolvedValue(true) } as any,
+            setting: { currentSettings: vi.fn().mockReturnValue({}) } as any,
+            storageEventManager: {
+                beginWatch: vi.fn(),
+                appendQueue: vi.fn(),
+                isWaiting: vi.fn(),
+                waitForIdle: vi.fn(),
+                restoreState: vi.fn(),
+            } as any,
+            storageAccessManager: {} as any,
+            vaultAccess: vaultAccess as any,
+        });
+
+        await expect(
+            service.renameFile("Calculus.md" as FilePathWithPrefix, "calculus.md" as FilePathWithPrefix)
+        ).resolves.toEqual(expect.objectContaining({ path: "calculus.md" }));
+
+        expect(vaultAccess.vaultRename).toHaveBeenCalledWith(nativeFile, "calculus.md");
+        expect(vaultAccess.touch).toHaveBeenCalledWith("calculus.md");
     });
 });

--- a/src/serviceModules/ServiceFileHandlerBase.ts
+++ b/src/serviceModules/ServiceFileHandlerBase.ts
@@ -10,7 +10,14 @@ import type {
     UXFileInfoStub,
     UXInternalFileInfoStub,
 } from "@lib/common/types";
-import { createBlob, getDocDataAsArray, isDocContentSame, isTextBlob, readAsBlob, readContent } from "@lib/common/utils";
+import {
+    createBlob,
+    getDocDataAsArray,
+    isDocContentSame,
+    isTextBlob,
+    readAsBlob,
+    readContent,
+} from "@lib/common/utils";
 import { shouldBeIgnored, stripAllPrefixes } from "@lib/string_and_binary/path";
 import { Semaphore } from "octagonal-wheels/concurrency/semaphore";
 import { eventHub } from "@lib/hub/hub";
@@ -53,6 +60,12 @@ async function isIncomingTextClearExtension(
     const incomingText = await incomingBlob.text();
     const localText = await localBlob.text();
     return incomingText.startsWith(localText) || incomingText.endsWith(localText);
+}
+
+async function serializedByKeys<T>(keys: readonly string[], callback: () => Promise<T>): Promise<T> {
+    const [key, ...remainingKeys] = keys;
+    if (key === undefined) return await callback();
+    return await serialized(key, () => serializedByKeys(remainingKeys, callback));
 }
 
 export abstract class ServiceFileHandlerBase
@@ -240,6 +253,37 @@ export abstract class ServiceFileHandlerBase
         return await this.db.delete(file);
     }
 
+    async renameFileInDB(info: UXFileInfoStub | UXFileInfo, oldPath: FilePath | FilePathWithPrefix): Promise<boolean> {
+        const newPath = getStoragePathFromUXFileInfo(info);
+        const [oldDocumentId, newDocumentId] = await Promise.all([
+            this.path.path2id(oldPath),
+            this.path.path2id(newPath),
+        ]);
+
+        if (oldDocumentId === newDocumentId) {
+            this._log(`Updating the stored path for case-only rename: ${oldPath} -> ${newPath}`, LOG_LEVEL_VERBOSE);
+            return await this.storeFileToDB(info, true);
+        }
+
+        const oldEntry = await this.db.fetchEntryMeta(oldPath, undefined, true);
+        if (!(await this.storeFileToDB(info, true))) {
+            this._log(`Failed to store rename target; preserving source in the database: ${oldPath}`, LOG_LEVEL_NOTICE);
+            return false;
+        }
+        if (!oldEntry || oldEntry.deleted || oldEntry._deleted) {
+            this._log(`Rename source is not present in the database: ${oldPath}`, LOG_LEVEL_VERBOSE);
+            return true;
+        }
+
+        const oldFile: UXFileInfoStub = {
+            path: oldPath,
+            name: oldPath.split("/").pop() ?? info.name,
+            stat: info.stat,
+            deleted: true,
+        };
+        return await this.deleteFileFromDB(oldFile);
+    }
+
     async deleteRevisionFromDB(
         info: UXFileInfoStub | FilePath | FilePathWithPrefix,
         rev: string
@@ -311,7 +355,7 @@ export abstract class ServiceFileHandlerBase
         }
 
         // 2. Check if the file is already exist on the storage.
-        const existDoc = await this.storage.getStub(path);
+        let existDoc = await this.storage.getStub(path);
         if (existDoc && existDoc.isFolder) {
             this._log(`Folder ${path} is already exist on the storage as a folder`, LOG_LEVEL_VERBOSE);
             // We can do nothing, and other modules should also nothing to do.
@@ -320,12 +364,11 @@ export abstract class ServiceFileHandlerBase
 
         // Check existence of both file and docEntry.
         const existOnDB = !(docEntry._deleted || docEntry.deleted || false);
-        const existOnStorage = existDoc != null;
-        if (!existOnDB && !existOnStorage) {
+        if (!existOnDB && !existDoc) {
             this._log(`File ${path} seems to be deleted, but already not on storage`, LOG_LEVEL_VERBOSE);
             return true;
         }
-        if (!existOnDB && existOnStorage) {
+        if (!existOnDB && existDoc) {
             if (
                 !force &&
                 !settings.writeDocumentsIfConflicted &&
@@ -338,6 +381,25 @@ export abstract class ServiceFileHandlerBase
             // And it does not care actually deleted.
             await this.storage.deleteVaultItem(path);
             return true;
+        }
+        if (existDoc && existDoc.path !== path) {
+            const [existingDocumentId, targetDocumentId] = await Promise.all([
+                this.path.path2id(existDoc.path),
+                this.path.path2id(path),
+            ]);
+            if (existingDocumentId !== targetDocumentId) {
+                this._log(
+                    `Refusing to overwrite ${existDoc.path} while applying the distinct path ${path}`,
+                    LOG_LEVEL_NOTICE
+                );
+                return false;
+            }
+            const renamedFile = await this.storage.renameFile(existDoc, path);
+            if (!renamedFile) {
+                this._log(`Could not apply the stored filename case: ${existDoc.path} -> ${path}`, LOG_LEVEL_NOTICE);
+                return false;
+            }
+            existDoc = renamedFile;
         }
         // Okay, the file is exist on the database. Let's check the file is exist on the storage.
         const docRead = await this.db.fetchEntryFromMeta(docEntry);
@@ -360,7 +422,7 @@ export abstract class ServiceFileHandlerBase
 
         const docData = readContent(docRead);
 
-        if (existOnStorage && !force) {
+        if (existDoc && !force) {
             // The file is exist on the storage. Let's check the difference between the file and the entry.
             // But, if force is true, then it should be updated.
             // Ok, we have to compare.
@@ -401,7 +463,7 @@ export abstract class ServiceFileHandlerBase
             // Let's apply the changes.
         } else {
             this._log(
-                `File ${docRead.path} ${existOnStorage ? "(new) " : ""} ${force ? " (forced)" : ""}`,
+                `File ${docRead.path} ${existDoc ? "(new) " : ""} ${force ? " (forced)" : ""}`,
                 LOG_LEVEL_VERBOSE
             );
         }
@@ -453,14 +515,25 @@ export abstract class ServiceFileHandlerBase
             this._log(`File ${path} should be ignored`, LOG_LEVEL_VERBOSE);
             return false;
         }
-        const lockKey = `processFileEvent-${path}`;
-        return await serialized(lockKey, async () => {
+        if (type === "RENAME" && !eventItem.oldPath) {
+            this._log(`Rename event for ${path} has no source path`, LOG_LEVEL_VERBOSE);
+            return false;
+        }
+        const eventPaths = type === "RENAME" ? [path, eventItem.oldPath as FilePathWithPrefix] : [path];
+        const documentIds = await Promise.all(eventPaths.map((eventPath) => this.path.path2id(eventPath)));
+        const lockKeys = [...new Set(documentIds)].sort().map((documentId) => `processFileEvent-${documentId}`);
+        return await serializedByKeys(lockKeys, async () => {
             switch (type) {
                 case "CREATE":
                 case "CHANGED":
                     return await this.storeFileToDB(item.args.file);
                 case "DELETE":
                     return await this.deleteFileFromDB(item.args.file);
+                case "RENAME":
+                    return await this.renameFileInDB(
+                        item.args.file as UXFileInfoStub,
+                        item.args.oldPath as FilePathWithPrefix
+                    );
                 case "INTERNAL":
                     // this should be handled on the other module.
                     return false;
@@ -472,7 +545,7 @@ export abstract class ServiceFileHandlerBase
     }
 
     async _anyProcessReplicatedDoc(entry: MetaEntry): Promise<boolean> {
-        return await serialized(entry.path, async () => {
+        return await serialized(`processReplicatedDoc-${entry._id}`, async () => {
             if (!(await this.vault.isTargetFile(entry.path))) {
                 this._log(`File ${entry.path} is not the target file`, LOG_LEVEL_VERBOSE);
                 return false;

--- a/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts
+++ b/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { BASE_IS_NEW, EVEN, TARGET_IS_NEW } from "@lib/common/models/shared.const.symbols";
-import type { MetaEntry, UXFileInfo, UXFileInfoStub } from "@lib/common/types";
+import type { FileEventItem, FilePath, MetaEntry, UXFileInfo, UXFileInfoStub } from "@lib/common/types";
 import { createTextBlob } from "@lib/common/utils";
 import { ServiceFileHandlerBase, type ServiceFileHandlerDependencies } from "./ServiceFileHandlerBase";
 
@@ -70,6 +70,7 @@ function createHandler(
         writeFileAuto: vi.fn().mockResolvedValue(true),
         touched: vi.fn().mockResolvedValue(undefined),
         triggerFileEvent: vi.fn(),
+        renameFile: vi.fn(),
     };
     const conflict = {
         queueCheckFor: vi.fn().mockResolvedValue(undefined),
@@ -77,6 +78,7 @@ function createHandler(
     };
     const pathService = {
         getPath: vi.fn().mockImplementation((entry: MetaEntry) => entry.path),
+        path2id: vi.fn().mockImplementation(async (path: string) => path.toLowerCase()),
         compareFileFreshness: vi.fn().mockReturnValue(freshness),
         markChangesAreSame: vi.fn(),
     };
@@ -103,7 +105,192 @@ function createHandler(
     };
 }
 
+function createRenameHandler(caseInsensitive: boolean, oldEntry: MetaEntry | false = createMeta("old.md", "body")) {
+    let processFileEvent: ((item: FileEventItem) => Promise<boolean>) | undefined;
+    const databaseFileAccess = {
+        fetchEntryMeta: vi.fn().mockResolvedValue(oldEntry),
+        getConflictedRevs: vi.fn().mockResolvedValue([]),
+        fetchEntry: vi.fn().mockResolvedValue(oldEntry),
+        delete: vi.fn().mockResolvedValue(true),
+    };
+    const pathService = {
+        path2id: vi.fn().mockImplementation(async (path: string) => (caseInsensitive ? path.toLowerCase() : path)),
+    };
+    const deps = {
+        API: { addLog: vi.fn() },
+        databaseFileAccess,
+        storageAccess: {},
+        fileProcessing: {
+            processFileEvent: {
+                addHandler: vi.fn((handler: (item: FileEventItem) => Promise<boolean>) => {
+                    processFileEvent = handler;
+                }),
+            },
+        },
+        replication: { processSynchroniseResult: { addHandler: vi.fn() } },
+        conflict: {},
+        path: pathService,
+        setting: { currentSettings: vi.fn().mockReturnValue({}) },
+        vault: { isTargetFile: vi.fn().mockResolvedValue(true) },
+    } as unknown as ServiceFileHandlerDependencies;
+    const handler = new TestFileHandler(deps);
+    if (!processFileEvent) throw new Error("File event handler was not registered");
+    return { handler, processFileEvent, databaseFileAccess, pathService };
+}
+
+describe("ServiceFileHandlerBase.renameFileInDB", () => {
+    it("updates one document without deleting it for a case-only rename", async () => {
+        const { handler, databaseFileAccess, pathService } = createRenameHandler(true);
+        const storeSpy = vi.spyOn(handler, "storeFileToDB").mockResolvedValue(true);
+        const deleteSpy = vi.spyOn(handler, "deleteFileFromDB").mockResolvedValue(true);
+        const file = createStorageFile("calculus.md", "body");
+
+        await expect(handler.renameFileInDB(file, "Calculus.md" as FilePath)).resolves.toBe(true);
+
+        expect(pathService.path2id).toHaveBeenNthCalledWith(1, "Calculus.md");
+        expect(pathService.path2id).toHaveBeenNthCalledWith(2, "calculus.md");
+        expect(storeSpy).toHaveBeenCalledWith(file, true);
+        expect(databaseFileAccess.fetchEntryMeta).not.toHaveBeenCalled();
+        expect(deleteSpy).not.toHaveBeenCalled();
+    });
+
+    it("stores the target before deleting the source for an ordinary rename", async () => {
+        const { handler, databaseFileAccess } = createRenameHandler(false);
+        const storeSpy = vi.spyOn(handler, "storeFileToDB").mockResolvedValue(true);
+        const deleteSpy = vi.spyOn(handler, "deleteFileFromDB").mockResolvedValue(true);
+        const file = createStorageFile("new.md", "body");
+
+        await expect(handler.renameFileInDB(file, "old.md" as FilePath)).resolves.toBe(true);
+
+        expect(databaseFileAccess.fetchEntryMeta).toHaveBeenCalledWith("old.md", undefined, true);
+        expect(storeSpy.mock.invocationCallOrder[0]).toBeLessThan(deleteSpy.mock.invocationCallOrder[0]);
+        expect(deleteSpy).toHaveBeenCalledWith(expect.objectContaining({ path: "old.md", deleted: true }));
+    });
+
+    it("preserves the source when storing the rename target fails", async () => {
+        const { handler } = createRenameHandler(false);
+        vi.spyOn(handler, "storeFileToDB").mockResolvedValue(false);
+        const deleteSpy = vi.spyOn(handler, "deleteFileFromDB").mockResolvedValue(true);
+        const file = createStorageFile("new.md", "body");
+
+        await expect(handler.renameFileInDB(file, "old.md" as FilePath)).resolves.toBe(false);
+
+        expect(deleteSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not fail when the rename source is already absent", async () => {
+        const { handler } = createRenameHandler(false, false);
+        vi.spyOn(handler, "storeFileToDB").mockResolvedValue(true);
+        const deleteSpy = vi.spyOn(handler, "deleteFileFromDB").mockResolvedValue(true);
+        const file = createStorageFile("new.md", "body");
+
+        await expect(handler.renameFileInDB(file, "old.md" as FilePath)).resolves.toBe(true);
+
+        expect(deleteSpy).not.toHaveBeenCalled();
+    });
+
+    it("dispatches a rename event to the atomic rename handler", async () => {
+        const { handler, processFileEvent } = createRenameHandler(true);
+        const renameSpy = vi.spyOn(handler, "renameFileInDB").mockResolvedValue(true);
+        const file = createStorageFile("calculus.md", "body");
+        const event: FileEventItem = {
+            type: "RENAME",
+            args: { file, oldPath: "Calculus.md" },
+            key: "rename",
+        };
+
+        await expect(processFileEvent(event)).resolves.toBe(true);
+
+        expect(renameSpy).toHaveBeenCalledWith(file, "Calculus.md");
+    });
+
+    it("serialises case variants by their canonical document ID", async () => {
+        const { handler, processFileEvent } = createRenameHandler(true);
+        let notifyDeleteStarted: (() => void) | undefined;
+        let releaseDelete: (() => void) | undefined;
+        const deleteStarted = new Promise<void>((resolve) => {
+            notifyDeleteStarted = resolve;
+        });
+        const deleteGate = new Promise<void>((resolve) => {
+            releaseDelete = resolve;
+        });
+        vi.spyOn(handler, "deleteFileFromDB").mockImplementation(async () => {
+            notifyDeleteStarted?.();
+            await deleteGate;
+            return true;
+        });
+        const storeSpy = vi.spyOn(handler, "storeFileToDB").mockResolvedValue(true);
+        const oldFile = createStorageFile("Calculus.md", "body");
+        const newFile = createStorageFile("calculus.md", "body");
+
+        const deletePromise = processFileEvent({ type: "DELETE", args: { file: oldFile }, key: "delete" });
+        await deleteStarted;
+        const createPromise = processFileEvent({ type: "CREATE", args: { file: newFile }, key: "create" });
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(storeSpy).not.toHaveBeenCalled();
+        releaseDelete?.();
+        await Promise.all([deletePromise, createPromise]);
+        expect(storeSpy).toHaveBeenCalledTimes(1);
+    });
+});
+
 describe("ServiceFileHandlerBase.dbToStorage", () => {
+    it("applies a canonical filename case change before comparing content", async () => {
+        const { handler, storageStub, databaseFileAccess, storageAccess, pathService } = createHandler(
+            "same body",
+            "same body",
+            false,
+            EVEN
+        );
+        const remoteMeta = createMeta("calculus.md", "same body");
+        const existingFile = {
+            ...storageStub,
+            name: "Calculus.md",
+            path: "Calculus.md" as FilePath,
+        };
+        const renamedFile = {
+            ...existingFile,
+            name: "calculus.md",
+            path: "calculus.md" as FilePath,
+        };
+        databaseFileAccess.fetchEntryMeta.mockResolvedValue(remoteMeta);
+        databaseFileAccess.fetchEntryFromMeta.mockResolvedValue({ ...remoteMeta, data: "same body" });
+        storageAccess.getStub.mockResolvedValue(existingFile);
+        storageAccess.renameFile.mockResolvedValue(renamedFile);
+        storageAccess.readStubContent.mockResolvedValue(createStorageFile("calculus.md", "same body"));
+
+        await expect(handler.dbToStorage(remoteMeta, existingFile)).resolves.toBe(true);
+
+        expect(pathService.path2id).toHaveBeenCalledWith("Calculus.md");
+        expect(pathService.path2id).toHaveBeenCalledWith("calculus.md");
+        expect(storageAccess.renameFile).toHaveBeenCalledWith(existingFile, "calculus.md");
+        expect(storageAccess.writeFileAuto).not.toHaveBeenCalled();
+    });
+
+    it("stops remote reflection when the canonical filename case cannot be applied", async () => {
+        const { handler, storageStub, databaseFileAccess, storageAccess } = createHandler(
+            "same body",
+            "same body",
+            false,
+            EVEN
+        );
+        const remoteMeta = createMeta("calculus.md", "same body");
+        const existingFile = {
+            ...storageStub,
+            name: "Calculus.md",
+            path: "Calculus.md" as FilePath,
+        };
+        databaseFileAccess.fetchEntryMeta.mockResolvedValue(remoteMeta);
+        storageAccess.getStub.mockResolvedValue(existingFile);
+        storageAccess.renameFile.mockResolvedValue(null);
+
+        await expect(handler.dbToStorage(remoteMeta, existingFile)).resolves.toBe(false);
+
+        expect(databaseFileAccess.fetchEntryFromMeta).not.toHaveBeenCalled();
+        expect(storageAccess.writeFileAuto).not.toHaveBeenCalled();
+    });
+
     it("preserves unknown local storage content as a conflict before applying a remote revision", async () => {
         const { handler, remoteMeta, storageStub, databaseFileAccess, storageAccess, conflict } = createHandler(
             "local unsynced",
@@ -135,10 +322,14 @@ describe("ServiceFileHandlerBase.dbToStorage", () => {
 
         expect(databaseFileAccess.storeAsConflictedRevision).not.toHaveBeenCalled();
         expect(conflict.queueCheckFor).not.toHaveBeenCalled();
-        expect(storageAccess.writeFileAuto).toHaveBeenCalledWith("note.md", "existing synced content\nnew desktop paragraph\n", {
-            ctime: 1,
-            mtime: 2,
-        });
+        expect(storageAccess.writeFileAuto).toHaveBeenCalledWith(
+            "note.md",
+            "existing synced content\nnew desktop paragraph\n",
+            {
+                ctime: 1,
+                mtime: 2,
+            }
+        );
     });
 
     it("preserves unknown local storage content even when the incoming entry is newer", async () => {

--- a/src/serviceModules/adapters/IFileSystemAdapter.ts
+++ b/src/serviceModules/adapters/IFileSystemAdapter.ts
@@ -51,6 +51,11 @@ export interface IFileSystemAdapter<
     getFiles(): Promise<TNativeFile[]>;
 
     /**
+     * Rename a file and refresh any platform-specific caches
+     */
+    renameFile(file: TNativeFile, newPath: string): Promise<TNativeFile>;
+
+    /**
      * Get file statistics from a native file object
      */
     statFromNative(file: TNativeFile): Promise<UXStat>;

--- a/src/serviceModules/adapters/IVaultAdapter.ts
+++ b/src/serviceModules/adapters/IVaultAdapter.ts
@@ -41,6 +41,11 @@ export interface IVaultAdapter<TNativeFile = unknown, TNativeFolder = unknown> {
     createBinary(path: string, data: ArrayBuffer, options?: UXDataWriteOptions): Promise<TNativeFile>;
 
     /**
+     * Rename or move an existing file
+     */
+    rename(file: TNativeFile, newPath: string): Promise<void>;
+
+    /**
      * Delete a file or folder
      */
     delete(file: TNativeFile | TNativeFolder, force?: boolean): Promise<void>;

--- a/src/string_and_binary/path.unit.spec.ts
+++ b/src/string_and_binary/path.unit.spec.ts
@@ -18,7 +18,24 @@ vi.mock("minimatch", async (importOriginal) => {
     };
 });
 
-import { isAccepted } from "./path";
+import type { FilePath } from "@lib/common/types";
+import { isAccepted, path2id_base } from "./path";
+
+describe("path2id_base path case", () => {
+    it("maps case variants to one document ID in case-insensitive mode", async () => {
+        const upperCasePath = await path2id_base("Calculus.md" as FilePath, false, true);
+        const lowerCasePath = await path2id_base("calculus.md" as FilePath, false, true);
+
+        expect(upperCasePath).toBe(lowerCasePath);
+    });
+
+    it("keeps case variants separate in case-sensitive mode", async () => {
+        const upperCasePath = await path2id_base("Calculus.md" as FilePath, false, false);
+        const lowerCasePath = await path2id_base("calculus.md" as FilePath, false, false);
+
+        expect(upperCasePath).not.toBe(lowerCasePath);
+    });
+});
 
 describe("isAccepted matcher cache", () => {
     beforeEach(() => {


### PR DESCRIPTION
## Summary

This PR addresses vrtmrz/obsidian-livesync#198, where renaming a note by changing only its letter case (e.g. `Calculus.md` → `calculus.md`) can lead to the note being deleted on other devices.

- Handle a storage rename as a single `RENAME` event instead of a delete/create pair, and serialise file events by canonical document ID.
- For case-only (same-ID) renames, update the shared document in place, so no tombstone is written.
- For ordinary (different-ID) renames, take both canonical locks in sorted order and store the destination before deleting the source; if storing the destination fails, the source document is kept.
- On receiving devices, apply an incoming path-case change as a real, cache-aware storage rename — only when both paths resolve to the same canonical document ID; a failed rename stops reflection without touching a distinct path.
- Extend the file-system / vault adapter contracts with rename operations, and add regression tests for event conversion, sync-target boundary crossings, locking, failure ordering, and remote reflection.

## Background

As far as I can tell, the issue comes from an interaction of a few behaviours: with `handleFilenameCaseSensitive` disabled, both spellings resolve to the same database document ID, while a rename is currently handled as independent `DELETE Calculus.md` and `CREATE calculus.md` operations, serialised by their case-sensitive path strings. The two operations can therefore run under different locks while modifying the same document. When the create side finds the content unchanged and skips its write, the delete side's tombstone can become the winning revision, and replication then propagates it to other devices as a real file deletion.

## Testing

Run from the parent `obsidian-livesync` workspace with this commit checked out in `src/lib`:

- `npm run check`
- `npm run test:unit` — 72 test files, 1,403 tests
- `npm run build`

Any feedback on the approach would be much appreciated.
