### PR TITLE
Allow selecting a downstream CI ref

### DIFF
--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       downstream_ref:
-        description: Obsidian LiveSync branch, tag, or commit SHA to test
+        description: Self-hosted LiveSync branch, tag, or commit SHA to test
         required: false
         default: main
         type: string
@@ -18,7 +18,8 @@ permissions:
   contents: read
 
 jobs:
-  obsidian-livesync-unit-tests:
+  self-hosted-livesync-unit-tests:
+    name: Self-hosted LiveSync unit tests
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +29,7 @@ jobs:
           path: livesync-commonlib
           persist-credentials: false
 
-      - name: Checkout obsidian-livesync
+      - name: Checkout Self-hosted LiveSync
         uses: actions/checkout@v4
         with:
           repository: vrtmrz/obsidian-livesync
@@ -45,7 +46,7 @@ jobs:
             echo "### Downstream CI revisions"
             echo
             printf -- '- commonlib: `%s`\n' "$(git -C livesync-commonlib rev-parse HEAD)"
-            printf -- '- obsidian-livesync: `%s`\n' "$(git -C obsidian-livesync rev-parse HEAD)"
+            printf -- '- Self-hosted LiveSync: `%s`\n' "$(git -C obsidian-livesync rev-parse HEAD)"
             printf -- '- requested downstream ref: `%s`\n' "$DOWNSTREAM_REF"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -1,11 +1,21 @@
 name: Downstream CI
 
 on:
+  workflow_dispatch:
+    inputs:
+      downstream_ref:
+        description: Obsidian LiveSync branch, tag, or commit SHA to test
+        required: false
+        default: main
+        type: string
   pull_request:
   push:
     branches:
       - main
       - master
+
+permissions:
+  contents: read
 
 jobs:
   obsidian-livesync-unit-tests:
@@ -16,13 +26,28 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: livesync-commonlib
+          persist-credentials: false
 
       - name: Checkout obsidian-livesync
         uses: actions/checkout@v4
         with:
           repository: vrtmrz/obsidian-livesync
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.downstream_ref || 'main' }}
           path: obsidian-livesync
           submodules: false
+          persist-credentials: false
+
+      - name: Record checked-out revisions
+        env:
+          DOWNSTREAM_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.downstream_ref || 'main' }}
+        run: |
+          {
+            echo "### Downstream CI revisions"
+            echo
+            printf -- '- commonlib: `%s`\n' "$(git -C livesync-commonlib rev-parse HEAD)"
+            printf -- '- obsidian-livesync: `%s`\n' "$(git -C obsidian-livesync rev-parse HEAD)"
+            printf -- '- requested downstream ref: `%s`\n' "$DOWNSTREAM_REF"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Replace commonlib submodule
         run: |


### PR DESCRIPTION
## Summary

- allow manually dispatched Downstream CI runs to select a Self-hosted LiveSync branch, tag, or commit SHA
- keep automatic pull request and push runs fixed to the Self-hosted LiveSync `main` branch
- record the requested ref and both resolved commit SHAs in the job summary
- limit the workflow token to read-only contents access and avoid persisting checkout credentials

## Why

Cross-repository contract changes can require compatible, unmerged commonlib and Self-hosted LiveSync revisions. The existing automatic check correctly exposes incompatibility with the current downstream `main`, but it cannot provide supplementary validation of the staged integration.

The manual ref selector adds that validation path without weakening or replacing the automatic compatibility check.

## Behavioural impact

There are no production-code changes. Automatic CI behaviour remains unchanged: pull request and push runs continue to test Self-hosted LiveSync `main`. A different downstream ref is used only for an explicitly dispatched run.

## Known automatic CI failure

The automatic check currently reaches the downstream type check and then fails because commonlib `main` requires the `renameFile` and `rename` adapter contracts, which Self-hosted LiveSync `main` does not yet implement. This is the existing cross-repository integration mismatch that motivated the manual selector, rather than a failure introduced by this workflow change.

The automatic result remains visible as the compatibility signal for the current downstream `main`. Once this workflow is available on the default branch, the matching downstream integration ref will be validated with a manually dispatched run before the related changes are merged.

## Validation

- `actionlint .github/workflows/downstream-ci.yml`
- `git diff --check origin/main...HEAD`
