### PR TITLE
Guard case-only file renames across parent directories

### DIFF
--- a/src/serviceModules/ServiceFileHandlerBase.ts
+++ b/src/serviceModules/ServiceFileHandlerBase.ts
@@ -68,6 +68,11 @@ async function serializedByKeys<T>(keys: readonly string[], callback: () => Prom
     return await serialized(key, () => serializedByKeys(remainingKeys, callback));
 }
 
+function getParentPath(path: string): string {
+    const lastSeparator = path.lastIndexOf("/");
+    return lastSeparator < 0 ? "" : path.slice(0, lastSeparator);
+}
+
 export abstract class ServiceFileHandlerBase
     extends ServiceModuleBase<ServiceFileHandlerDependencies>
     implements IFileHandler
@@ -390,6 +395,13 @@ export abstract class ServiceFileHandlerBase
             if (existingDocumentId !== targetDocumentId) {
                 this._log(
                     `Refusing to overwrite ${existDoc.path} while applying the distinct path ${path}`,
+                    LOG_LEVEL_NOTICE
+                );
+                return false;
+            }
+            if (getParentPath(existDoc.path) !== getParentPath(path)) {
+                this._log(
+                    `Refusing to apply a filename case change across differently cased parent directories: ${existDoc.path} -> ${path}`,
                     LOG_LEVEL_NOTICE
                 );
                 return false;

--- a/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts
+++ b/src/serviceModules/ServiceFileHandlerBase.unit.spec.ts
@@ -268,6 +268,29 @@ describe("ServiceFileHandlerBase.dbToStorage", () => {
         expect(storageAccess.writeFileAuto).not.toHaveBeenCalled();
     });
 
+    it("preserves a file when the canonical path change also changes parent directory case", async () => {
+        const { handler, storageStub, databaseFileAccess, storageAccess } = createHandler(
+            "same body",
+            "same body",
+            false,
+            EVEN
+        );
+        const remoteMeta = createMeta("renamed/calculus.md", "same body");
+        const existingFile = {
+            ...storageStub,
+            name: "Calculus.md",
+            path: "Renamed/Calculus.md" as FilePath,
+        };
+        databaseFileAccess.fetchEntryMeta.mockResolvedValue(remoteMeta);
+        storageAccess.getStub.mockResolvedValue(existingFile);
+
+        await expect(handler.dbToStorage(remoteMeta, existingFile)).resolves.toBe(false);
+
+        expect(storageAccess.renameFile).not.toHaveBeenCalled();
+        expect(databaseFileAccess.fetchEntryFromMeta).not.toHaveBeenCalled();
+        expect(storageAccess.writeFileAuto).not.toHaveBeenCalled();
+    });
+
     it("stops remote reflection when the canonical filename case cannot be applied", async () => {
         const { handler, storageStub, databaseFileAccess, storageAccess } = createHandler(
             "same body",


### PR DESCRIPTION
## Summary

- Refuse to apply a file-name case change when the exact case of its parent directory also differs.
- Preserve the existing file and leave directory case changes to future directory-aware handling.
- Add regression coverage for the unsafe parent-directory case-change path.

## Rationale

PR #68 safely handles case-only file renames within the same directory. Manual verification on Windows showed that representing a parent-directory case change as a child-file rename can leave Obsidian's Vault cache and the file system out of agreement.

This guard keeps the file-level handler within its intended boundary. Same-directory file-name case changes remain supported, while directory case changes remain unsupported and vrtmrz/obsidian-livesync#198 stays open for folder-aware handling.

## Verification

- Confirmed that the new regression test fails against the unmodified implementation because `renameFile` is called.
- Confirmed that the same test passes after the guard is applied.
- `ServiceFileHandlerBase.unit.spec.ts`: 15 tests passed.

## Downstream integration

The [automatic pull-request run](https://github.com/vrtmrz/livesync-commonlib/actions/runs/29491659963) against Self-hosted LiveSync `main` is expected to fail at type checking. The current downstream `main` does not yet implement the `renameFile` and `rename` adapter contracts introduced by commonlib PR #68, so that result remains visible as the compatibility signal for the current downstream branch.

The [manually dispatched downstream run](https://github.com/vrtmrz/livesync-commonlib/actions/runs/29491888079) against the matching integration branch passed:

- commonlib: `86629d1e6e3c837078fbe5e8161880cd5ee7cc19`
- Self-hosted LiveSync: `37a6db05b90105f986dc7bd34aca9612025813ac`
- `npm run tsc-check`: passed
- unit tests: 87 test files and 1,498 tests passed
