### PR TITLE
Track finite remote delivery and request activity

### DIFF
--- a/src/common/models/shared.const.behabiour.ts
+++ b/src/common/models/shared.const.behabiour.ts
@@ -6,7 +6,8 @@ export const MAX_DOC_SIZE_BIN = 102400; // 100kb
 export const VER = 12; // 12 Since 0.25.0, HKDF is used for encryption, so the version is changed to 12.
 
 export const RECENT_MODIFIED_DOCS_QTY = 30;
-export const LEAF_WAIT_TIMEOUT = 30000; // in synchronization, waiting missing leaf time out.
+// Deprecated arrival-delay values retained for source compatibility. Chunk reads now follow explicit delivery lifecycles.
+export const LEAF_WAIT_TIMEOUT = 30000;
 export const LEAF_WAIT_ONLY_REMOTE = 5000;
 export const LEAF_WAIT_TIMEOUT_SEQUENTIAL_REPLICATOR = 5000;
 export const REPLICATION_BUSY_TIMEOUT = 3000000;

--- a/src/managers/ChunkArrivalQuiescence.unit.spec.ts
+++ b/src/managers/ChunkArrivalQuiescence.unit.spec.ts
@@ -1,0 +1,186 @@
+import { reactiveSource, type ReactiveSource } from "octagonal-wheels/dataobject/reactive";
+import { delay } from "octagonal-wheels/promises";
+import PouchDB from "pouchdb-core";
+import MemoryAdapter from "pouchdb-adapter-memory";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DocumentID, EntryDoc, EntryLeaf } from "@lib/common/types";
+import type { IReplicatorService, ISettingService } from "@lib/services/base/IService";
+import { ChunkFetcher } from "./ChunkFetcher";
+import { LayeredChunkManager } from "./LayeredChunkManager";
+
+PouchDB.plugin(MemoryAdapter);
+
+let databaseSequence = 0;
+
+function createChunk(id: string): EntryLeaf {
+    return {
+        _id: id,
+        data: `data-${id}`,
+        type: "leaf",
+    } as EntryLeaf;
+}
+
+describe("chunk arrival quiescence", () => {
+    type FetchRemoteChunks = (missingChunks: string[], showResult: boolean) => Promise<false | EntryLeaf[]>;
+
+    let chunkFetcher: ChunkFetcher;
+    let chunkManager: LayeredChunkManager;
+    let database: PouchDB.Database<EntryDoc>;
+    let fetchRemoteChunks: ReturnType<typeof vi.fn<FetchRemoteChunks>>;
+    let getActiveReplicator: ReturnType<typeof vi.fn>;
+    let boundedRemoteActivityCount: ReactiveSource<number>;
+    let finiteReplicationActivityCount: ReactiveSource<number>;
+    let replicatorService: IReplicatorService;
+    let settingService: ISettingService;
+
+    beforeEach(() => {
+        databaseSequence++;
+        database = new PouchDB(`chunk-arrival-quiescence-${databaseSequence}`, { adapter: "memory" });
+
+        settingService = {
+            currentSettings: vi.fn(() => ({
+                concurrencyOfReadChunksOnline: 1,
+                hashCacheMaxCount: 10,
+                minimumIntervalOfReadChunksOnline: 1,
+            })),
+        } as unknown as ISettingService;
+        boundedRemoteActivityCount = reactiveSource(0);
+        finiteReplicationActivityCount = reactiveSource(0);
+        const changeManager = {
+            addCallback: vi.fn(() => vi.fn()),
+        };
+        chunkManager = new LayeredChunkManager({
+            changeManager: changeManager as never,
+            database,
+            finiteReplicationActivity: finiteReplicationActivityCount,
+            settingService,
+        });
+
+        fetchRemoteChunks = vi.fn<FetchRemoteChunks>();
+        getActiveReplicator = vi.fn(() => ({ fetchRemoteChunks }));
+        replicatorService = {
+            boundedRemoteActivityCount,
+            finiteReplicationActivityCount,
+            getActiveReplicator,
+            runBoundedRemoteActivity: vi.fn(async (task: () => unknown) => {
+                boundedRemoteActivityCount.value++;
+                try {
+                    return await task();
+                } finally {
+                    boundedRemoteActivityCount.value--;
+                }
+            }),
+        } as unknown as IReplicatorService;
+        chunkFetcher = new ChunkFetcher({ chunkManager, replicatorService, settingService });
+    });
+
+    afterEach(async () => {
+        chunkFetcher.destroy();
+        chunkManager.destroy();
+        await database.destroy();
+    });
+
+    it("waits for an on-demand fetch without imposing an arrival deadline", async () => {
+        const chunk = createChunk("chunk-1");
+        let resolveFetch!: (chunks: EntryLeaf[]) => void;
+        fetchRemoteChunks.mockImplementation(
+            () =>
+                new Promise<EntryLeaf[]>((resolve) => {
+                    resolveFetch = resolve;
+                })
+        );
+
+        const readPromise = chunkManager.read([chunk._id], { waitForDelivery: true });
+        await vi.waitFor(() => expect(fetchRemoteChunks).toHaveBeenCalledOnce());
+
+        await delay(40);
+        resolveFetch([chunk]);
+        await vi.waitFor(() => expect(fetchRemoteChunks).toHaveBeenCalledOnce());
+
+        await expect(readPromise).resolves.toEqual([expect.objectContaining(chunk)]);
+    });
+
+    it("keeps the delivery activity open through local persistence", async () => {
+        const chunk = createChunk("chunk-1");
+        let resolveWrite!: () => void;
+        const writeGate = new Promise<void>((resolve) => {
+            resolveWrite = resolve;
+        });
+        const originalWrite = chunkManager.write.bind(chunkManager);
+        const write = vi.spyOn(chunkManager, "write").mockImplementation(async (...args) => {
+            await writeGate;
+            return await originalWrite(...args);
+        });
+        fetchRemoteChunks.mockResolvedValue([chunk]);
+        let settled = false;
+
+        const readPromise = chunkManager.read([chunk._id], { waitForDelivery: true });
+        void readPromise.then(() => {
+            settled = true;
+        });
+        await vi.waitFor(() => expect(write).toHaveBeenCalledOnce());
+        await delay(40);
+
+        expect(settled).toBe(false);
+        expect(boundedRemoteActivityCount.value).toBe(1);
+
+        resolveWrite();
+        await expect(readPromise).resolves.toEqual([chunk]);
+        await vi.waitFor(() => expect(boundedRemoteActivityCount.value).toBe(0));
+    });
+
+    it("rechecks local chunks when finite replication reaches its latest sequence", async () => {
+        const chunk = createChunk("chunk-1");
+        finiteReplicationActivityCount.value = 1;
+        let settled = false;
+
+        const readPromise = chunkManager.read([chunk._id], {
+            preventRemoteRequest: true,
+            waitForDelivery: true,
+        });
+        void readPromise.then(() => {
+            settled = true;
+        });
+        await delay(40);
+        expect(settled).toBe(false);
+
+        await database.put(chunk);
+        finiteReplicationActivityCount.value = 0;
+
+        await expect(readPromise).resolves.toEqual([expect.objectContaining(chunk)]);
+    });
+
+    it("settles after a failed fetch claim completes", async () => {
+        fetchRemoteChunks.mockRejectedValue(new Error("network failed"));
+
+        const result = await chunkManager.read(["chunk-1" as DocumentID], { waitForDelivery: true });
+
+        expect(result).toEqual([false]);
+        await vi.waitFor(() => expect(boundedRemoteActivityCount.value).toBe(0));
+    });
+
+    it("releases a claim when no active replicator can service it", async () => {
+        getActiveReplicator.mockReturnValue(undefined);
+
+        const result = await chunkManager.read(["chunk-1" as DocumentID], { waitForDelivery: true });
+
+        expect(result).toEqual([false]);
+        await vi.waitFor(() => expect(boundedRemoteActivityCount.value).toBe(0));
+    });
+
+    it("uses an inactivity watchdog to release a fetch which never settles", async () => {
+        chunkFetcher.destroy();
+        chunkFetcher = new ChunkFetcher({
+            chunkManager,
+            deliveryStallTimeoutMs: 20,
+            replicatorService,
+            settingService,
+        });
+        fetchRemoteChunks.mockImplementation(() => new Promise<EntryLeaf[]>(() => undefined));
+
+        const result = await chunkManager.read(["chunk-1" as DocumentID], { waitForDelivery: true });
+
+        expect(result).toEqual([false]);
+        await vi.waitFor(() => expect(boundedRemoteActivityCount.value).toBe(0));
+    });
+});

--- a/src/managers/ChunkDeliveryCoordinator.ts
+++ b/src/managers/ChunkDeliveryCoordinator.ts
@@ -1,0 +1,181 @@
+import type { ReactiveSource } from "octagonal-wheels/dataobject/reactive";
+import { promiseWithResolvers } from "octagonal-wheels/promises";
+import { compatGlobal } from "@lib/common/coreEnvFunctions";
+import type { DocumentID } from "@lib/common/types";
+
+/**
+ * A last-resort leak fuse for an accepted delivery claim which reports no
+ * observable progress. It releases logical ownership so a waiter, and an
+ * entered bounded activity with its Wake Lock and indicator, cannot be retained
+ * forever by a stalled transport or never-settling Promise.
+ *
+ * Five minutes is a conservative operational ceiling, not a normal
+ * chunk-arrival budget, evidence of remote absence, or a transport deadline.
+ * The transport contract cannot yet abort the underlying request when it fires.
+ */
+export const DEFAULT_CHUNK_DELIVERY_STALL_TIMEOUT_MS = 5 * 60 * 1000;
+
+export type ActivityCountSource = Pick<ReactiveSource<number>, "value" | "onChanged" | "offChanged">;
+
+export type ChunkDeliveryClaimOptions = {
+    stallTimeoutMs?: number;
+    onStalled?: (ids: readonly DocumentID[]) => void;
+};
+
+export type ChunkDeliveryChangeListener = (ids?: readonly DocumentID[]) => void;
+
+/** A finite claim that keeps chunk arrival waiters paused until every owned identifier settles. */
+export interface ChunkDeliveryClaim {
+    readonly done: Promise<void>;
+    readonly pendingIds: readonly DocumentID[];
+    release(): void;
+    settle(id: DocumentID): void;
+    touch(): void;
+}
+
+/**
+ * Coordinates on-demand chunk ownership with broader finite remote activity.
+ *
+ * `ChunkFetcher` owns claims. `ArrivalWaitLayer` observes only whether an
+ * identifier may still be delivered, so it does not depend on a replicator
+ * service or on fetch scheduling details.
+ */
+export class ChunkDeliveryCoordinator {
+    private readonly activeClaimCounts = new Map<DocumentID, number>();
+    private readonly claimReleases = new Set<() => void>();
+    private readonly listeners = new Set<ChunkDeliveryChangeListener>();
+    private finiteActivityWasActive = false;
+    private readonly finiteActivityChanged = () => {
+        const active = (this.finiteReplicationActivity?.value ?? 0) > 0;
+        if (active === this.finiteActivityWasActive) return;
+        this.finiteActivityWasActive = active;
+        this.notifyChanged();
+    };
+    private disposed = false;
+
+    constructor(private readonly finiteReplicationActivity?: ActivityCountSource) {
+        this.finiteActivityWasActive = (finiteReplicationActivity?.value ?? 0) > 0;
+        this.finiteReplicationActivity?.onChanged(this.finiteActivityChanged);
+    }
+
+    claim(ids: readonly DocumentID[], options: ChunkDeliveryClaimOptions = {}): ChunkDeliveryClaim {
+        if (this.disposed) {
+            throw new Error("Cannot claim chunk delivery activity after the coordinator has been disposed.");
+        }
+
+        const pending = new Set(ids);
+        const resolver = promiseWithResolvers<void>();
+        if (pending.size === 0) {
+            resolver.resolve();
+            return {
+                done: resolver.promise,
+                pendingIds: [],
+                release: () => undefined,
+                settle: () => undefined,
+                touch: () => undefined,
+            };
+        }
+        const stallTimeoutMs = options.stallTimeoutMs ?? DEFAULT_CHUNK_DELIVERY_STALL_TIMEOUT_MS;
+        let timer: number | undefined;
+        let released = false;
+
+        const clearTimer = () => {
+            if (timer === undefined) return;
+            compatGlobal.clearTimeout(timer);
+            timer = undefined;
+        };
+        const removeActiveIds = (activeIds: readonly DocumentID[]) => {
+            for (const id of activeIds) {
+                const count = this.activeClaimCounts.get(id) ?? 0;
+                if (count <= 1) {
+                    this.activeClaimCounts.delete(id);
+                } else {
+                    this.activeClaimCounts.set(id, count - 1);
+                }
+            }
+        };
+        const release = () => {
+            if (released) return;
+            released = true;
+            clearTimer();
+            const activeIds = [...pending];
+            pending.clear();
+            removeActiveIds(activeIds);
+            this.claimReleases.delete(release);
+            resolver.resolve();
+            if (activeIds.length > 0) {
+                this.notifyChanged(activeIds);
+            }
+        };
+        const armStallTimer = () => {
+            clearTimer();
+            if (released || pending.size === 0 || stallTimeoutMs <= 0) return;
+            timer = compatGlobal.setTimeout(() => {
+                timer = undefined;
+                const stalledIds = [...pending];
+                release();
+                options.onStalled?.(stalledIds);
+            }, stallTimeoutMs);
+        };
+        const settle = (id: DocumentID) => {
+            if (released || !pending.delete(id)) return;
+            removeActiveIds([id]);
+            this.notifyChanged([id]);
+            if (pending.size === 0) {
+                release();
+            } else {
+                armStallTimer();
+            }
+        };
+
+        for (const id of pending) {
+            this.activeClaimCounts.set(id, (this.activeClaimCounts.get(id) ?? 0) + 1);
+        }
+        this.claimReleases.add(release);
+        this.notifyChanged([...pending]);
+        armStallTimer();
+
+        return {
+            done: resolver.promise,
+            get pendingIds() {
+                return [...pending];
+            },
+            release,
+            settle,
+            touch: armStallTimer,
+        };
+    }
+
+    isActivityActiveFor(id: DocumentID): boolean {
+        return this.isClaimActiveFor(id) || this.isFiniteReplicationActive();
+    }
+
+    isClaimActiveFor(id: DocumentID): boolean {
+        return this.activeClaimCounts.has(id);
+    }
+
+    isFiniteReplicationActive(): boolean {
+        return (this.finiteReplicationActivity?.value ?? 0) > 0;
+    }
+
+    onChanged(listener: ChunkDeliveryChangeListener): () => void {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
+    dispose(): void {
+        if (this.disposed) return;
+        this.disposed = true;
+        this.finiteReplicationActivity?.offChanged(this.finiteActivityChanged);
+        for (const release of [...this.claimReleases]) {
+            release();
+        }
+        this.listeners.clear();
+    }
+
+    private notifyChanged(ids?: readonly DocumentID[]): void {
+        for (const listener of this.listeners) {
+            listener(ids);
+        }
+    }
+}

--- a/src/managers/ChunkDeliveryCoordinator.unit.spec.ts
+++ b/src/managers/ChunkDeliveryCoordinator.unit.spec.ts
@@ -1,0 +1,112 @@
+import { reactiveSource } from "octagonal-wheels/dataobject/reactive";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DocumentID } from "@lib/common/types";
+import { ChunkDeliveryCoordinator } from "./ChunkDeliveryCoordinator";
+
+describe("ChunkDeliveryCoordinator", () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("tracks and settles each identifier owned by a claim", async () => {
+        const coordinator = new ChunkDeliveryCoordinator();
+        const first = "chunk-1" as DocumentID;
+        const second = "chunk-2" as DocumentID;
+        const claim = coordinator.claim([first, second], { stallTimeoutMs: 0 });
+
+        expect(coordinator.isActivityActiveFor(first)).toBe(true);
+        expect(coordinator.isActivityActiveFor(second)).toBe(true);
+
+        claim.settle(first);
+        expect(coordinator.isActivityActiveFor(first)).toBe(false);
+        expect(coordinator.isActivityActiveFor(second)).toBe(true);
+
+        claim.settle(second);
+        await expect(claim.done).resolves.toBeUndefined();
+        expect(coordinator.isActivityActiveFor(second)).toBe(false);
+        coordinator.dispose();
+    });
+
+    it("settles an empty claim immediately", async () => {
+        const coordinator = new ChunkDeliveryCoordinator();
+        const claim = coordinator.claim([]);
+
+        await expect(claim.done).resolves.toBeUndefined();
+        coordinator.dispose();
+    });
+
+    it("keeps an identifier active until every overlapping claim settles", () => {
+        const coordinator = new ChunkDeliveryCoordinator();
+        const id = "chunk-1" as DocumentID;
+        const first = coordinator.claim([id], { stallTimeoutMs: 0 });
+        const second = coordinator.claim([id], { stallTimeoutMs: 0 });
+
+        first.release();
+        expect(coordinator.isActivityActiveFor(id)).toBe(true);
+
+        second.release();
+        expect(coordinator.isActivityActiveFor(id)).toBe(false);
+        coordinator.dispose();
+    });
+
+    it("uses finite replication as a delivery gate", () => {
+        const finiteActivity = reactiveSource(0);
+        const coordinator = new ChunkDeliveryCoordinator(finiteActivity);
+        const changed = vi.fn();
+        coordinator.onChanged(changed);
+
+        finiteActivity.value = 1;
+        expect(coordinator.isActivityActiveFor("chunk-1" as DocumentID)).toBe(true);
+
+        finiteActivity.value = 2;
+        finiteActivity.value = 1;
+
+        finiteActivity.value = 0;
+        expect(coordinator.isActivityActiveFor("chunk-1" as DocumentID)).toBe(false);
+        expect(changed).toHaveBeenCalledTimes(2);
+        coordinator.dispose();
+    });
+
+    it("releases a stalled claim and resets its inactivity watchdog on progress", async () => {
+        vi.useFakeTimers();
+        const coordinator = new ChunkDeliveryCoordinator();
+        const onStalled = vi.fn();
+        const id = "chunk-1" as DocumentID;
+        const claim = coordinator.claim([id], { onStalled, stallTimeoutMs: 100 });
+
+        await vi.advanceTimersByTimeAsync(75);
+        claim.touch();
+        await vi.advanceTimersByTimeAsync(75);
+        expect(coordinator.isActivityActiveFor(id)).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(25);
+        await expect(claim.done).resolves.toBeUndefined();
+        expect(coordinator.isActivityActiveFor(id)).toBe(false);
+        expect(onStalled).toHaveBeenCalledWith([id]);
+        coordinator.dispose();
+    });
+
+    it("uses five minutes only as the default last-resort leak fuse", async () => {
+        vi.useFakeTimers();
+        const coordinator = new ChunkDeliveryCoordinator();
+        const id = "chunk-1" as DocumentID;
+        const claim = coordinator.claim([id]);
+
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000 - 1);
+        expect(coordinator.isActivityActiveFor(id)).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(1);
+        await expect(claim.done).resolves.toBeUndefined();
+        expect(coordinator.isActivityActiveFor(id)).toBe(false);
+        coordinator.dispose();
+    });
+
+    it("releases every claim when disposed", async () => {
+        const coordinator = new ChunkDeliveryCoordinator();
+        const claim = coordinator.claim(["chunk-1" as DocumentID], { stallTimeoutMs: 0 });
+
+        coordinator.dispose();
+
+        await expect(claim.done).resolves.toBeUndefined();
+    });
+});

--- a/src/managers/ChunkFetcher.ts
+++ b/src/managers/ChunkFetcher.ts
@@ -1,4 +1,4 @@
-import { delay } from "octagonal-wheels/promises";
+import { delay, promiseWithResolvers } from "octagonal-wheels/promises";
 import { unique } from "octagonal-wheels/collection";
 import { LOG_LEVEL_VERBOSE, Logger } from "@lib/common/logger.ts";
 import { DEFAULT_SETTINGS, type DocumentID, type EntryLeaf } from "@lib/common/types.ts";
@@ -7,6 +7,7 @@ import { type ChunkManager } from "./ChunkManager.ts";
 
 import type { IReplicatorService, ISettingService } from "@lib/services/base/IService.ts";
 import { compatGlobal } from "@lib/common/coreEnvFunctions.ts";
+import { DEFAULT_CHUNK_DELIVERY_STALL_TIMEOUT_MS, type ChunkDeliveryClaim } from "./ChunkDeliveryCoordinator.ts";
 
 export const EVENT_MISSING_CHUNKS = "missingChunks";
 export const EVENT_MISSING_CHUNK_REMOTE = "missingChunkRemote";
@@ -15,8 +16,15 @@ export type ChunkFetcherOptions = {
     settingService: ISettingService;
     chunkManager: ChunkManager;
     replicatorService: IReplicatorService;
+    deliveryStallTimeoutMs?: number;
 };
 const BATCH_SIZE = 100; // Number of chunks to fetch in one request
+
+type PendingChunkDelivery = {
+    activityBoundaryEntered: Promise<boolean>;
+    claim: ChunkDeliveryClaim;
+    resolveActivityBoundary: (entered: boolean) => void;
+};
 
 export class ChunkFetcher {
     options: ChunkFetcherOptions;
@@ -25,6 +33,8 @@ export class ChunkFetcher {
     }
 
     queue = [] as DocumentID[];
+    private readonly pendingClaims = new Map<DocumentID, PendingChunkDelivery>();
+    private destroyed = false;
 
     get interval(): number {
         const settings = this.options.settingService.currentSettings();
@@ -45,16 +55,111 @@ export class ChunkFetcher {
         });
     }
     destroy(): void {
-        this.abort.abort(); // Abort any ongoing requests.
+        if (this.destroyed) return;
+        this.destroyed = true;
+        this.abort.abort(); // Stop accepting missing-chunk events.
         this.queue = []; // Clear the queue.
+        const pendingDeliveries = new Set(this.pendingClaims.values());
+        this.pendingClaims.clear();
+        for (const pending of pendingDeliveries) {
+            pending.resolveActivityBoundary(false);
+            pending.claim.release();
+        }
     }
     onEventHandler = this.onEvent.bind(this);
 
     onEvent(ids: DocumentID[]): void {
-        this.queue = unique([...this.queue, ...ids]);
+        if (this.destroyed) return;
+        const claimedIds = this.ensureClaims(ids);
+        this.queue = unique([...this.queue, ...claimedIds]);
         if (this.canRequestMore()) {
             compatGlobal.setTimeout(() => void this.requestMissingChunks(), 1);
         }
+    }
+
+    private ensureClaims(ids: readonly DocumentID[]): DocumentID[] {
+        const unclaimedIds = unique(ids.filter((id) => !this.pendingClaims.has(id)));
+        if (unclaimedIds.length === 0) return [];
+
+        let pending!: PendingChunkDelivery;
+        const activityBoundary = promiseWithResolvers<boolean>();
+        const claim = this.chunkManager.deliveryCoordinator.claim(unclaimedIds, {
+            stallTimeoutMs: this.options.deliveryStallTimeoutMs ?? DEFAULT_CHUNK_DELIVERY_STALL_TIMEOUT_MS,
+            onStalled: (stalledIds) => this.onClaimStalled(pending, stalledIds),
+        });
+        pending = {
+            activityBoundaryEntered: activityBoundary.promise,
+            claim,
+            resolveActivityBoundary: activityBoundary.resolve,
+        };
+        for (const id of unclaimedIds) {
+            this.pendingClaims.set(id, pending);
+        }
+        void this.options.replicatorService
+            .runBoundedRemoteActivity(
+                () => {
+                    pending.claim.touch();
+                    pending.resolveActivityBoundary(true);
+                    return claim.done;
+                },
+                { label: "chunk-fetch" }
+            )
+            .catch((error) => {
+                const abandonedIds = claim.pendingIds;
+                pending.resolveActivityBoundary(false);
+                this.removePendingDelivery(pending, abandonedIds);
+                claim.release();
+                Logger("The chunk-delivery activity runner rejected before the claim settled.", LOG_LEVEL_VERBOSE);
+                Logger(error, LOG_LEVEL_VERBOSE);
+            });
+        return unclaimedIds;
+    }
+
+    private removePendingDelivery(pending: PendingChunkDelivery, ids: readonly DocumentID[]): void {
+        for (const id of ids) {
+            if (this.pendingClaims.get(id) === pending) {
+                this.pendingClaims.delete(id);
+            }
+        }
+        const removed = new Set(ids);
+        this.queue = this.queue.filter((id) => !(removed.has(id) && !this.pendingClaims.has(id)));
+    }
+
+    private onClaimStalled(pending: PendingChunkDelivery, stalledIds: readonly DocumentID[]): void {
+        pending.resolveActivityBoundary(false);
+        this.removePendingDelivery(pending, stalledIds);
+        Logger(`Chunk delivery stalled for the following IDs: ${stalledIds.join(", ")}`, LOG_LEVEL_VERBOSE);
+    }
+
+    private settleClaim(id: DocumentID): void {
+        const pending = this.pendingClaims.get(id);
+        if (!pending) return;
+        this.pendingClaims.delete(id);
+        pending.claim.settle(id);
+    }
+
+    private touchClaims(ids: readonly DocumentID[]): void {
+        const pendingDeliveries = new Set(
+            ids.map((id) => this.pendingClaims.get(id)).filter((pending) => pending !== undefined)
+        );
+        for (const pending of pendingDeliveries) {
+            pending.claim.touch();
+        }
+    }
+
+    private async waitForActivityBoundary(ids: readonly DocumentID[]): Promise<DocumentID[]> {
+        const pendingDeliveries = new Set(
+            ids.map((id) => this.pendingClaims.get(id)).filter((pending) => pending !== undefined)
+        );
+        const entered = new Map(
+            await Promise.all(
+                [...pendingDeliveries].map(async (pending) => [pending, await pending.activityBoundaryEntered] as const)
+            )
+        );
+        return ids.filter((id) => {
+            const pending = this.pendingClaims.get(id);
+            return pending !== undefined && entered.get(pending) === true;
+        });
     }
 
     /**
@@ -73,28 +178,34 @@ export class ChunkFetcher {
     }
 
     async requestMissingChunks(): Promise<void> {
-        if (!this.canRequestMore()) {
+        if (this.destroyed || !this.canRequestMore()) {
             return; // Do not proceed if the concurrency limit is reached or the queue is empty.
         }
+        let requestIDs: DocumentID[] = [];
         try {
             // Logger(`Requesting missing chunks: ${this.queue.join(", ")}`);
             this.currentProcessing++;
-            const requestIDs = this.queue.splice(0, BATCH_SIZE);
+            requestIDs = this.queue.splice(0, BATCH_SIZE);
+            this.ensureClaims(requestIDs);
+            requestIDs = await this.waitForActivityBoundary(requestIDs);
+            if (requestIDs.length === 0) return;
+            this.touchClaims(requestIDs);
             const now = Date.now();
             const timeSinceLastRequest = now - this.previousRequestTime;
             this.previousRequestTime = now;
             const timeToWait = Math.max(this.interval - timeSinceLastRequest, 0);
+            // An interval at or above the claim's inactivity fuse is exceptional;
+            // the safety valve may release logical ownership before this pause ends.
             if (timeToWait > 0) await delay(timeToWait);
+            this.touchClaims(requestIDs);
             const replicator = this.options.replicatorService.getActiveReplicator();
             if (!replicator) {
                 Logger("No active replicator was found to request missing chunks.");
                 return;
             }
             // Request the replicator to fetch the missing chunks.
-            const fetched = await this.options.replicatorService.runBoundedRemoteActivity(
-                () => replicator.fetchRemoteChunks(requestIDs, false),
-                { label: "chunk-fetch" }
-            );
+            const fetched = await replicator.fetchRemoteChunks(requestIDs, false);
+            this.touchClaims(requestIDs);
             if (!fetched) {
                 Logger(`No chunks were found for the following IDs: ${requestIDs.join(", ")}`);
                 for (const chunkID of requestIDs) {
@@ -135,6 +246,7 @@ export class ChunkFetcher {
                     },
                     "ChunkFetcher" as DocumentID
                 );
+                this.touchClaims(requestIDs);
                 if (result.result === true) {
                     // Successfully written to the database
                     Logger(`Fetched chunks were stored successfully: ${chunks.length}`, LOG_LEVEL_VERBOSE);
@@ -157,7 +269,13 @@ export class ChunkFetcher {
                 }
             }
             // The queue is cleared after requesting.
+        } catch (error) {
+            Logger("An error occurred while fetching remote chunks.", LOG_LEVEL_VERBOSE);
+            Logger(error, LOG_LEVEL_VERBOSE);
         } finally {
+            for (const id of requestIDs) {
+                this.settleClaim(id);
+            }
             this.currentProcessing--;
             this.previousRequestTime = Date.now();
             if (this.queue.length > 0) {

--- a/src/managers/ChunkFetcher.unit.spec.ts
+++ b/src/managers/ChunkFetcher.unit.spec.ts
@@ -4,6 +4,8 @@ import type { ChunkFetcherOptions } from "./ChunkFetcher";
 import type { DocumentID, EntryLeaf } from "@lib/common/types";
 import type { ChunkManager } from "./ChunkManager";
 import type { IReplicatorService, ISettingService } from "@lib/services/base/IService";
+import { ChunkDeliveryCoordinator } from "./ChunkDeliveryCoordinator";
+import { delay, promiseWithResolvers } from "octagonal-wheels/promises";
 
 function createMockLeaf(id: string, data: string = `data-${id}`): EntryLeaf {
     return {
@@ -20,12 +22,14 @@ describe("ChunkFetcher", () => {
     let mockReplicatorService: Partial<IReplicatorService> & { getActiveReplicator: ReturnType<typeof vi.fn> };
     let runBoundedRemoteActivity: ReturnType<typeof vi.fn>;
     let eventListeners: Map<string, ((...args: any[]) => void)[]>;
+    let deliveryCoordinator: ChunkDeliveryCoordinator;
 
     beforeEach(() => {
         // Reset event listeners
         eventListeners = new Map();
 
         // Mock ChunkManager
+        deliveryCoordinator = new ChunkDeliveryCoordinator();
         mockChunkManager = {
             addListener: vi.fn((event: string, handler: (...args: any[]) => void, options?: any) => {
                 if (!eventListeners.has(event)) {
@@ -43,6 +47,7 @@ describe("ChunkFetcher", () => {
                 result: true,
                 processed: { written: 1 },
             }),
+            deliveryCoordinator,
         } as any;
 
         // Mock SettingService
@@ -71,6 +76,7 @@ describe("ChunkFetcher", () => {
 
     afterEach(() => {
         chunkFetcher.destroy();
+        deliveryCoordinator.dispose();
         vi.clearAllMocks();
     });
 
@@ -111,6 +117,17 @@ describe("ChunkFetcher", () => {
 
             expect(chunkFetcher.queue).toEqual([]);
             expect(abortSpy).toHaveBeenCalled();
+        });
+
+        it("should release queued delivery claims on destroy", () => {
+            const id = "chunk-1" as DocumentID;
+            chunkFetcher.currentProcessing = chunkFetcher.concurrency;
+            chunkFetcher.onEvent([id]);
+            expect(deliveryCoordinator.isActivityActiveFor(id)).toBe(true);
+
+            chunkFetcher.destroy();
+
+            expect(deliveryCoordinator.isActivityActiveFor(id)).toBe(false);
         });
     });
 
@@ -209,6 +226,65 @@ describe("ChunkFetcher", () => {
             expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
                 label: "chunk-fetch",
             });
+        });
+
+        it("should not start a remote chunk request before entering the activity boundary", async () => {
+            const activityMayStart = promiseWithResolvers<void>();
+            runBoundedRemoteActivity.mockImplementation(async (task: () => unknown) => {
+                await activityMayStart.promise;
+                return await task();
+            });
+            const mockReplicator = {
+                fetchRemoteChunks: vi.fn().mockResolvedValue([createMockLeaf("chunk-1")]),
+            };
+            mockReplicatorService.getActiveReplicator.mockReturnValue(mockReplicator as any);
+
+            chunkFetcher.onEvent(["chunk-1" as DocumentID]);
+            await delay(20);
+
+            expect(mockReplicator.fetchRemoteChunks).not.toHaveBeenCalled();
+
+            activityMayStart.resolve();
+            await vi.waitFor(() => expect(mockReplicator.fetchRemoteChunks).toHaveBeenCalledOnce());
+        });
+
+        it("should release queued claims when the activity runner rejects before entry", async () => {
+            const id = "chunk-1" as DocumentID;
+            runBoundedRemoteActivity.mockRejectedValue(new Error("activity unavailable"));
+            const mockReplicator = {
+                fetchRemoteChunks: vi.fn().mockResolvedValue([createMockLeaf(id)]),
+            };
+            mockReplicatorService.getActiveReplicator.mockReturnValue(mockReplicator as any);
+
+            chunkFetcher.onEvent([id]);
+            await vi.waitFor(() => expect(deliveryCoordinator.isActivityActiveFor(id)).toBe(false));
+
+            expect(chunkFetcher.queue).toEqual([]);
+            expect(mockReplicator.fetchRemoteChunks).not.toHaveBeenCalled();
+        });
+
+        it("should release queued claims when the activity runner never enters", async () => {
+            chunkFetcher.destroy();
+            chunkFetcher = new ChunkFetcher({
+                chunkManager: mockChunkManager as ChunkManager,
+                deliveryStallTimeoutMs: 20,
+                replicatorService: mockReplicatorService as IReplicatorService,
+                settingService: mockSettingService as ISettingService,
+            });
+            const id = "chunk-1" as DocumentID;
+            runBoundedRemoteActivity.mockImplementation(() => new Promise(() => undefined));
+            const mockReplicator = {
+                fetchRemoteChunks: vi.fn().mockResolvedValue([createMockLeaf(id)]),
+            };
+            mockReplicatorService.getActiveReplicator.mockReturnValue(mockReplicator as any);
+
+            chunkFetcher.onEvent([id]);
+            expect(deliveryCoordinator.isActivityActiveFor(id)).toBe(true);
+            await delay(40);
+
+            expect(deliveryCoordinator.isActivityActiveFor(id)).toBe(false);
+            expect(chunkFetcher.queue).toEqual([]);
+            expect(mockReplicator.fetchRemoteChunks).not.toHaveBeenCalled();
         });
 
         it("should handle no active replicator", async () => {

--- a/src/managers/EntryManager/EntryManagerImpls.ts
+++ b/src/managers/EntryManager/EntryManagerImpls.ts
@@ -16,9 +16,6 @@ import {
     REMOTE_COUCHDB,
     type ObsidianLiveSyncSettings,
     type MetaEntry,
-    LEAF_WAIT_ONLY_REMOTE,
-    LEAF_WAIT_TIMEOUT,
-    LEAF_WAIT_TIMEOUT_SEQUENTIAL_REPLICATOR,
     RemoteTypes,
     type NoteEntry,
 } from "@lib/common/types";
@@ -395,36 +392,29 @@ function canFetchRemotely(settings: ObsidianLiveSyncSettings) {
 }
 /**
  * Decide how to retrieve chunks based on settings and waitForReady flag.
- * When waitForReady is true, it will wait for a certain time to retrieve chunks from the remote source if they are not available locally, depending on the settings.
+ * `waitForReady` allows an already-observable finite delivery lifecycle to finish.
  */
-function computeChunkRetrievalMethod(waitForReady: boolean, settings: ObsidianLiveSyncSettings) {
+export function computeChunkRetrievalMethod(waitForReady: boolean, settings: ObsidianLiveSyncSettings) {
     const isOnDemandFetchEnabled = canFetchRemotely(settings);
-    const isSequentialReplicator = settings.remoteType === RemoteTypes.REMOTE_MINIO;
     if (!waitForReady) {
-        // if waitForReady=false, basically, we should respond immediately.
-        // However, while on-demand chunking is enabled, we do not have chunks on local database until they are fetched from the remote source.
+        // Normally this requests an immediate local result. CouchDB on-demand
+        // delivery is the exception because synchronous dispatch creates a
+        // producer claim which has a meaningful completion boundary.
         if (isOnDemandFetchEnabled) {
             return {
-                timeout: LEAF_WAIT_ONLY_REMOTE,
+                waitForDelivery: true,
                 preventRemoteRequest: false,
             };
         }
         return {
-            timeout: 0,
+            waitForDelivery: false,
             preventRemoteRequest: true,
         };
     }
-    // if waitForReady=true, we can wait for a certain time to retrieve chunks from the remote source if they are not available locally, depending on the settings.
-    if (isSequentialReplicator) {
-        // if sequential replicator is used, we can wait longer because chunks will be corrected incrementally, so the chance to get chunks from local database will increase over time while waiting.
-        return {
-            timeout: LEAF_WAIT_TIMEOUT_SEQUENTIAL_REPLICATOR,
-            preventRemoteRequest: true, // Sequential replicator may not use on-demand fetching
-        };
-    }
-    // on-demand fetch behaviour.
+    // Wait only for an already-observable finite replication, or for the
+    // per-identifier claim created by CouchDB on-demand fetching.
     return {
-        timeout: LEAF_WAIT_TIMEOUT,
+        waitForDelivery: true,
         preventRemoteRequest: !isOnDemandFetchEnabled,
     };
 }
@@ -469,24 +459,14 @@ async function respondEntryFromMeta(
             edenChunks = Object.fromEntries(chunks.map((e) => [e._id, e]));
         }
 
-        // const isChunksCorrectedIncrementally = settings.remoteType !== RemoteTypes.REMOTE_MINIO;
-        // const isNetworkEnabled = isOnDemandChunkEnabled(settings)
-        //     && settings.remoteType !== RemoteTypes.REMOTE_MINIO;
-        // const timeout = waitForReady
-        //     ? isChunksCorrectedIncrementally
-        //         ? LEAF_WAIT_TIMEOUT
-        //         : LEAF_WAIT_TIMEOUT_SEQUENTIAL_REPLICATOR
-        //     : isNetworkEnabled
-        //         ? LEAF_WAIT_ONLY_REMOTE
-        //         : 0;
-        const { timeout, preventRemoteRequest } = computeChunkRetrievalMethod(waitForReady, settings);
+        const { waitForDelivery, preventRemoteRequest } = computeChunkRetrievalMethod(waitForReady, settings);
 
         const childrenKeys = [...meta.children] as DocumentID[];
         const chunks = await chunkManager.read(
             childrenKeys,
             {
                 skipCache: false,
-                timeout: timeout,
+                waitForDelivery,
                 preventRemoteRequest: preventRemoteRequest,
             },
             edenChunks

--- a/src/managers/EntryManager/EntryManagerImpls.unit.spec.ts
+++ b/src/managers/EntryManager/EntryManagerImpls.unit.spec.ts
@@ -11,6 +11,7 @@ import {
     getDBEntryByPath,
     deleteDBEntryByPath,
     canUseOnDemandChunking,
+    computeChunkRetrievalMethod,
     isLegacyNote,
 } from "./EntryManagerImpls";
 import type {
@@ -21,8 +22,16 @@ import type {
     SavingEntry,
     ObsidianLiveSyncSettings,
     NewEntry,
+    PlainEntry,
 } from "@lib/common/types";
-import { DEFAULT_SETTINGS, REMOTE_COUCHDB, IDPrefixes, ChunkAlgorithms } from "@lib/common/types";
+import {
+    DEFAULT_SETTINGS,
+    REMOTE_COUCHDB,
+    REMOTE_MINIO,
+    REMOTE_P2P,
+    IDPrefixes,
+    ChunkAlgorithms,
+} from "@lib/common/types";
 import { LayeredChunkManager } from "@lib/managers/LayeredChunkManager";
 import { HashManager } from "@lib/managers/HashManager/HashManager";
 import type { IPathService, ISettingService } from "@lib/services/base/IService";
@@ -323,6 +332,31 @@ describe("EntryManagerImpls", () => {
             }
         });
 
+        it("persists every referenced chunk before publishing its metadata", async () => {
+            const entry = createSavingEntry("ordered-entry", "Content which must exist before its metadata");
+            const host = createHost(mockSettingService, mockPathService);
+            const metadataPut = vi.fn(
+                async (doc: PouchDB.Core.PutDocument<PlainEntry | NewEntry>, options?: PouchDB.Core.PutOptions) => {
+                    if ("children" in doc) {
+                        for (const chunkID of doc.children) {
+                            await expect(db.get(chunkID)).resolves.toMatchObject({ _id: chunkID, type: "leaf" });
+                        }
+                    }
+                    return await db.put<PlainEntry | NewEntry>(doc, options);
+                }
+            );
+            const localDatabase = {
+                get: db.get.bind(db),
+                put: metadataPut,
+            } as unknown as PouchDB.Database<EntryDoc>;
+
+            await expect(
+                putDBEntry(host, { localDatabase, chunkManager, hashManager, splitter }, entry)
+            ).resolves.not.toBe(false);
+
+            expect(metadataPut).toHaveBeenCalledOnce();
+        });
+
         it("should save only chunks when onlyChunks is true", async () => {
             const entry = createSavingEntry("chunks-only", "Only chunks should be saved");
             const host = createHost(mockSettingService, mockPathService);
@@ -618,7 +652,7 @@ describe("EntryManagerImpls", () => {
         });
     });
 
-    describe("isOnDemandChunkEnabled", () => {
+    describe("remote chunk fetch capability", () => {
         it("should return true for CouchDB without useOnlyLocalChunk", () => {
             const settings = {
                 ...DEFAULT_SETTINGS,
@@ -648,6 +682,106 @@ describe("EntryManagerImpls", () => {
 
             expect(canUseOnDemandChunking(settings)).toBe(false);
         });
+    });
+
+    describe("computeChunkRetrievalMethod", () => {
+        it.each([
+            {
+                expected: { preventRemoteRequest: false, waitForDelivery: true },
+                remoteType: REMOTE_COUCHDB,
+                useOnlyLocalChunk: false,
+                waitForReady: false,
+            },
+            {
+                expected: { preventRemoteRequest: false, waitForDelivery: true },
+                remoteType: REMOTE_COUCHDB,
+                useOnlyLocalChunk: false,
+                waitForReady: true,
+            },
+            {
+                expected: { preventRemoteRequest: true, waitForDelivery: false },
+                remoteType: REMOTE_COUCHDB,
+                useOnlyLocalChunk: true,
+                waitForReady: false,
+            },
+            {
+                expected: { preventRemoteRequest: true, waitForDelivery: true },
+                remoteType: REMOTE_COUCHDB,
+                useOnlyLocalChunk: true,
+                waitForReady: true,
+            },
+            {
+                expected: { preventRemoteRequest: true, waitForDelivery: false },
+                remoteType: REMOTE_MINIO,
+                useOnlyLocalChunk: false,
+                waitForReady: false,
+            },
+            {
+                expected: { preventRemoteRequest: true, waitForDelivery: true },
+                remoteType: REMOTE_MINIO,
+                useOnlyLocalChunk: false,
+                waitForReady: true,
+            },
+            {
+                expected: { preventRemoteRequest: true, waitForDelivery: false },
+                remoteType: REMOTE_MINIO,
+                useOnlyLocalChunk: true,
+                waitForReady: false,
+            },
+            {
+                expected: { preventRemoteRequest: true, waitForDelivery: true },
+                remoteType: REMOTE_MINIO,
+                useOnlyLocalChunk: true,
+                waitForReady: true,
+            },
+            {
+                expected: { preventRemoteRequest: true, waitForDelivery: true },
+                remoteType: REMOTE_P2P,
+                useOnlyLocalChunk: false,
+                waitForReady: true,
+            },
+            {
+                expected: { preventRemoteRequest: true, waitForDelivery: false },
+                remoteType: REMOTE_P2P,
+                useOnlyLocalChunk: false,
+                waitForReady: false,
+            },
+            {
+                expected: { preventRemoteRequest: true, waitForDelivery: false },
+                remoteType: REMOTE_P2P,
+                useOnlyLocalChunk: true,
+                waitForReady: false,
+            },
+            {
+                expected: { preventRemoteRequest: true, waitForDelivery: true },
+                remoteType: REMOTE_P2P,
+                useOnlyLocalChunk: true,
+                waitForReady: true,
+            },
+        ])("returns $expected for $remoteType when waitForReady=$waitForReady", (testCase) => {
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                remoteType: testCase.remoteType,
+                useOnlyLocalChunk: testCase.useOnlyLocalChunk,
+            } as ObsidianLiveSyncSettings;
+
+            expect(computeChunkRetrievalMethod(testCase.waitForReady, settings)).toEqual(testCase.expected);
+        });
+
+        it.each([false, true])(
+            "keeps direct CouchDB fallback available whether normal replication includes chunks or not when waitForReady=$waitForReady",
+            (waitForReady) => {
+                const base = {
+                    ...DEFAULT_SETTINGS,
+                    remoteType: REMOTE_COUCHDB,
+                    useOnlyLocalChunk: false,
+                } as ObsidianLiveSyncSettings;
+
+                expect(computeChunkRetrievalMethod(waitForReady, { ...base, readChunksOnline: true })).toEqual(
+                    computeChunkRetrievalMethod(waitForReady, { ...base, readChunksOnline: false })
+                );
+            }
+        );
     });
 
     describe("isNoteEntry", () => {

--- a/src/managers/LayeredChunkManager.ts
+++ b/src/managers/LayeredChunkManager.ts
@@ -16,6 +16,7 @@ import type {
     WriteResult,
 } from "./LayeredChunkManager/types.ts";
 import { unique } from "octagonal-wheels/collection";
+import { ChunkDeliveryCoordinator } from "./ChunkDeliveryCoordinator.ts";
 
 /**
  * ChunkManager class that manages chunk operations such as reading, writing, and caching.
@@ -27,9 +28,11 @@ export class LayeredChunkManager {
 
     // Middleware layers
     private cacheLayer: CacheLayer;
+    private databaseReadLayer: DatabaseReadLayer;
     private readLayers: IReadLayer[];
     private writeLayers: IWriteLayer[];
     private arrivalWaitLayer: ArrivalWaitLayer;
+    readonly deliveryCoordinator: ChunkDeliveryCoordinator;
 
     get changeManager(): ChangeManager<EntryDoc> {
         return this.options.changeManager;
@@ -82,17 +85,28 @@ export class LayeredChunkManager {
 
         // Initialize cache layer
         this.cacheLayer = new CacheLayer(maxCacheSize);
+        this.databaseReadLayer = new DatabaseReadLayer(this.database);
 
-        // Initialise arrival wait layer
-        this.arrivalWaitLayer = new ArrivalWaitLayer((eventName: string, data: DocumentID[]) => {
-            if (eventName === "missingChunks") {
-                this.emitEvent(EVENT_MISSING_CHUNKS, data);
-            }
-        });
+        // Initialise the shared arrival/fetch activity coordinator and wait layer.
+        this.deliveryCoordinator = new ChunkDeliveryCoordinator(options.finiteReplicationActivity);
+        this.arrivalWaitLayer = new ArrivalWaitLayer(
+            (eventName: string, data: DocumentID[]) => {
+                if (eventName === "missingChunks") {
+                    this.emitEvent(EVENT_MISSING_CHUNKS, data);
+                }
+            },
+            this.deliveryCoordinator,
+            (ids) =>
+                this.databaseReadLayer.read(
+                    [...ids],
+                    { preventRemoteRequest: true, skipCache: true, waitForDelivery: false },
+                    (remaining) => Promise.resolve(remaining.map(() => false))
+                )
+        );
 
         // Build read layers pipeline: Cache → Database → ArrivalWait
         // Cache layer implements IReadLayer interface
-        this.readLayers = [this.cacheLayer, new DatabaseReadLayer(this.database), this.arrivalWaitLayer];
+        this.readLayers = [this.cacheLayer, this.databaseReadLayer, this.arrivalWaitLayer];
 
         // Build write layers pipeline: HotPack → Database → Cache
         // Cache layer implements IWriteLayer interface at the end
@@ -119,6 +133,7 @@ export class LayeredChunkManager {
                 layer.tearDown();
             }
         }
+        this.deliveryCoordinator.dispose();
     }
 
     // Cache management methods (delegated to cacheLayer)

--- a/src/managers/LayeredChunkManager.unit.spec.ts
+++ b/src/managers/LayeredChunkManager.unit.spec.ts
@@ -305,9 +305,10 @@ describe("LayeredChunkManager Integration Tests", () => {
 
         it("should handle chunk arrival events", async () => {
             const chunk = createMockLeaf("chunk-1");
+            const claim = chunkManager.deliveryCoordinator.claim([chunk._id], { stallTimeoutMs: 0 });
 
-            // Start reading (will wait for arrival)
-            const promise = chunkManager.read(["chunk-1" as DocumentID], { timeout: 1000 });
+            // Start reading while an observable producer owns the chunk.
+            const promise = chunkManager.read([chunk._id], { waitForDelivery: true });
 
             // Simulate chunk arrival via change event after a small delay
             setTimeout(() => {
@@ -329,19 +330,29 @@ describe("LayeredChunkManager Integration Tests", () => {
             expect(results).toHaveLength(1);
             expect(results[0]).not.toBe(false);
             expect((results[0] as EntryLeaf)._id).toBe("chunk-1");
+            claim.release();
         });
 
         it("should handle EVENT_MISSING_CHUNK_REMOTE", async () => {
-            // Start reading (will wait for arrival)
-            const promise = chunkManager.read(["chunk-1" as DocumentID], { timeout: 1000 });
+            const id = "chunk-1" as DocumentID;
+            const claim = chunkManager.deliveryCoordinator.claim([id], { stallTimeoutMs: 0 });
+            let resolveRequest!: () => void;
+            const requestDispatched = new Promise<void>((resolve) => {
+                resolveRequest = resolve;
+            });
+            const stopObservingRequest = chunkManager.addListener(EVENT_MISSING_CHUNKS, () => resolveRequest());
+            const promise = chunkManager.read([id], { waitForDelivery: true });
 
             // Emit missing chunk remote event
-            chunkManager.emitEvent(EVENT_MISSING_CHUNK_REMOTE, "chunk-1" as DocumentID);
+            await requestDispatched;
+            chunkManager.emitEvent(EVENT_MISSING_CHUNK_REMOTE, id);
 
             const results = await promise;
 
             expect(results).toHaveLength(1);
             expect(results[0]).toBe(false); // Should resolve to false
+            stopObservingRequest();
+            claim.release();
         });
 
         it("should remove event listeners via returned cleanup function", () => {
@@ -465,9 +476,10 @@ describe("LayeredChunkManager Integration Tests", () => {
 
         it("should handle chunk arrival during read wait", async () => {
             const chunk = createMockLeaf("chunk-1");
+            const claim = chunkManager.deliveryCoordinator.claim([chunk._id], { stallTimeoutMs: 0 });
 
-            // Start reading (will wait)
-            const readPromise = chunkManager.read(["chunk-1" as DocumentID], { timeout: 1000 });
+            // Start reading while an observable producer owns the chunk.
+            const readPromise = chunkManager.read([chunk._id], { waitForDelivery: true });
 
             // Simulate chunk arrival after a short delay
             setTimeout(() => {
@@ -487,6 +499,7 @@ describe("LayeredChunkManager Integration Tests", () => {
             expect(results).toHaveLength(1);
             expect(results[0]).not.toBe(false);
             expect((results[0] as EntryLeaf)._id).toBe("chunk-1");
+            claim.release();
         });
     });
 });

--- a/src/managers/LayeredChunkManager/ArrivalWaitLayer.ts
+++ b/src/managers/LayeredChunkManager/ArrivalWaitLayer.ts
@@ -2,82 +2,118 @@ import { type PromiseWithResolvers, promiseWithResolvers } from "octagonal-wheel
 import type { DocumentID, EntryLeaf } from "@lib/common/types";
 import type { IReadLayer } from "./ChunkLayerInterfaces";
 import type { ChunkReadOptions } from "./types.ts";
-import { compatGlobal } from "@lib/common/coreEnvFunctions.ts";
+import { ChunkDeliveryCoordinator } from "@lib/managers/ChunkDeliveryCoordinator.ts";
+import { LOG_LEVEL_VERBOSE, Logger } from "@lib/common/logger.ts";
+
+export type ChunkAvailabilityRecheck = (ids: readonly DocumentID[]) => Promise<readonly (EntryLeaf | false)[]>;
 
 /**
- * Arrival wait layer - emits events for fetcher, and waits for chunks to arrive
+ * Waits only for a delivery lifecycle which is already observable when the
+ * local miss is handled. It does not guess at an arrival delay.
  */
-
 export class ArrivalWaitLayer implements IReadLayer {
-    private waitingMap = new Map<
+    private readonly waitingMap = new Map<
         DocumentID,
         {
             resolver: PromiseWithResolvers<EntryLeaf | false>;
+            observedActivity: boolean;
+            activityVersion: number;
         }
     >();
-    private readonly DEFAULT_TIMEOUT = 15000;
     private readonly eventEmitter: (eventName: string, data: DocumentID[]) => void;
+    private readonly deliveryCoordinator: ChunkDeliveryCoordinator;
+    private readonly ownsDeliveryCoordinator: boolean;
+    private readonly stopObservingActivity: () => void;
 
-    constructor(eventEmitter: (eventName: string, data: DocumentID[]) => void) {
+    constructor(
+        eventEmitter: (eventName: string, data: DocumentID[]) => void,
+        deliveryCoordinator?: ChunkDeliveryCoordinator,
+        private readonly recheckAvailability?: ChunkAvailabilityRecheck
+    ) {
         this.eventEmitter = eventEmitter;
+        this.deliveryCoordinator = deliveryCoordinator ?? new ChunkDeliveryCoordinator();
+        this.ownsDeliveryCoordinator = deliveryCoordinator === undefined;
+        this.stopObservingActivity = this.deliveryCoordinator.onChanged((ids) => this.refreshActivity(ids));
     }
 
-    private enqueueWaiting(id: DocumentID, timeout: number): Promise<EntryLeaf | false> {
+    private enqueueWaiting(id: DocumentID): Promise<EntryLeaf | false> {
         const previous = this.waitingMap.get(id);
-        if (previous) {
-            return previous.resolver.promise;
-        }
+        if (previous) return previous.resolver.promise;
 
         const resolver = promiseWithResolvers<EntryLeaf | false>();
-        this.waitingMap.set(id, { resolver });
-
-        return this.withTimeout(resolver.promise, timeout, () => {
-            const current = this.waitingMap.get(id);
-            if (current && current.resolver === resolver) {
-                this.waitingMap.delete(id);
-            }
-            return false;
-        });
+        this.waitingMap.set(id, { activityVersion: 0, observedActivity: false, resolver });
+        return resolver.promise;
     }
 
-    private withTimeout<T>(proc: Promise<T>, timeout: number, onTimedOut: () => T): Promise<T> {
-        return new Promise((resolve, reject) => {
-            const timer = compatGlobal.setTimeout(() => {
-                resolve(onTimedOut());
-            }, timeout);
-            proc.then(resolve)
-                .catch(reject)
-                .finally(() => {
-                    compatGlobal.clearTimeout(timer);
-                });
-        });
+    private settle(id: DocumentID, value: EntryLeaf | false): void {
+        const queue = this.waitingMap.get(id);
+        if (!queue) return;
+        this.waitingMap.delete(id);
+        queue.resolver.resolve(value);
     }
 
-    /**
-     * Handle chunk arrival (called when a chunk document arrives)
-     */
-    onChunkArrived(doc: EntryLeaf, deleted: boolean = false): void {
-        const id = doc._id;
-        if (this.waitingMap.has(id)) {
-            const queue = this.waitingMap.get(id)!;
-            this.waitingMap.delete(id);
-            if (doc._deleted || deleted) {
-                queue.resolver.resolve(false);
+    private async settleAfterObservedActivity(ids: readonly DocumentID[]): Promise<void> {
+        const candidates = ids.flatMap((id) => {
+            const queue = this.waitingMap.get(id);
+            if (!queue?.observedActivity || this.deliveryCoordinator.isActivityActiveFor(id)) return [];
+            const version = ++queue.activityVersion;
+            return [{ id, version }];
+        });
+        if (candidates.length === 0) return;
+
+        let results: readonly (EntryLeaf | false)[];
+        try {
+            results = this.recheckAvailability
+                ? await this.recheckAvailability(candidates.map(({ id }) => id))
+                : candidates.map(() => false);
+        } catch (error) {
+            Logger("Could not recheck chunk availability after finite delivery activity completed.", LOG_LEVEL_VERBOSE);
+            Logger(error, LOG_LEVEL_VERBOSE);
+            results = candidates.map(() => false);
+        }
+
+        for (let index = 0; index < candidates.length; index++) {
+            const { id, version } = candidates[index];
+            const queue = this.waitingMap.get(id);
+            if (!queue || queue.activityVersion !== version) continue;
+            const result = results[index] ?? false;
+            if (result) {
+                this.settle(id, result);
+            } else if (this.deliveryCoordinator.isActivityActiveFor(id)) {
+                this.refreshActivity([id]);
             } else {
-                queue.resolver.resolve(doc);
+                this.settle(id, false);
             }
         }
     }
 
-    /**
-     * Handle missing chunk (called when a chunk is confirmed missing)
-     */
-    onMissingChunk(id: DocumentID): void {
-        if (this.waitingMap.has(id)) {
-            const queue = this.waitingMap.get(id)!;
-            this.waitingMap.delete(id);
-            queue.resolver.resolve(false);
+    private refreshActivity(ids: readonly DocumentID[] = [...this.waitingMap.keys()]): void {
+        const completedActivityIds: DocumentID[] = [];
+        for (const id of ids) {
+            const queue = this.waitingMap.get(id);
+            if (!queue) continue;
+            if (this.deliveryCoordinator.isActivityActiveFor(id)) {
+                queue.observedActivity = true;
+                queue.activityVersion++;
+            } else if (queue.observedActivity) {
+                completedActivityIds.push(id);
+            } else {
+                this.settle(id, false);
+            }
         }
+        if (completedActivityIds.length > 0) {
+            void this.settleAfterObservedActivity(completedActivityIds);
+        }
+    }
+
+    /** Handle a chunk document becoming available. */
+    onChunkArrived(doc: EntryLeaf, deleted: boolean = false): void {
+        this.settle(doc._id, doc._deleted || deleted ? false : doc);
+    }
+
+    /** Handle an explicit remote-missing result. */
+    onMissingChunk(id: DocumentID): void {
+        this.settle(id, false);
     }
 
     async read(
@@ -85,39 +121,33 @@ export class ArrivalWaitLayer implements IReadLayer {
         options: ChunkReadOptions,
         next: (remaining: DocumentID[]) => Promise<(EntryLeaf | false)[]>
     ): Promise<(EntryLeaf | false)[]> {
-        const timeout = options.timeout ?? this.DEFAULT_TIMEOUT;
+        const waitForDelivery = options.waitForDelivery ?? (options.timeout === undefined || options.timeout > 0);
+        if (!waitForDelivery || ids.length === 0) return ids.map(() => false);
 
-        if (timeout <= 0 || ids.length === 0) {
-            return ids.map(() => false);
-        }
-
-        // Wait for chunks to arrive
-        const tasks = ids.map((id) => this.enqueueWaiting(id, timeout));
-
+        const tasks = ids.map((id) => this.enqueueWaiting(id));
         if (!options.preventRemoteRequest) {
+            // EventTarget dispatch is synchronous. ChunkFetcher claims the identifiers
+            // before this call returns, closing the scheduling gap without a timer.
             this.eventEmitter("missingChunks", ids);
         }
-
-        const results = await Promise.all(tasks);
-        return results;
+        this.refreshActivity(ids);
+        return await Promise.all(tasks);
     }
 
-    /**
-     * Clear all waiting requests
-     */
     clearWaiting(): void {
-        for (const [, queue] of this.waitingMap.entries()) {
-            queue.resolver.resolve(false);
+        for (const id of [...this.waitingMap.keys()]) {
+            this.settle(id, false);
         }
-        this.waitingMap.clear();
     }
 
     tearDown(): void {
+        this.stopObservingActivity();
         this.clearWaiting();
+        if (this.ownsDeliveryCoordinator) {
+            this.deliveryCoordinator.dispose();
+        }
     }
-    /**
-     * Get count of waiting chunks
-     */
+
     getWaitingCount(): number {
         return this.waitingMap.size;
     }

--- a/src/managers/LayeredChunkManager/ArrivalWaitLayer.unit.spec.ts
+++ b/src/managers/LayeredChunkManager/ArrivalWaitLayer.unit.spec.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { ArrivalWaitLayer } from "./ArrivalWaitLayer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { reactiveSource } from "octagonal-wheels/dataobject/reactive";
 import type { DocumentID, EntryLeaf } from "@lib/common/types";
+import { ChunkDeliveryCoordinator, type ChunkDeliveryClaim } from "@lib/managers/ChunkDeliveryCoordinator";
+import { ArrivalWaitLayer } from "./ArrivalWaitLayer";
 
 function createMockLeaf(id: string, data: string = `data-${id}`): EntryLeaf {
     return {
         _id: id as DocumentID,
-        type: "leaf" as any,
-        data: data,
+        data,
+        type: "leaf",
     } as EntryLeaf;
 }
 
@@ -19,310 +21,244 @@ describe("ArrivalWaitLayer", () => {
         arrivalWaitLayer = new ArrivalWaitLayer(eventEmitter);
     });
 
-    it("should initialise with event emitter", () => {
-        expect(arrivalWaitLayer).toBeDefined();
+    it("initialises without a waiter", () => {
         expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
     });
 
-    it("should return false for empty ids array", async () => {
-        const nextFn = vi.fn();
-        const result = await arrivalWaitLayer.read([], {}, nextFn);
-
-        expect(result).toEqual([]);
-        expect(eventEmitter).not.toHaveBeenCalled();
-        expect(nextFn).not.toHaveBeenCalled();
-    });
-
-    it("should return false immediately when timeout is 0", async () => {
-        const ids = ["chunk-1" as DocumentID, "chunk-2" as DocumentID];
-        const nextFn = vi.fn();
-
-        const result = await arrivalWaitLayer.read(ids, { timeout: 0 }, nextFn);
-
-        expect(result).toEqual([false, false]);
-        expect(eventEmitter).not.toHaveBeenCalled();
-        expect(nextFn).not.toHaveBeenCalled();
-    });
-
-    it("should return false immediately when timeout is negative", async () => {
-        const ids = ["chunk-1" as DocumentID];
-        const nextFn = vi.fn();
-
-        const result = await arrivalWaitLayer.read(ids, { timeout: -1 }, nextFn);
-
-        expect(result).toEqual([false]);
+    it("returns immediately for an empty identifier list", async () => {
+        await expect(arrivalWaitLayer.read([], {}, vi.fn())).resolves.toEqual([]);
         expect(eventEmitter).not.toHaveBeenCalled();
     });
 
-    it("should emit missingChunks event when preventRemoteRequest is not set", async () => {
-        const ids = ["chunk-1" as DocumentID, "chunk-2" as DocumentID];
-        const nextFn = vi.fn();
+    it.each([{ waitForDelivery: false }, { timeout: 0 }, { timeout: -1 }])(
+        "returns immediately when delivery waiting is disabled by $waitForDelivery$timeout",
+        async (options) => {
+            await expect(arrivalWaitLayer.read(["chunk-1" as DocumentID], options, vi.fn())).resolves.toEqual([false]);
+            expect(eventEmitter).not.toHaveBeenCalled();
+        }
+    );
 
-        // Start waiting (do not await yet)
-        const promise = arrivalWaitLayer.read(ids, { timeout: 100 }, nextFn);
+    it.each([{}, { waitForDelivery: true }, { timeout: 1 }, { timeout: 60_000 }])(
+        "does not guess an arrival delay when no producer is observable with $timeout",
+        async (options) => {
+            const id = "chunk-1" as DocumentID;
 
-        // Event should be emitted immediately
-        expect(eventEmitter).toHaveBeenCalledWith("missingChunks", ids);
+            await expect(arrivalWaitLayer.read([id], options, vi.fn())).resolves.toEqual([false]);
 
-        // Clean up
-        await promise;
-    });
+            expect(eventEmitter).toHaveBeenCalledWith("missingChunks", [id]);
+            expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
+        }
+    );
 
-    it("should not emit missingChunks event when preventRemoteRequest is true", async () => {
-        const ids = ["chunk-1" as DocumentID];
-        const nextFn = vi.fn();
-
-        const promise = arrivalWaitLayer.read(ids, { timeout: 100, preventRemoteRequest: true }, nextFn);
+    it("does not dispatch a remote request when prevented", async () => {
+        await expect(
+            arrivalWaitLayer.read(
+                ["chunk-1" as DocumentID],
+                { preventRemoteRequest: true, waitForDelivery: true },
+                vi.fn()
+            )
+        ).resolves.toEqual([false]);
 
         expect(eventEmitter).not.toHaveBeenCalled();
-
-        // Clean up
-        await promise;
     });
 
-    it("should resolve with chunk when onChunkArrived is called", async () => {
-        const ids = ["chunk-1" as DocumentID];
-        const chunk = createMockLeaf("chunk-1");
-        const nextFn = vi.fn();
-
-        const promise = arrivalWaitLayer.read(ids, { timeout: 5000 }, nextFn);
-
-        // Simulate chunk arrival
-        arrivalWaitLayer.onChunkArrived(chunk);
-
-        const result = await promise;
-
-        expect(result).toEqual([chunk]);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
-    });
-
-    it("should resolve with false when onChunkArrived is called with deleted chunk", async () => {
-        const ids = ["chunk-1" as DocumentID];
-        const chunk = {
-            ...createMockLeaf("chunk-1"),
-            _deleted: true,
-        };
-        const nextFn = vi.fn();
-
-        const promise = arrivalWaitLayer.read(ids, { timeout: 5000 }, nextFn);
-
-        // Simulate deleted chunk arrival
-        arrivalWaitLayer.onChunkArrived(chunk as EntryLeaf);
-
-        const result = await promise;
-
-        expect(result).toEqual([false]);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
-    });
-
-    it("should resolve with false when onChunkArrived is called with deleted=true parameter", async () => {
-        const ids = ["chunk-1" as DocumentID];
-        const chunk = createMockLeaf("chunk-1");
-        const nextFn = vi.fn();
-
-        const promise = arrivalWaitLayer.read(ids, { timeout: 5000 }, nextFn);
-
-        // Simulate chunk arrival with deleted parameter
-        arrivalWaitLayer.onChunkArrived(chunk, true);
-
-        const result = await promise;
-
-        expect(result).toEqual([false]);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
-    });
-
-    it("should resolve with false when onMissingChunk is called", async () => {
-        const ids = ["chunk-1" as DocumentID];
-        const nextFn = vi.fn();
-
-        const promise = arrivalWaitLayer.read(ids, { timeout: 5000 }, nextFn);
-
-        // Simulate missing chunk notification
-        arrivalWaitLayer.onMissingChunk("chunk-1" as DocumentID);
-
-        const result = await promise;
-
-        expect(result).toEqual([false]);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
-    });
-
-    it("should timeout and return false after default timeout", async () => {
+    it("waits for a synchronously claimed on-demand delivery without a wall-clock deadline", async () => {
         vi.useFakeTimers();
-        const ids = ["chunk-1" as DocumentID];
-        const nextFn = vi.fn();
+        const coordinator = new ChunkDeliveryCoordinator();
+        let claim!: ChunkDeliveryClaim;
+        eventEmitter = vi.fn((_event: string, ids: DocumentID[]) => {
+            claim = coordinator.claim(ids, { stallTimeoutMs: 0 });
+        });
+        arrivalWaitLayer.tearDown();
+        arrivalWaitLayer = new ArrivalWaitLayer(eventEmitter, coordinator);
+        let settled = false;
 
-        const promise = arrivalWaitLayer.read(ids, { timeout: 100 }, nextFn);
+        const promise = arrivalWaitLayer.read(["chunk-1" as DocumentID], { waitForDelivery: true }, vi.fn());
+        void promise.then(() => {
+            settled = true;
+        });
+        await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+        expect(settled).toBe(false);
 
-        await vi.advanceTimersByTimeAsync(100);
-
-        const result = await promise;
-
-        expect(result).toEqual([false]);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
+        claim.release();
+        await expect(promise).resolves.toEqual([false]);
+        coordinator.dispose();
         vi.useRealTimers();
     });
 
-    it("should handle multiple chunks waiting simultaneously", async () => {
-        const ids = ["chunk-1" as DocumentID, "chunk-2" as DocumentID, "chunk-3" as DocumentID];
-        const chunk1 = createMockLeaf("chunk-1");
-        const chunk3 = createMockLeaf("chunk-3");
-        const nextFn = vi.fn();
-
-        const promise = arrivalWaitLayer.read(ids, { timeout: 5000 }, nextFn);
-
-        // Check waiting count
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(3);
-
-        // Resolve chunk-1 and chunk-3, let chunk-2 time out
-        arrivalWaitLayer.onChunkArrived(chunk1);
-        arrivalWaitLayer.onMissingChunk("chunk-2" as DocumentID);
-        arrivalWaitLayer.onChunkArrived(chunk3);
-
-        const result = await promise;
-
-        expect(result).toEqual([chunk1, false, chunk3]);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
-    });
-
-    it("should reuse existing promise for duplicate id requests", async () => {
-        const id = "chunk-1" as DocumentID;
+    it("resolves with a chunk delivered by an active claim", async () => {
+        const coordinator = new ChunkDeliveryCoordinator();
+        let claim!: ChunkDeliveryClaim;
+        eventEmitter = vi.fn((_event: string, ids: DocumentID[]) => {
+            claim = coordinator.claim(ids, { stallTimeoutMs: 0 });
+        });
+        arrivalWaitLayer.tearDown();
+        arrivalWaitLayer = new ArrivalWaitLayer(eventEmitter, coordinator);
         const chunk = createMockLeaf("chunk-1");
-        const nextFn = vi.fn();
 
-        // Start first request
-        const promise1 = arrivalWaitLayer.read([id], { timeout: 5000 }, nextFn);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(1);
-
-        // Start second request for the same id
-        const promise2 = arrivalWaitLayer.read([id], { timeout: 5000 }, nextFn);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(1); // Should still be 1
-
-        // Resolve the chunk
+        const promise = arrivalWaitLayer.read([chunk._id], { waitForDelivery: true }, vi.fn());
         arrivalWaitLayer.onChunkArrived(chunk);
 
-        const result1 = await promise1;
-        const result2 = await promise2;
-
-        expect(result1).toEqual([chunk]);
-        expect(result2).toEqual([chunk]);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
+        await expect(promise).resolves.toEqual([chunk]);
+        claim.release();
+        coordinator.dispose();
     });
 
-    it("should clear all waiting requests", async () => {
-        const ids = ["chunk-1" as DocumentID, "chunk-2" as DocumentID];
-        const nextFn = vi.fn();
+    it("resolves explicit remote absence while other activity remains", async () => {
+        const coordinator = new ChunkDeliveryCoordinator();
+        let claim!: ChunkDeliveryClaim;
+        eventEmitter = vi.fn((_event: string, ids: DocumentID[]) => {
+            claim = coordinator.claim(ids, { stallTimeoutMs: 0 });
+        });
+        arrivalWaitLayer.tearDown();
+        arrivalWaitLayer = new ArrivalWaitLayer(eventEmitter, coordinator);
+        const id = "chunk-1" as DocumentID;
 
-        // Start waiting with long timeout
-        const promise = arrivalWaitLayer.read(ids, { timeout: 5000 }, nextFn);
+        const promise = arrivalWaitLayer.read([id], { waitForDelivery: true }, vi.fn());
+        arrivalWaitLayer.onMissingChunk(id);
 
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(2);
+        await expect(promise).resolves.toEqual([false]);
+        claim.release();
+        coordinator.dispose();
+    });
 
-        // Clear waiting - should resolve all promises immediately
+    it("treats a deleted chunk arrival as unavailable", async () => {
+        const coordinator = new ChunkDeliveryCoordinator();
+        let claim!: ChunkDeliveryClaim;
+        eventEmitter = vi.fn((_event: string, ids: DocumentID[]) => {
+            claim = coordinator.claim(ids, { stallTimeoutMs: 0 });
+        });
+        arrivalWaitLayer.tearDown();
+        arrivalWaitLayer = new ArrivalWaitLayer(eventEmitter, coordinator);
+        const chunk = createMockLeaf("chunk-1");
+
+        const promise = arrivalWaitLayer.read([chunk._id], { waitForDelivery: true }, vi.fn());
+        arrivalWaitLayer.onChunkArrived(chunk, true);
+
+        await expect(promise).resolves.toEqual([false]);
+        claim.release();
+        coordinator.dispose();
+    });
+
+    it("rechecks local availability when observed finite replication completes", async () => {
+        const finiteActivity = reactiveSource(1);
+        const coordinator = new ChunkDeliveryCoordinator(finiteActivity);
+        const chunk = createMockLeaf("chunk-1");
+        const recheckAvailability = vi.fn().mockResolvedValue([chunk]);
+        arrivalWaitLayer.tearDown();
+        arrivalWaitLayer = new ArrivalWaitLayer(eventEmitter, coordinator, recheckAvailability);
+
+        const promise = arrivalWaitLayer.read(
+            [chunk._id],
+            { preventRemoteRequest: true, waitForDelivery: true },
+            vi.fn()
+        );
+        finiteActivity.value = 0;
+
+        await expect(promise).resolves.toEqual([chunk]);
+        expect(recheckAvailability).toHaveBeenCalledWith([chunk._id]);
+        coordinator.dispose();
+    });
+
+    it("settles unavailable after a finite producer completes and the local recheck misses", async () => {
+        const finiteActivity = reactiveSource(1);
+        const coordinator = new ChunkDeliveryCoordinator(finiteActivity);
+        const recheckAvailability = vi.fn().mockResolvedValue([false]);
+        arrivalWaitLayer.tearDown();
+        arrivalWaitLayer = new ArrivalWaitLayer(eventEmitter, coordinator, recheckAvailability);
+        const id = "chunk-1" as DocumentID;
+
+        const promise = arrivalWaitLayer.read([id], { preventRemoteRequest: true, waitForDelivery: true }, vi.fn());
+        finiteActivity.value = 0;
+
+        await expect(promise).resolves.toEqual([false]);
+        expect(recheckAvailability).toHaveBeenCalledWith([id]);
+        coordinator.dispose();
+    });
+
+    it("discards a stale recheck when finite replication starts again", async () => {
+        const finiteActivity = reactiveSource(1);
+        const coordinator = new ChunkDeliveryCoordinator(finiteActivity);
+        const chunk = createMockLeaf("chunk-1");
+        let resolveFirstRecheck!: (value: readonly (EntryLeaf | false)[]) => void;
+        const firstRecheck = new Promise<readonly (EntryLeaf | false)[]>((resolve) => {
+            resolveFirstRecheck = resolve;
+        });
+        const recheckAvailability = vi
+            .fn()
+            .mockImplementationOnce(() => firstRecheck)
+            .mockResolvedValueOnce([chunk]);
+        arrivalWaitLayer.tearDown();
+        arrivalWaitLayer = new ArrivalWaitLayer(eventEmitter, coordinator, recheckAvailability);
+        let settled = false;
+
+        const promise = arrivalWaitLayer.read(
+            [chunk._id],
+            { preventRemoteRequest: true, waitForDelivery: true },
+            vi.fn()
+        );
+        void promise.then(() => {
+            settled = true;
+        });
+        finiteActivity.value = 0;
+        await vi.waitFor(() => expect(recheckAvailability).toHaveBeenCalledOnce());
+
+        finiteActivity.value = 1;
+        resolveFirstRecheck([false]);
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        finiteActivity.value = 0;
+        await expect(promise).resolves.toEqual([chunk]);
+        expect(recheckAvailability).toHaveBeenCalledTimes(2);
+        coordinator.dispose();
+    });
+
+    it("shares one waiter for concurrent reads of the same identifier", async () => {
+        const coordinator = new ChunkDeliveryCoordinator();
+        let claim: ChunkDeliveryClaim | undefined;
+        eventEmitter = vi.fn((_event: string, ids: DocumentID[]) => {
+            claim ??= coordinator.claim(ids, { stallTimeoutMs: 0 });
+        });
+        arrivalWaitLayer.tearDown();
+        arrivalWaitLayer = new ArrivalWaitLayer(eventEmitter, coordinator);
+        const chunk = createMockLeaf("chunk-1");
+
+        const first = arrivalWaitLayer.read([chunk._id], { waitForDelivery: true }, vi.fn());
+        const second = arrivalWaitLayer.read([chunk._id], { waitForDelivery: true }, vi.fn());
+        expect(arrivalWaitLayer.getWaitingCount()).toBe(1);
+
+        arrivalWaitLayer.onChunkArrived(chunk);
+        await expect(first).resolves.toEqual([chunk]);
+        await expect(second).resolves.toEqual([chunk]);
+        claim?.release();
+        coordinator.dispose();
+    });
+
+    it("clears every pending waiter during teardown", async () => {
+        const coordinator = new ChunkDeliveryCoordinator();
+        let claim!: ChunkDeliveryClaim;
+        eventEmitter = vi.fn((_event: string, ids: DocumentID[]) => {
+            claim = coordinator.claim(ids, { stallTimeoutMs: 0 });
+        });
+        arrivalWaitLayer.tearDown();
+        arrivalWaitLayer = new ArrivalWaitLayer(eventEmitter, coordinator);
+
+        const promise = arrivalWaitLayer.read(
+            ["chunk-1" as DocumentID, "chunk-2" as DocumentID],
+            { waitForDelivery: true },
+            vi.fn()
+        );
         arrivalWaitLayer.clearWaiting();
 
+        await expect(promise).resolves.toEqual([false, false]);
         expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
-
-        // The promises should resolve immediately with false
-        const result = await promise;
-        expect(result).toEqual([false, false]);
+        claim.release();
+        coordinator.dispose();
     });
 
-    it("should handle onChunkArrived for non-waiting chunk gracefully", () => {
-        const chunk = createMockLeaf("chunk-1");
-
-        // Call onChunkArrived without any waiting request
-        expect(() => {
-            arrivalWaitLayer.onChunkArrived(chunk);
-        }).not.toThrow();
-
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
-    });
-
-    it("should handle onMissingChunk for non-waiting chunk gracefully", () => {
-        // Call onMissingChunk without any waiting request
-        expect(() => {
-            arrivalWaitLayer.onMissingChunk("chunk-1" as DocumentID);
-        }).not.toThrow();
-
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
-    });
-
-    it("should use default timeout when timeout option is not provided", async () => {
-        const ids = ["chunk-1" as DocumentID];
-        const nextFn = vi.fn();
-
-        // Start waiting without timeout option (should use default 15000ms)
-        const promise = arrivalWaitLayer.read(ids, {}, nextFn);
-
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(1);
-
-        // Resolve immediately to avoid waiting for default timeout
-        arrivalWaitLayer.onMissingChunk("chunk-1" as DocumentID);
-
-        const result = await promise;
-        expect(result).toEqual([false]);
-    });
-
-    it("should handle chunk arrival before read completion", async () => {
-        const ids = ["chunk-1" as DocumentID];
-        const chunk = createMockLeaf("chunk-1");
-        const nextFn = vi.fn();
-
-        const promise = arrivalWaitLayer.read(ids, { timeout: 5000 }, nextFn);
-
-        // Arrive chunk almost immediately
-        setTimeout(() => {
-            arrivalWaitLayer.onChunkArrived(chunk);
-        }, 10);
-
-        const result = await promise;
-
-        expect(result).toEqual([chunk]);
-    });
-
-    it("should maintain correct waiting count during concurrent operations", async () => {
-        const nextFn = vi.fn();
-
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
-
-        // Start first request
-        const promise1 = arrivalWaitLayer.read(["chunk-1" as DocumentID], { timeout: 5000 }, nextFn);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(1);
-
-        // Start second request
-        const promise2 = arrivalWaitLayer.read(["chunk-2" as DocumentID], { timeout: 5000 }, nextFn);
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(2);
-
-        // Resolve first
-        arrivalWaitLayer.onMissingChunk("chunk-1" as DocumentID);
-        await promise1;
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(1);
-
-        // Resolve second
-        arrivalWaitLayer.onMissingChunk("chunk-2" as DocumentID);
-        await promise2;
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
-    });
-
-    it("should handle timeout cleanup correctly", async () => {
-        const ids = ["chunk-1" as DocumentID];
-        const chunk = createMockLeaf("chunk-1");
-        const nextFn = vi.fn();
-
-        // Set a timeout and resolve before it expires
-        const promise = arrivalWaitLayer.read(ids, { timeout: 1000 }, nextFn);
-
-        // Resolve immediately
-        arrivalWaitLayer.onChunkArrived(chunk);
-
-        const result = await promise;
-
-        expect(result).toEqual([chunk]);
-
-        // Wait a bit to ensure timeout was cleared
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        // Waiting count should still be 0
-        expect(arrivalWaitLayer.getWaitingCount()).toBe(0);
+    it("handles terminal events for identifiers without waiters", () => {
+        expect(() => arrivalWaitLayer.onChunkArrived(createMockLeaf("chunk-1"))).not.toThrow();
+        expect(() => arrivalWaitLayer.onMissingChunk("chunk-1" as DocumentID)).not.toThrow();
     });
 });

--- a/src/managers/LayeredChunkManager/types.ts
+++ b/src/managers/LayeredChunkManager/types.ts
@@ -3,16 +3,22 @@ import type { DocumentID, EntryLeaf } from "@lib/common/models/db.type";
 import type { ISettingService } from "@lib/services/base/IService";
 import type { ChangeManager } from "@lib/managers/ChangeManager";
 import type { EVENT_CHUNK_FETCHED, EVENT_MISSING_CHUNK_REMOTE, EVENT_MISSING_CHUNKS } from "@lib/managers/ChunkFetcher";
+import type { ActivityCountSource } from "@lib/managers/ChunkDeliveryCoordinator";
 
 export type ChunkManagerOptions = {
     database: PouchDB.Database<EntryDoc>;
     changeManager: ChangeManager<EntryDoc>;
     // maxCacheSize?: number; // Maximum cache size
     settingService: ISettingService;
+    /** Finite replication which may still deliver a requested chunk. */
+    finiteReplicationActivity?: ActivityCountSource;
 };
 export type ChunkReadOptions = {
     skipCache?: boolean; // Skip cache when reading
-    timeout?: number; // Timeout in milliseconds
+    /** Wait for an already-observable finite delivery lifecycle. */
+    waitForDelivery?: boolean;
+    /** @deprecated Use `waitForDelivery`. Positive values no longer represent an arrival duration. */
+    timeout?: number;
     preventRemoteRequest?: boolean; // Prevent dispatching missing chunk event
 };
 export type ChunkWriteOptions = {

--- a/src/managers/LiveSyncManagers.ts
+++ b/src/managers/LiveSyncManagers.ts
@@ -95,6 +95,7 @@ export class LiveSyncManagers {
             changeManager: changeManager,
             database,
             settingService: this.options.settingService,
+            finiteReplicationActivity: this.options.replicatorService.finiteReplicationActivityCount,
         });
         const chunkFetcher = new ChunkFetcher({
             chunkManager: chunkManager,

--- a/src/replication/couchdb/LiveSyncReplicator.ts
+++ b/src/replication/couchdb/LiveSyncReplicator.ts
@@ -893,7 +893,11 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             }
             const localDB = this.rawDatabase;
             Logger($msg("liveSyncReplicator.beforeLiveSync"));
-            if (await this.openOneShotReplication(setting, showResult, false, "pullOnly")) {
+            const caughtUp = await this.env.services.replicator.runFiniteReplicationActivity(
+                () => this.openOneShotReplication(setting, showResult, false, "pullOnly"),
+                { label: "replication" }
+            );
+            if (caughtUp) {
                 Logger($msg("liveSyncReplicator.liveSyncBegin"));
                 const ret = await this.checkReplicationConnectivity(setting, true, true, showResult);
                 if (ret === false) {

--- a/src/replication/couchdb/LiveSyncReplicator.unit.spec.ts
+++ b/src/replication/couchdb/LiveSyncReplicator.unit.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RemoteDBSettings } from "@lib/common/types.ts";
+import { LiveSyncCouchDBReplicator } from "./LiveSyncReplicator.ts";
+
+describe("LiveSyncCouchDBReplicator continuous catch-up", () => {
+    it("exposes the initial pull-only catch-up as finite replication activity", async () => {
+        const runFiniteReplicationActivity = vi.fn(async <T>(task: () => Promise<T>) => await task());
+        const replicator = Object.create(LiveSyncCouchDBReplicator.prototype) as LiveSyncCouchDBReplicator;
+        replicator.env = {
+            services: {
+                database: {
+                    localDatabase: {
+                        localDatabase: {},
+                    },
+                },
+                replicator: {
+                    runFiniteReplicationActivity,
+                },
+            },
+        } as unknown as LiveSyncCouchDBReplicator["env"];
+        const catchUp = vi.spyOn(replicator, "openOneShotReplication").mockResolvedValue(false);
+        const setting = {} as RemoteDBSettings;
+
+        await expect(replicator.openContinuousReplication(setting, false, false)).resolves.toBe(false);
+
+        expect(runFiniteReplicationActivity).toHaveBeenCalledOnce();
+        expect(runFiniteReplicationActivity).toHaveBeenCalledWith(expect.any(Function), { label: "replication" });
+        expect(catchUp).toHaveBeenCalledWith(setting, false, false, "pullOnly");
+    });
+
+    it("starts another finite catch-up when the live channel retries with smaller batches", async () => {
+        const runFiniteReplicationActivity = vi.fn(async <T>(task: () => Promise<T>) => await task());
+        const localDatabase = {
+            info: vi.fn().mockResolvedValue({ update_seq: 7 }),
+            sync: vi.fn(() => ({})),
+        };
+        const replicator = Object.create(LiveSyncCouchDBReplicator.prototype) as LiveSyncCouchDBReplicator;
+        replicator.env = {
+            services: {
+                database: {
+                    localDatabase: { localDatabase },
+                },
+                replicator: { runFiniteReplicationActivity },
+            },
+        } as unknown as LiveSyncCouchDBReplicator["env"];
+        replicator.docArrived = 0;
+        replicator.docSent = 0;
+        replicator.updateInfo = vi.fn();
+        replicator.terminateSync = vi.fn();
+        const catchUp = vi
+            .spyOn(replicator, "openOneShotReplication")
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce(false);
+        vi.spyOn(replicator, "checkReplicationConnectivity").mockResolvedValue({
+            db: {},
+            info: { update_seq: 9 },
+            syncOption: {},
+        } as never);
+        vi.spyOn(replicator, "processSync").mockResolvedValue("NEED_RETRY");
+        const setting = {
+            batch_size: 20,
+            batches_limit: 20,
+        } as RemoteDBSettings;
+
+        await expect(replicator.openContinuousReplication(setting, false, false)).resolves.toBe(false);
+
+        expect(runFiniteReplicationActivity).toHaveBeenCalledTimes(2);
+        expect(catchUp).toHaveBeenNthCalledWith(1, setting, false, false, "pullOnly");
+        expect(catchUp).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ batch_size: 12, batches_limit: 12 }),
+            false,
+            false,
+            "pullOnly"
+        );
+    });
+});

--- a/src/replication/journal/objectstore/MinioStorageAdapter.integration.spec.ts
+++ b/src/replication/journal/objectstore/MinioStorageAdapter.integration.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { MinioStorageAdapter } from "./MinioStorageAdapter.ts";
 import type { BucketSyncSetting } from "@lib/common/types.ts";
 import type { LiveSyncJournalReplicatorEnv } from "@lib/replication/journal/LiveSyncJournalReplicatorEnv.ts";
+import { reactiveSource } from "octagonal-wheels/dataobject/reactive";
 
 describe("MinioStorageAdapter Integration Tests", () => {
     // Requires minioEndpoint, accessKey, secretKey, bucketName in env
@@ -25,11 +26,16 @@ describe("MinioStorageAdapter Integration Tests", () => {
             bucketCustomHeaders: "",
         } as BucketSyncSetting;
 
+        const requestCount = reactiveSource(0);
+        const responseCount = reactiveSource(0);
+
         // Mock env
         const env = {
             services: {
                 API: {
                     getCustomFetchHandler: () => undefined,
+                    requestCount,
+                    responseCount,
                 },
             },
         } as unknown as LiveSyncJournalReplicatorEnv;
@@ -62,6 +68,8 @@ describe("MinioStorageAdapter Integration Tests", () => {
         // List again
         const filesAfterDelete = await adapter.listFiles("");
         expect(filesAfterDelete).not.toContain(testKey);
+        expect(requestCount.value).toBeGreaterThan(0);
+        expect(responseCount.value).toBe(requestCount.value);
     });
 
     it("skips tests if MinIO environment variables are not set", () => {

--- a/src/replication/journal/objectstore/MinioStorageAdapter.ts
+++ b/src/replication/journal/objectstore/MinioStorageAdapter.ts
@@ -18,6 +18,7 @@ import type { RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator
 import type { IJournalStorage } from "./JournalStorageAdapter.ts";
 import { parseHeaderValues } from "@lib/common/utils.ts";
 import type { LiveSyncJournalReplicatorEnv } from "@lib/replication/journal/LiveSyncJournalReplicatorEnv.ts";
+import { runWithTrackedPhysicalRequest } from "@lib/services/lib/remoteActivity.ts";
 
 export class MinioStorageAdapter implements IJournalStorage {
     _instance?: S3;
@@ -27,6 +28,10 @@ export class MinioStorageAdapter implements IJournalStorage {
     constructor(settings: BucketSyncSetting, env: LiveSyncJournalReplicatorEnv) {
         this._settings = settings;
         this._env = env;
+    }
+
+    private async runTrackedRequest<T>(task: () => T | PromiseLike<T>): Promise<T> {
+        return await runWithTrackedPhysicalRequest(this._env.services.API, task);
     }
 
     applyNewConfig(settings: BucketSyncSetting): void {
@@ -121,7 +126,7 @@ export class MinioStorageAdapter implements IJournalStorage {
                 Body: data,
                 ContentType: mime,
             });
-            if (await client.send(cmd)) {
+            if (await this.runTrackedRequest(() => client.send(cmd))) {
                 return true;
             }
         } catch (ex) {
@@ -140,10 +145,13 @@ export class MinioStorageAdapter implements IJournalStorage {
         });
 
         try {
-            const r = await client.send(cmd);
-            if (r.Body) {
-                return new Uint8Array(await r.Body.transformToByteArray());
-            }
+            return await this.runTrackedRequest(async () => {
+                const r = await client.send(cmd);
+                if (r.Body) {
+                    return new Uint8Array(await r.Body.transformToByteArray());
+                }
+                return false;
+            });
         } catch (ex) {
             Logger(`Could not download ${key}`);
             Logger(ex, LOG_LEVEL_VERBOSE);
@@ -153,12 +161,14 @@ export class MinioStorageAdapter implements IJournalStorage {
 
     async listFiles(from: string, limit?: number): Promise<string[]> {
         const client = this._getClient();
-        const objects = await client.listObjectsV2({
-            Bucket: this._settings.bucket,
-            Prefix: this._settings.bucketPrefix,
-            StartAfter: `${this._settings.bucketPrefix || ""}${from || ""}`,
-            ...(limit ? { MaxKeys: limit } : {}),
-        });
+        const objects = await this.runTrackedRequest(() =>
+            client.listObjectsV2({
+                Bucket: this._settings.bucket,
+                Prefix: this._settings.bucketPrefix,
+                StartAfter: `${this._settings.bucketPrefix || ""}${from || ""}`,
+                ...(limit ? { MaxKeys: limit } : {}),
+            })
+        );
         if (!objects.Contents) return [];
         return objects.Contents.filter((e) => e.Key?.startsWith(this._settings.bucketPrefix)).map((e) =>
             e.Key?.substring(this._settings.bucketPrefix.length)
@@ -175,7 +185,7 @@ export class MinioStorageAdapter implements IJournalStorage {
                     Objects: keys.map((e) => ({ Key: `${this._settings.bucketPrefix}${e}` })),
                 },
             });
-            const r = await client.send(cmd);
+            const r = await this.runTrackedRequest(() => client.send(cmd));
             const { Deleted, Errors } = r;
             const deleteCount = Deleted?.length || 0;
             const errorCount = Errors?.length || 0;
@@ -196,7 +206,7 @@ export class MinioStorageAdapter implements IJournalStorage {
         const client = this._getClient();
         const cmd = new HeadBucketCommand({ Bucket: this._settings.bucket });
         try {
-            await client.send(cmd);
+            await this.runTrackedRequest(() => client.send(cmd));
             return true;
         } catch (ex) {
             Logger(`Could not connect to the remote bucket`, LOG_LEVEL_NOTICE);
@@ -208,7 +218,7 @@ export class MinioStorageAdapter implements IJournalStorage {
     async getUsage(): Promise<false | RemoteDBStatus> {
         const client = this._getClient();
         try {
-            const objects = await client.listObjectsV2({ Bucket: this._settings.bucket });
+            const objects = await this.runTrackedRequest(() => client.listObjectsV2({ Bucket: this._settings.bucket }));
             if (!objects.Contents) return {};
             return {
                 estimatedSize: objects.Contents.reduce((acc, e) => acc + (e.Size || 0), 0),

--- a/src/replication/journal/objectstore/MinioStorageAdapter.unit.spec.ts
+++ b/src/replication/journal/objectstore/MinioStorageAdapter.unit.spec.ts
@@ -1,0 +1,142 @@
+import type { S3 } from "@aws-sdk/client-s3";
+import type { FetchHttpHandler } from "@smithy/fetch-http-handler";
+import { HttpResponse } from "@smithy/protocol-http";
+import { reactiveSource } from "octagonal-wheels/dataobject/reactive";
+import { promiseWithResolvers } from "octagonal-wheels/promises";
+import { describe, expect, it, vi } from "vitest";
+
+import type { BucketSyncSetting } from "@lib/common/types.ts";
+import type { LiveSyncJournalReplicatorEnv } from "@lib/replication/journal/LiveSyncJournalReplicatorEnv.ts";
+import { MinioStorageAdapter } from "./MinioStorageAdapter.ts";
+
+type MockS3Client = {
+    listObjectsV2?: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+};
+
+function createAdapter(client: MockS3Client) {
+    const requestCount = reactiveSource(0);
+    const responseCount = reactiveSource(0);
+    const settings = {
+        endpoint: "https://example.invalid",
+        accessKey: "access-key",
+        secretKey: "secret-key",
+        bucket: "bucket",
+        region: "us-east-1",
+        bucketPrefix: "test/",
+        forcePathStyle: true,
+        useCustomRequestHandler: false,
+        bucketCustomHeaders: "",
+    } as BucketSyncSetting;
+    const env = {
+        services: {
+            API: {
+                getCustomFetchHandler: () => undefined,
+                requestCount,
+                responseCount,
+            },
+        },
+    } as unknown as LiveSyncJournalReplicatorEnv;
+    const adapter = new MinioStorageAdapter(settings, env);
+    adapter._instance = client as unknown as S3;
+    return { adapter, requestCount, responseCount };
+}
+
+describe("MinioStorageAdapter physical request activity", () => {
+    it("tracks an SDK command while it is in progress", async () => {
+        const request = promiseWithResolvers<object>();
+        const { adapter, requestCount, responseCount } = createAdapter({ send: vi.fn(() => request.promise) });
+
+        const uploading = adapter.upload("file.txt", new TextEncoder().encode("content"), "text/plain");
+
+        await vi.waitFor(() => expect(requestCount.value - responseCount.value).toBe(1));
+        request.resolve({});
+        await expect(uploading).resolves.toBe(true);
+        expect(requestCount.value).toBe(1);
+        expect(responseCount.value).toBe(1);
+    });
+
+    it("keeps a download active until its response body has been consumed", async () => {
+        const body = promiseWithResolvers<Uint8Array>();
+        const send = vi.fn(() =>
+            Promise.resolve({
+                Body: {
+                    transformToByteArray: () => body.promise,
+                },
+            })
+        );
+        const { adapter, requestCount, responseCount } = createAdapter({ send });
+
+        const downloading = adapter.download("file.txt");
+
+        await vi.waitFor(() => expect(requestCount.value - responseCount.value).toBe(1));
+        body.resolve(new Uint8Array([1, 2, 3]));
+        await expect(downloading).resolves.toEqual(new Uint8Array([1, 2, 3]));
+        expect(requestCount.value).toBe(1);
+        expect(responseCount.value).toBe(1);
+    });
+
+    it("balances activity when an SDK command rejects", async () => {
+        const { adapter, requestCount, responseCount } = createAdapter({
+            send: vi.fn(() => Promise.reject(new Error("network failed"))),
+        });
+
+        await expect(adapter.upload("file.txt", new Uint8Array(), "text/plain")).resolves.toBe(false);
+
+        expect(requestCount.value).toBe(1);
+        expect(responseCount.value).toBe(1);
+    });
+
+    it("tracks each supported Object Storage command unit", async () => {
+        const send = vi.fn(() => Promise.resolve({}));
+        const listObjectsV2 = vi.fn(() => Promise.resolve({ Contents: [] }));
+        const { adapter, requestCount, responseCount } = createAdapter({ listObjectsV2, send });
+
+        await expect(adapter.listFiles("")).resolves.toEqual([]);
+        await expect(adapter.deleteFiles(["file.txt"])).resolves.toBe(true);
+        await expect(adapter.isAvailable()).resolves.toBe(true);
+        await expect(adapter.getUsage()).resolves.toEqual({ estimatedSize: 0 });
+
+        expect(requestCount.value).toBe(4);
+        expect(responseCount.value).toBe(4);
+    });
+
+    it("tracks the custom request-handler path once at the SDK command boundary", async () => {
+        const request = promiseWithResolvers<{ response: HttpResponse }>();
+        const handle = vi.fn(() => request.promise);
+        const requestCount = reactiveSource(0);
+        const responseCount = reactiveSource(0);
+        const env = {
+            services: {
+                API: {
+                    getCustomFetchHandler: () => ({ handle }) as unknown as FetchHttpHandler,
+                    requestCount,
+                    responseCount,
+                },
+            },
+        } as unknown as LiveSyncJournalReplicatorEnv;
+        const settings = {
+            endpoint: "https://example.invalid",
+            accessKey: "access-key",
+            secretKey: "secret-key",
+            bucket: "bucket",
+            region: "us-east-1",
+            bucketPrefix: "test/",
+            forcePathStyle: true,
+            useCustomRequestHandler: true,
+            bucketCustomHeaders: "",
+        } as BucketSyncSetting;
+        const adapter = new MinioStorageAdapter(settings, env);
+
+        const uploading = adapter.upload("file.txt", new TextEncoder().encode("content"), "text/plain");
+
+        await vi.waitFor(() => {
+            expect(requestCount.value - responseCount.value).toBe(1);
+            expect(handle).toHaveBeenCalledOnce();
+        });
+        request.resolve({ response: new HttpResponse({ headers: {}, statusCode: 200 }) });
+        await expect(uploading).resolves.toBe(true);
+        expect(requestCount.value).toBe(1);
+        expect(responseCount.value).toBe(1);
+    });
+});

--- a/src/replication/trystero/LiveSyncTrysteroReplicator.ts
+++ b/src/replication/trystero/LiveSyncTrysteroReplicator.ts
@@ -91,8 +91,8 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
             get confirm() {
                 return services.API.confirm;
             },
-            runBoundedRemoteActivity: <T>(task: () => T | PromiseLike<T>, options?: AsyncActivityOptions) =>
-                services.replicator.runBoundedRemoteActivity(task, options),
+            runFiniteReplicationActivity: <T>(task: () => T | PromiseLike<T>, options?: AsyncActivityOptions) =>
+                services.replicator.runFiniteReplicationActivity(task, options),
             processReplicatedDocs: async (docs: Parameters<typeof services.replication.parseSynchroniseResult>[0]) => {
                 const settings = services.setting.currentSettings();
                 if (settings.suspendParseReplicationResult) {
@@ -179,15 +179,16 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
     async replicateFromCommand(showResult: boolean = false) {
         const replicator = this._replicator;
         if (!replicator) return;
-        await this.env.services.replicator.runBoundedRemoteActivity(() => replicator.replicateFromCommand(showResult), {
-            label: "replication",
-        });
+        await this.env.services.replicator.runFiniteReplicationActivity(
+            () => replicator.replicateFromCommand(showResult),
+            { label: "replication" }
+        );
     }
 
     async replicateFrom(peerId: string, showNotice: boolean = false) {
         const replicator = this._replicator;
         if (!replicator) throw new Error("P2P replicator is not open");
-        return await this.env.services.replicator.runBoundedRemoteActivity(
+        return await this.env.services.replicator.runFiniteReplicationActivity(
             () => replicator.replicateFrom(peerId, showNotice),
             { label: "replication" }
         );

--- a/src/replication/trystero/LiveSyncTrysteroReplicator.unit.spec.ts
+++ b/src/replication/trystero/LiveSyncTrysteroReplicator.unit.spec.ts
@@ -2,36 +2,36 @@ import { describe, expect, it, vi } from "vitest";
 import { LiveSyncTrysteroReplicator } from "./LiveSyncTrysteroReplicator";
 
 describe("LiveSyncTrysteroReplicator host environment", () => {
-    it("forwards raw P2P activity to the shared bounded-activity owner", async () => {
-        const runBoundedRemoteActivity = vi.fn(async (task: () => unknown) => await task());
+    it("forwards raw P2P activity to the shared finite-replication owner", async () => {
+        const runFiniteReplicationActivity = vi.fn(async (task: () => unknown) => await task());
         const replicator = new LiveSyncTrysteroReplicator({
             services: {
-                replicator: { runBoundedRemoteActivity },
+                replicator: { runFiniteReplicationActivity },
             },
         } as any);
         const env = (replicator as any)._buildEnv();
         const task = vi.fn(() => "done");
 
-        await expect(env.runBoundedRemoteActivity(task, { label: "replication" })).resolves.toBe("done");
+        await expect(env.runFiniteReplicationActivity(task, { label: "replication" })).resolves.toBe("done");
 
-        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(task, { label: "replication" });
+        expect(runFiniteReplicationActivity).toHaveBeenCalledWith(task, { label: "replication" });
     });
 });
 
 describe("LiveSyncTrysteroReplicator manual replication", () => {
     it("runs a finite command-triggered synchronisation through the shared activity boundary", async () => {
         const replicateFromCommand = vi.fn(async () => undefined);
-        const runBoundedRemoteActivity = vi.fn(async (task: () => unknown) => await task());
+        const runFiniteReplicationActivity = vi.fn(async (task: () => unknown) => await task());
         const replicator = new LiveSyncTrysteroReplicator({
             services: {
-                replicator: { runBoundedRemoteActivity },
+                replicator: { runFiniteReplicationActivity },
             },
         } as any);
         (replicator as any)._replicator = { replicateFromCommand };
 
         await replicator.replicateFromCommand(true);
 
-        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
+        expect(runFiniteReplicationActivity).toHaveBeenCalledWith(expect.any(Function), {
             label: "replication",
         });
         expect(replicateFromCommand).toHaveBeenCalledWith(true);
@@ -39,28 +39,29 @@ describe("LiveSyncTrysteroReplicator manual replication", () => {
 
     it("tracks a direct pull from a peer as finite remote activity", async () => {
         const replicateFrom = vi.fn(async () => ({ ok: true }));
-        const runBoundedRemoteActivity = vi.fn(async (task: () => unknown) => await task());
+        const runFiniteReplicationActivity = vi.fn(async (task: () => unknown) => await task());
         const replicator = new LiveSyncTrysteroReplicator({
             services: {
-                replicator: { runBoundedRemoteActivity },
+                replicator: { runFiniteReplicationActivity },
             },
         } as any);
         (replicator as any)._replicator = { replicateFrom };
 
         await expect(replicator.replicateFrom("peer-a", true)).resolves.toEqual({ ok: true });
 
-        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
+        expect(runFiniteReplicationActivity).toHaveBeenCalledWith(expect.any(Function), {
             label: "replication",
         });
         expect(replicateFrom).toHaveBeenCalledWith("peer-a", true);
     });
 
-    it("tracks a direct push to a peer as finite remote activity", async () => {
+    it("keeps a direct push broad without presenting it as a local delivery source", async () => {
         const requestSynchroniseToPeer = vi.fn(async () => ({ ok: true }));
         const runBoundedRemoteActivity = vi.fn(async (task: () => unknown) => await task());
+        const runFiniteReplicationActivity = vi.fn(async (task: () => unknown) => await task());
         const replicator = new LiveSyncTrysteroReplicator({
             services: {
-                replicator: { runBoundedRemoteActivity },
+                replicator: { runBoundedRemoteActivity, runFiniteReplicationActivity },
             },
         } as any);
         (replicator as any)._replicator = { requestSynchroniseToPeer };
@@ -70,6 +71,7 @@ describe("LiveSyncTrysteroReplicator manual replication", () => {
         expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
             label: "replication",
         });
+        expect(runFiniteReplicationActivity).not.toHaveBeenCalled();
         expect(requestSynchroniseToPeer).toHaveBeenCalledWith("peer-a");
     });
 });

--- a/src/replication/trystero/TrysteroReplicator.ts
+++ b/src/replication/trystero/TrysteroReplicator.ts
@@ -108,9 +108,9 @@ export class TrysteroReplicator {
         return this._env.confirm;
     }
 
-    private async runBoundedRemoteActivity<T>(task: () => T | PromiseLike<T>): Promise<T> {
-        if (this._env.runBoundedRemoteActivity) {
-            return await this._env.runBoundedRemoteActivity(task, { label: "replication" });
+    private async runFiniteReplicationActivity<T>(task: () => T | PromiseLike<T>): Promise<T> {
+        if (this._env.runFiniteReplicationActivity) {
+            return await this._env.runFiniteReplicationActivity(task, { label: "replication" });
         }
         return await task();
     }
@@ -184,7 +184,7 @@ export class TrysteroReplicator {
     async onNewPeer(peer: Advertisement) {
         const peerName = peer.name;
         if (this.autoSyncPeers.some((e) => e.test(peerName))) {
-            await this.runBoundedRemoteActivity(() => this.sync(peer.peerId));
+            await this.runFiniteReplicationActivity(() => this.sync(peer.peerId));
         }
         if (this.autoWatchPeers.some((e) => e.test(peerName))) {
             this.watchPeer(peer.peerId);
@@ -225,7 +225,7 @@ export class TrysteroReplicator {
                 if (this._onSetup) {
                     return { error: new Error("The setup is in progress") };
                 }
-                const result = await this.runBoundedRemoteActivity(() => this.replicateFrom(fromPeerId));
+                const result = await this.runFiniteReplicationActivity(() => this.replicateFrom(fromPeerId));
                 return result;
             },
             "!reqAuth": async (fromPeerId: string) => {
@@ -671,7 +671,7 @@ export class TrysteroReplicator {
         if (this._watchingPeers.has(fromPeerId)) {
             Logger(`Progress notification from ${fromPeerId}`, LOG_LEVEL_VERBOSE);
             return await serialized(`onProgress-${fromPeerId}`, async () => {
-                return await this.runBoundedRemoteActivity(() => this.replicateFrom(fromPeerId));
+                return await this.runFiniteReplicationActivity(() => this.replicateFrom(fromPeerId));
             });
         }
         return false;

--- a/src/replication/trystero/TrysteroReplicator.unit.spec.ts
+++ b/src/replication/trystero/TrysteroReplicator.unit.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { TrysteroReplicator } from "./TrysteroReplicator";
 
 function createReplicator(settings: Record<string, unknown> = {}) {
-    const runBoundedRemoteActivity = vi.fn(async (task: () => unknown) => await task());
+    const runFiniteReplicationActivity = vi.fn(async (task: () => unknown) => await task());
     const replicator = new TrysteroReplicator(
         {
             settings: {
@@ -16,50 +16,50 @@ function createReplicator(settings: Record<string, unknown> = {}) {
             platform: "test",
             confirm: {},
             processReplicatedDocs: vi.fn(),
-            runBoundedRemoteActivity,
+            runFiniteReplicationActivity,
         } as any,
         {
             _knownAdvertisements: new Map(),
         } as any
     );
-    return { replicator, runBoundedRemoteActivity };
+    return { replicator, runFiniteReplicationActivity };
 }
 
 describe("TrysteroReplicator automatic remote activity", () => {
     it("tracks automatic synchronisation when a configured peer is discovered", async () => {
-        const { replicator, runBoundedRemoteActivity } = createReplicator({
+        const { replicator, runFiniteReplicationActivity } = createReplicator({
             P2P_AutoSyncPeers: "peer-a",
         });
         const sync = vi.spyOn(replicator, "sync").mockResolvedValue(undefined);
 
         await replicator.onNewPeer({ peerId: "peer-id", name: "peer-a", platform: "test" });
 
-        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
+        expect(runFiniteReplicationActivity).toHaveBeenCalledWith(expect.any(Function), {
             label: "replication",
         });
         expect(sync).toHaveBeenCalledWith("peer-id");
     });
 
     it("tracks a pull requested by a remote peer", async () => {
-        const { replicator, runBoundedRemoteActivity } = createReplicator();
+        const { replicator, runFiniteReplicationActivity } = createReplicator();
         const replicateFrom = vi.spyOn(replicator, "replicateFrom").mockResolvedValue({ ok: true });
 
         await replicator.getCommands().reqSync("peer-id");
 
-        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
+        expect(runFiniteReplicationActivity).toHaveBeenCalledWith(expect.any(Function), {
             label: "replication",
         });
         expect(replicateFrom).toHaveBeenCalledWith("peer-id");
     });
 
     it("tracks a watched pull after a peer reports progress", async () => {
-        const { replicator, runBoundedRemoteActivity } = createReplicator();
+        const { replicator, runFiniteReplicationActivity } = createReplicator();
         const replicateFrom = vi.spyOn(replicator, "replicateFrom").mockResolvedValue({ ok: true });
         replicator._watchingPeers.add("peer-id");
 
         await replicator.onUpdateDatabase("peer-id");
 
-        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
+        expect(runFiniteReplicationActivity).toHaveBeenCalledWith(expect.any(Function), {
             label: "replication",
         });
         expect(replicateFrom).toHaveBeenCalledWith("peer-id");
@@ -69,7 +69,7 @@ describe("TrysteroReplicator automatic remote activity", () => {
         const { replicator } = createReplicator({
             P2P_AutoSyncPeers: "peer-a",
         });
-        (replicator as any)._env.runBoundedRemoteActivity = undefined;
+        (replicator as any)._env.runFiniteReplicationActivity = undefined;
         const sync = vi.spyOn(replicator, "sync").mockResolvedValue(undefined);
 
         await replicator.onNewPeer({ peerId: "peer-id", name: "peer-a", platform: "test" });

--- a/src/replication/trystero/types.ts
+++ b/src/replication/trystero/types.ts
@@ -99,7 +99,7 @@ export interface ReplicatorHostEnv extends ReplicatorHost {
     settings: P2PSyncSetting;
     db: PouchDB.Database<EntryDoc>;
     simpleStore: SimpleStore<unknown>;
-    runBoundedRemoteActivity?: AsyncActivityRunner["run"];
+    runFiniteReplicationActivity?: AsyncActivityRunner["run"];
 
     processReplicatedDocs(docs: Array<PouchDB.Core.ExistingDocument<EntryDoc>>): void | Promise<void>;
 }

--- a/src/services/base/IService.ts
+++ b/src/services/base/IService.ts
@@ -170,11 +170,12 @@ export interface IReplicatorService {
     replicationStatics: ReactiveSource<ReplicationStatics>;
     /** Number of finite remote operations currently in progress. */
     boundedRemoteActivityCount: ReactiveSource<number>;
+    /** Number of finite replication operations which can still deliver database documents. */
+    finiteReplicationActivityCount: ReactiveSource<number>;
     /** Runs a finite remote operation within the host activity policy. */
-    runBoundedRemoteActivity<T>(
-        task: () => T | PromiseLike<T>,
-        options?: AsyncActivityOptions
-    ): Promise<T>;
+    runBoundedRemoteActivity<T>(task: () => T | PromiseLike<T>, options?: AsyncActivityOptions): Promise<T>;
+    /** Runs finite replication which may place documents in the local database. */
+    runFiniteReplicationActivity<T>(task: () => T | PromiseLike<T>, options?: AsyncActivityOptions): Promise<T>;
 }
 export interface IReplicationService {
     processSynchroniseResult(doc: MetaEntry): Promise<boolean>;

--- a/src/services/base/RemoteService.ts
+++ b/src/services/base/RemoteService.ts
@@ -93,42 +93,46 @@ export abstract class RemoteService<T extends ServiceContext = ServiceContext>
             ? this._APIService.nativeFetch.bind(this._APIService)
             : this._APIService.webCompatFetch.bind(this._APIService);
         this._APIService.requestCount.value = this._APIService.requestCount.value + 1;
-        const response = await fetchFunction(req, opts);
-        const method = opts?.method ?? "GET";
-        if (method == "POST" || method == "PUT") {
-            this.last_successful_post = response.ok;
-        } else {
-            this.last_successful_post = true;
-        }
-        const url = new URL(typeof req === "string" ? req : req.url);
-        const localURL = `${url.protocol}//${url.host}${url.pathname}`;
-        this._log(`[REQ] (${method}) ${localURL} -> ${response.status}`, LOG_LEVEL_DEBUG);
-        if (Math.floor(response.status / 100) !== 2) {
-            if (response.status == 404) {
-                if (method === "GET" && url.pathname.indexOf("/_local/") === -1) {
+        try {
+            const response = await fetchFunction(req, opts);
+            const method = opts?.method ?? "GET";
+            if (method == "POST" || method == "PUT") {
+                this.last_successful_post = response.ok;
+            } else {
+                this.last_successful_post = true;
+            }
+            const url = new URL(typeof req === "string" ? req : req.url);
+            const localURL = `${url.protocol}//${url.host}${url.pathname}`;
+            this._log(`[REQ] (${method}) ${localURL} -> ${response.status}`, LOG_LEVEL_DEBUG);
+            if (Math.floor(response.status / 100) !== 2) {
+                if (response.status == 404) {
+                    if (method === "GET" && url.pathname.indexOf("/_local/") === -1) {
+                        this._log(
+                            `Just checkpoint or some server information has been missing. The 404 error shown above is not an error.`,
+                            LOG_LEVEL_VERBOSE
+                        );
+                    }
+                } else {
+                    const r = response.clone();
                     this._log(
-                        `Just checkpoint or some server information has been missing. The 404 error shown above is not an error.`,
-                        LOG_LEVEL_VERBOSE
+                        `The request may have failed. The reason sent by the server: ${r.status}: ${r.statusText}`,
+                        LOG_LEVEL_NOTICE
                     );
+                    try {
+                        const result = await r.text();
+                        this._log(result, LOG_LEVEL_VERBOSE);
+                    } catch (_) {
+                        this._log("Could not fetch response body", LOG_LEVEL_VERBOSE);
+                        this._log(_, LOG_LEVEL_VERBOSE);
+                    }
                 }
             } else {
-                const r = response.clone();
-                this._log(
-                    `The request may have failed. The reason sent by the server: ${r.status}: ${r.statusText}`,
-                    LOG_LEVEL_NOTICE
-                );
-                try {
-                    const result = await r.text();
-                    this._log(result, LOG_LEVEL_VERBOSE);
-                } catch (_) {
-                    this._log("Could not fetch response body", LOG_LEVEL_VERBOSE);
-                    this._log(_, LOG_LEVEL_VERBOSE);
-                }
+                this.clearErrors();
             }
-        } else {
-            this.clearErrors();
+            return response;
+        } finally {
+            this._APIService.responseCount.value = this._APIService.responseCount.value + 1;
         }
-        return response;
     }
 
     async connect(
@@ -188,7 +192,6 @@ export abstract class RemoteService<T extends ServiceContext = ServiceContext>
                         headers.append("authorization", authHeader);
                     }
                     try {
-                        this._APIService.requestCount.value = this._APIService.requestCount.value + 1;
                         // const response: Response = await (useRequestAPI
                         //     ? this.nativeFetch(url.toString(), { ...opts, headers })
                         //     : this.webCompatFetch(url, { ...opts, headers }));
@@ -267,8 +270,6 @@ export abstract class RemoteService<T extends ServiceContext = ServiceContext>
                     }
                     this._log(ex);
                     throw ex;
-                } finally {
-                    this._APIService.responseCount.value = this._APIService.responseCount.value + 1;
                 }
                 // return await fetch(url, opts);
             },

--- a/src/services/base/RemoteService.ts
+++ b/src/services/base/RemoteService.ts
@@ -17,6 +17,7 @@ import type { AppLifecycleService } from "@lib/services/base/AppLifecycleService
 import type { SettingService } from "@lib/services/base/SettingService";
 import { UnresolvedErrorManager } from "@lib/services/base/UnresolvedErrorManager";
 import { createInstanceLogFunction, MARK_LOG_NETWORK_ERROR, type LogFunction } from "@lib/services/lib/logUtils";
+import { runWithTrackedPhysicalRequest } from "@lib/services/lib/remoteActivity.ts";
 import { PouchDB } from "@lib/pouchdb/pouchdb-browser.ts";
 import { LiveSyncError } from "@lib/common/LSError";
 export interface RemoteServiceDependencies {
@@ -92,8 +93,7 @@ export abstract class RemoteService<T extends ServiceContext = ServiceContext>
         const fetchFunction = useNativeFetch
             ? this._APIService.nativeFetch.bind(this._APIService)
             : this._APIService.webCompatFetch.bind(this._APIService);
-        this._APIService.requestCount.value = this._APIService.requestCount.value + 1;
-        try {
+        return await runWithTrackedPhysicalRequest(this._APIService, async () => {
             const response = await fetchFunction(req, opts);
             const method = opts?.method ?? "GET";
             if (method == "POST" || method == "PUT") {
@@ -130,9 +130,7 @@ export abstract class RemoteService<T extends ServiceContext = ServiceContext>
                 this.clearErrors();
             }
             return response;
-        } finally {
-            this._APIService.responseCount.value = this._APIService.responseCount.value + 1;
-        }
+        });
     }
 
     async connect(

--- a/src/services/base/RemoteService.unit.spec.ts
+++ b/src/services/base/RemoteService.unit.spec.ts
@@ -1,0 +1,115 @@
+import { reactiveSource } from "octagonal-wheels/dataobject/reactive";
+import { describe, expect, it, vi } from "vitest";
+import type { APIService } from "./APIService";
+import type { AppLifecycleService } from "./AppLifecycleService";
+import { RemoteService } from "./RemoteService";
+import { ServiceContext } from "./ServiceBase";
+import type { SettingService } from "./SettingService";
+
+class TestRemoteService extends RemoteService {}
+
+function createService(fetchImplementation: (req: string | Request, opts?: RequestInit) => Promise<Response>) {
+    const requestCount = reactiveSource(0);
+    const responseCount = reactiveSource(0);
+    const nativeFetch = vi.fn(fetchImplementation);
+    const webCompatFetch = vi.fn(fetchImplementation);
+    const APIService = {
+        addLog: vi.fn(),
+        isOnline: true,
+        nativeFetch,
+        requestCount,
+        responseCount,
+        webCompatFetch,
+    } as unknown as APIService;
+    const appLifecycle = {
+        getUnresolvedMessages: { addHandler: vi.fn() },
+    } as unknown as AppLifecycleService;
+    const setting = {
+        currentSettings: vi.fn(() => ({ E2EEAlgorithm: "v2" })),
+    } as unknown as SettingService;
+    const service = new TestRemoteService(new ServiceContext(), {
+        APIService,
+        appLifecycle,
+        setting,
+    });
+    return { APIService, nativeFetch, requestCount, responseCount, service, webCompatFetch };
+}
+
+const databaseInfo = {
+    compact_running: false,
+    data_size: 0,
+    db_name: "db",
+    disk_format_version: 6,
+    disk_size: 0,
+    doc_count: 0,
+    doc_del_count: 0,
+    instance_start_time: "0",
+    purge_seq: 0,
+    update_seq: "0",
+};
+
+function createDatabaseInfoResponse() {
+    return new Response(JSON.stringify(databaseInfo), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+    });
+}
+
+async function connect(service: TestRemoteService) {
+    const connection = await service.connect(
+        "https://example.com/db",
+        { username: "user", password: "password", type: "basic" },
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        {},
+        false,
+        () => Promise.resolve(new Uint8Array())
+    );
+    expect(typeof connection).not.toBe("string");
+    if (typeof connection === "string") throw new Error(connection);
+    return connection;
+}
+
+describe("RemoteService request activity", () => {
+    it("balances the counters after a CouchDB adapter request settles", async () => {
+        const { requestCount, responseCount, service } = createService(() =>
+            Promise.resolve(createDatabaseInfoResponse())
+        );
+
+        const connection = await connect(service);
+        await connection.db.info();
+
+        expect(requestCount.value).toBe(1);
+        expect(responseCount.value).toBe(1);
+    });
+
+    it("balances both attempts when a web request falls back to the native API", async () => {
+        const { nativeFetch, requestCount, responseCount, service, webCompatFetch } = createService(() =>
+            Promise.reject(new TypeError("CORS failed"))
+        );
+        nativeFetch.mockResolvedValue(createDatabaseInfoResponse());
+
+        const connection = await connect(service);
+        await connection.db.info();
+
+        expect(webCompatFetch).toHaveBeenCalledOnce();
+        expect(nativeFetch).toHaveBeenCalledOnce();
+        expect(requestCount.value).toBe(2);
+        expect(responseCount.value).toBe(2);
+    });
+
+    it("balances the counters when an individual request rejects", async () => {
+        const { requestCount, responseCount, service } = createService(() =>
+            Promise.reject(new TypeError("network failed"))
+        );
+
+        await expect(service.performFetch("https://example.com/db")).rejects.toThrow("network failed");
+
+        expect(requestCount.value).toBe(1);
+        expect(responseCount.value).toBe(1);
+    });
+});

--- a/src/services/base/ReplicationService.ts
+++ b/src/services/base/ReplicationService.ts
@@ -177,7 +177,7 @@ export abstract class ReplicationService<T extends ServiceContext = ServiceConte
         try {
             const checkBeforeReplicate = await this.isReplicationReady(showMessage);
             if (!checkBeforeReplicate) return false;
-            const result = await this.replicatorService.runBoundedRemoteActivity(
+            const result = await this.replicatorService.runFiniteReplicationActivity(
                 () => this.performReplicationRequest(showMessage),
                 { label: "replication" }
             );

--- a/src/services/base/ReplicationService.unit.spec.ts
+++ b/src/services/base/ReplicationService.unit.spec.ts
@@ -7,7 +7,7 @@ class TestReplicationService extends ReplicationService<ServiceContext> {}
 describe("ReplicationService activity boundary", () => {
     const createDependencies = () => {
         const openReplication = vi.fn().mockResolvedValue(true);
-        const runBoundedRemoteActivity = vi.fn(async (task: () => unknown) => await task());
+        const runFiniteReplicationActivity = vi.fn(async (task: () => unknown) => await task());
         const getUnresolvedMessages = Object.assign(vi.fn().mockResolvedValue([]), {
             addHandler: vi.fn(),
         });
@@ -23,37 +23,37 @@ describe("ReplicationService activity boundary", () => {
             },
             replicatorService: {
                 getActiveReplicator: () => ({ openReplication }),
-                runBoundedRemoteActivity,
+                runFiniteReplicationActivity,
             },
             settingService: {
                 currentSettings: () => ({ versionUpFlash: "" }),
             },
         } as unknown as ReplicationServiceDependencies;
 
-        return { dependencies, openReplication, runBoundedRemoteActivity };
+        return { dependencies, openReplication, runFiniteReplicationActivity };
     };
 
     it("runs a ready one-shot replication through the bounded remote activity boundary", async () => {
-        const { dependencies, openReplication, runBoundedRemoteActivity } = createDependencies();
+        const { dependencies, openReplication, runFiniteReplicationActivity } = createDependencies();
         const service = new TestReplicationService(new ServiceContext(), dependencies);
 
         await expect(service.replicate(true)).resolves.toBe(true);
 
-        expect(runBoundedRemoteActivity).toHaveBeenCalledOnce();
-        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
+        expect(runFiniteReplicationActivity).toHaveBeenCalledOnce();
+        expect(runFiniteReplicationActivity).toHaveBeenCalledWith(expect.any(Function), {
             label: "replication",
         });
         expect(openReplication).toHaveBeenCalledOnce();
     });
 
     it("does not start an activity while replication readiness checks fail", async () => {
-        const { dependencies, openReplication, runBoundedRemoteActivity } = createDependencies();
+        const { dependencies, openReplication, runFiniteReplicationActivity } = createDependencies();
         Object.assign(dependencies.APIService, { isOnline: false });
         const service = new TestReplicationService(new ServiceContext(), dependencies);
 
         await expect(service.replicate(true)).resolves.toBe(false);
 
-        expect(runBoundedRemoteActivity).not.toHaveBeenCalled();
+        expect(runFiniteReplicationActivity).not.toHaveBeenCalled();
         expect(openReplication).not.toHaveBeenCalled();
     });
 
@@ -61,7 +61,7 @@ describe("ReplicationService activity boundary", () => {
         const { dependencies, openReplication } = createDependencies();
         const calls: string[] = [];
         openReplication.mockResolvedValue(false);
-        (dependencies.replicatorService as any).runBoundedRemoteActivity = vi.fn(async (task: () => unknown) => {
+        (dependencies.replicatorService as any).runFiniteReplicationActivity = vi.fn(async (task: () => unknown) => {
             calls.push("activity-started");
             try {
                 return await task();
@@ -81,7 +81,7 @@ describe("ReplicationService activity boundary", () => {
     });
 
     it("preserves failure handling for direct performReplication callers", async () => {
-        const { dependencies, openReplication, runBoundedRemoteActivity } = createDependencies();
+        const { dependencies, openReplication, runFiniteReplicationActivity } = createDependencies();
         openReplication.mockResolvedValue(false);
         const service = new TestReplicationService(new ServiceContext(), dependencies);
         const handleFailure = vi.fn(async () => false);
@@ -90,6 +90,6 @@ describe("ReplicationService activity boundary", () => {
         await expect(service.performReplication(true)).resolves.toBe(false);
 
         expect(handleFailure).toHaveBeenCalledWith(true);
-        expect(runBoundedRemoteActivity).not.toHaveBeenCalled();
+        expect(runFiniteReplicationActivity).not.toHaveBeenCalled();
     });
 });

--- a/src/services/base/ReplicatorService.ts
+++ b/src/services/base/ReplicatorService.ts
@@ -33,6 +33,7 @@ export abstract class ReplicatorService<T extends ServiceContext = ServiceContex
     implements IReplicatorService
 {
     readonly boundedRemoteActivityCount = reactiveSource(0);
+    readonly finiteReplicationActivityCount = reactiveSource(0);
     _log = createInstanceLogFunction("ReplicatorService");
 
     private settingService: SettingService;
@@ -66,10 +67,32 @@ export abstract class ReplicatorService<T extends ServiceContext = ServiceContex
         task: () => TValue | PromiseLike<TValue>,
         options?: AsyncActivityOptions
     ): Promise<TValue> {
+        return await this.runRemoteActivity(task, options, false);
+    }
+
+    /** Runs one finite replication and exposes its document-delivery lifetime. */
+    async runFiniteReplicationActivity<TValue>(
+        task: () => TValue | PromiseLike<TValue>,
+        options?: AsyncActivityOptions
+    ): Promise<TValue> {
+        return await this.runRemoteActivity(task, options, true);
+    }
+
+    private async runRemoteActivity<TValue>(
+        task: () => TValue | PromiseLike<TValue>,
+        options: AsyncActivityOptions | undefined,
+        isFiniteReplication: boolean
+    ): Promise<TValue> {
         this.boundedRemoteActivityCount.value++;
+        if (isFiniteReplication) {
+            this.finiteReplicationActivityCount.value++;
+        }
         try {
             return await runWithOptionalActivity(this.dependencies.activityRunner, task, options);
         } finally {
+            if (isFiniteReplication) {
+                this.finiteReplicationActivityCount.value--;
+            }
             this.boundedRemoteActivityCount.value--;
         }
     }

--- a/src/services/base/ReplicatorService.unit.spec.ts
+++ b/src/services/base/ReplicatorService.unit.spec.ts
@@ -41,7 +41,7 @@ describe("ReplicatorService bounded remote activity", () => {
         });
 
         await expect(
-            service.runBoundedRemoteActivity(() => Promise.resolve("done"), { label: "replication" })
+            service.runFiniteReplicationActivity(() => Promise.resolve("done"), { label: "replication" })
         ).resolves.toBe("done");
 
         expect(run).toHaveBeenCalledWith(expect.any(Function), { label: "replication" });
@@ -50,33 +50,41 @@ describe("ReplicatorService bounded remote activity", () => {
     it("tracks overlapping bounded activities until each one settles", async () => {
         const service = createService();
         const observedCounts: number[] = [];
+        const observedReplicationCounts: number[] = [];
         service.boundedRemoteActivityCount.onChanged((value) => observedCounts.push(value.value));
+        service.finiteReplicationActivityCount.onChanged((value) => observedReplicationCounts.push(value.value));
         let finishFirst!: () => void;
         let finishSecond!: () => void;
         const firstGate = new Promise<void>((resolve) => (finishFirst = resolve));
         const secondGate = new Promise<void>((resolve) => (finishSecond = resolve));
 
-        const first = service.runBoundedRemoteActivity(() => firstGate, { label: "replication" });
+        const first = service.runFiniteReplicationActivity(() => firstGate, { label: "replication" });
         const second = service.runBoundedRemoteActivity(() => secondGate, { label: "chunk-fetch" });
 
         expect(service.boundedRemoteActivityCount.value).toBe(2);
+        expect(service.finiteReplicationActivityCount.value).toBe(1);
         finishFirst();
         await first;
         expect(service.boundedRemoteActivityCount.value).toBe(1);
+        expect(service.finiteReplicationActivityCount.value).toBe(0);
         finishSecond();
         await second;
 
         expect(service.boundedRemoteActivityCount.value).toBe(0);
         expect(observedCounts).toEqual([1, 2, 1, 0]);
+        expect(observedReplicationCounts).toEqual([1, 0]);
     });
 
     it("ends the activity when the bounded task rejects", async () => {
         const service = createService();
 
         await expect(
-            service.runBoundedRemoteActivity(() => Promise.reject(new Error("network failed")))
+            service.runFiniteReplicationActivity(() => Promise.reject(new Error("network failed")), {
+                label: "replication",
+            })
         ).rejects.toThrow("network failed");
 
         expect(service.boundedRemoteActivityCount.value).toBe(0);
+        expect(service.finiteReplicationActivityCount.value).toBe(0);
     });
 });

--- a/src/services/lib/remoteActivity.ts
+++ b/src/services/lib/remoteActivity.ts
@@ -1,0 +1,25 @@
+import type { ReactiveSource } from "octagonal-wheels/dataobject/reactive";
+
+export type TrackedPhysicalRequestCounters = {
+    requestCount: ReactiveSource<number>;
+    responseCount: ReactiveSource<number>;
+};
+
+/**
+ * Tracks one physical-request unit for status reporting.
+ *
+ * A unit may be an exact transport attempt or a higher-level SDK command. The
+ * resulting in-flight count is deliberately approximate and must not be used
+ * for protocol correctness, throttling, or completion decisions.
+ */
+export async function runWithTrackedPhysicalRequest<T>(
+    counters: TrackedPhysicalRequestCounters,
+    task: () => T | PromiseLike<T>
+): Promise<T> {
+    counters.requestCount.value++;
+    try {
+        return await task();
+    } finally {
+        counters.responseCount.value++;
+    }
+}


### PR DESCRIPTION
## Summary

- Coordinate missing-chunk delivery with per-document claims and finite-replication quiescence instead of relying on fixed arrival delays.
- Separate general bounded remote work from finite replication, and expose balanced physical-request activity for CouchDB and MinIO operations.
- Add focused coverage for concurrent claims, failures, cancellation, disposal, replication lifecycles, and request-counter balancing.

## Motivation

A fixed missing-chunk wait can expire while an accepted on-demand fetch or finite replication can still deliver the requested chunk. Request and response counters were also managed at individual call sites, which made exceptional paths harder to balance and prevented the downstream status display from distinguishing logical finite work from active network requests.

## Behaviour and constraints

- An on-demand fetch owns a claim until each requested chunk settles, the claim is released, or its inactivity fuse fires.
- A finite replication remains a possible delivery source until that replication completes. Continuous replication is deliberately outside this finite lifecycle.
- The five-minute claim timeout is a last-resort leak fuse. It is not a normal chunk-arrival allowance, evidence that a chunk is absent, or a transport deadline.
- Physical-request activity is deliberately approximate and is intended only for status reporting. Protocol correctness, throttling, and completion must not depend on it.
- Commonlib exposes activity signals and coordination only; platform Wake Lock handling and presentation remain downstream responsibilities.

## Verification

- TypeScript checking passed.
- Lint passed with no new errors.
- The full LiveSync workspace unit suite passed: 84 files and 1,466 tests.
- The focused final regression suite passed: 4 files and 17 tests.
- MinIO integration passed: 2 tests.
- Real Obsidian CouchDB and MinIO E2E runs confirmed that finite-delivery activity and physical-request activity are distinct, and that request counters return to balance after success.
