### PR TITLE
Prepare Commonlib 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.0-rc.14",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.0-rc.14",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.0-rc.14",
+  "version": "0.1.0",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
This pull request prepares stable `@vrtmrz/livesync-commonlib@0.1.0` for staged validation under `next`, changing only package version metadata while preserving the reviewed rc.14 package contents and behaviour.

## Summary

- Set the source manifest and root lockfile metadata from `0.1.0-rc.14` to `0.1.0`.
- Keep the generated package public, ESM-only, and configured to publish to the `next` dist-tag.
- Base the release commit directly on Commonlib `main` merge commit [`e9faf31`](https://github.com/vrtmrz/livesync-commonlib/commit/e9faf318a4e5480656b81bfc87fb666d14880418), which contains the exact reviewed head from PR #76.
- Leave dependencies, exports, generated code, documentation, runtime behaviour, and the `latest` dist-tag unchanged.

## Verification

- npm 11.18.0 clean installation succeeds.
- `npm run verify:package` passes 65 test files and 1,203 tests, seven package-boundary tests, twenty release-selection tests, the 114-entry compatibility build, and clean packed-consumer verification.
- `npm publish --dry-run .package --tag next --access public` succeeds for `@vrtmrz/livesync-commonlib@0.1.0`.
- The dry-run package contains 500 files, is 392.1 kB packed and 1.7 MB unpacked, and has SHA-512 integrity `sha512-pMGP5Dy0J6v9GvNcfskZyHwrzaYc13YAP1k5GX7qHlCgJc+1xWHu97AZQU5tJjAhQb4m7AgTMMOHt/WI67LvkA==`.
- The generated stable package and the exact reviewed rc.14 package are identical except for their manifest version. The locally generated stable tarball has SHA-256 `07fcd19c373bb86fcd9a5d5bc1d3288d8513d17256ac21581340312f453f258a`.
- Post-merge [Package CI run 30205375776](https://github.com/vrtmrz/livesync-commonlib/actions/runs/30205375776) passes package verification, managed integration tests, and the complete package gate at exact base commit `e9faf31`.
- The production audit retains the existing PouchDB 9 dependency fan-out from `uuid` advisory `GHSA-w5hq-g745-h8pq`: eighteen moderate findings, with no high or critical findings. npm's suggested automatic fixes require incompatible PouchDB downgrades, so this version-only release does not mix in a dependency change.

## Release gates

- [x] Prepare the version-only release commit from the exact reviewed `main` head.
- [x] Pass the complete package gate and publication dry run with the reviewed npm CLI.
- [ ] Merge the exact reviewed release commit into `main`.
- [ ] Dispatch staged publishing for `0.1.0` from that exact `main` commit under `next`.
- [ ] Inspect and approve the staged package as a separate operation.
- [ ] Validate the exact registry artefact in the Self-hosted LiveSync release candidate.
- [ ] Promote `0.1.0` to `latest` only after the exact LiveSync release candidate passes its separate real-environment gate.
