### PR TITLE
Add trusted prerelease staging workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,134 @@
+name: Stage npm package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact version in package.json
+        required: true
+        type: string
+      source_ref:
+        description: Branch whose exact commit will be packaged
+        required: true
+        type: string
+      expected_sha:
+        description: Full 40-character commit SHA expected on the source branch
+        required: true
+        type: string
+      confirmation:
+        description: "Type: stage @vrtmrz/livesync-commonlib@<version> from <expected-sha>"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-stage
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Require the trusted workflow branch
+        run: test "$GITHUB_REF" = refs/heads/main
+
+      - name: Check out the selected source commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ inputs.expected_sha }}
+          persist-credentials: false
+
+      - name: Require the exact selected source branch commit
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          PACKAGE_VERSION: ${{ inputs.version }}
+        run: |
+          git check-ref-format --branch "$SOURCE_REF" >/dev/null
+          remote_sha=$(git ls-remote --exit-code origin "refs/heads/$SOURCE_REF" | cut -f1)
+          test "$remote_sha" = "$EXPECTED_SHA"
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+          case "$PACKAGE_VERSION" in
+            *-*) ;;
+            *) test "$SOURCE_REF" = main ;;
+          esac
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Use the reviewed npm CLI
+        run: npm install --global npm@11.18.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify package and release selection
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          npm run verify:package
+          actual_sha=$(git rev-parse HEAD)
+          node _tools/validate-release-selection.mjs "$PACKAGE_VERSION" "$EXPECTED_SHA" "$actual_sha" "refs/heads/$SOURCE_REF" "$CONFIRMATION"
+
+      - name: Pack the verified package
+        run: |
+          mkdir -p "$RUNNER_TEMP/npm-package"
+          npm pack .package --pack-destination "$RUNNER_TEMP/npm-package"
+          cd "$RUNNER_TEMP/npm-package"
+          sha256sum ./*.tgz > SHA256SUMS
+          tar -tzf ./*.tgz
+
+      - name: Upload the verified package
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: npm-package
+          path: ${{ runner.temp }}/npm-package
+          if-no-files-found: error
+          retention-days: 7
+
+  stage:
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Use an npm CLI with staged publishing
+        run: npm install --global npm@11.18.0
+
+      - name: Download the verified package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: npm-package
+          path: ${{ runner.temp }}/npm-package
+
+      - name: Verify and stage the package
+        env:
+          DIST_TAG: next
+        run: |
+          cd "$RUNNER_TEMP/npm-package"
+          sha256sum --check SHA256SUMS
+          package_file=$(find . -maxdepth 1 -type f -name '*.tgz' -print -quit)
+          test -n "$package_file"
+          npm stage publish "$package_file" --tag "$DIST_TAG"


### PR DESCRIPTION
## Summary

- add a manually dispatched npm staging workflow whose trusted definition runs from `main`
- allow a reviewed pre-release to package the exact commit at a named source branch
- keep stable sources restricted to `main`, and keep every staged package on `next`

## Why

The installable package and its release gates are being reviewed in #76, but that package must be validated from the exact pull request commit before #76 is merged. Requiring the package source itself to be on `main` makes that validation loop impossible.

This pull request adds only the trusted broker workflow. It does not add the package implementation or change Commonlib runtime behaviour. After this is merged, the workflow can run from `main`, verify that the reviewed source branch still points to the requested full SHA, build that exact commit without publication credentials, and pass only the verified tarball to the protected `npm` environment.

## Trust boundary

- the workflow definition and protected-environment deployment remain on `main`
- the source must be an existing branch whose remote head equals the requested full SHA
- stable versions still require `main` as their source branch
- the verification job has read-only repository access and no npm publication identity
- the protected staging job receives the verified artifact and publishes only to `next`

## Verification

- `actionlint .github/workflows/publish-npm.yml`
- `git diff --check`

Related: #76
