### PR TITLE
Release 0.1.1 with Deno direct-access support

### DIFF
--- a/_tools/check-packed-package.mjs
+++ b/_tools/check-packed-package.mjs
@@ -135,7 +135,11 @@ await writeConsumerFile(
     type ServiceContextContract,
     type ServiceContextOptions,
 } from "${packageName}/context";
-import { DirectFileManipulator, type DirectFileManipulatorOptions } from "${packageName}";
+import {
+    DirectFileManipulator,
+    type DirectFileManipulatorOptions,
+    type DirectFileManipulatorRuntimeOptions,
+} from "${packageName}";
 import {
     createFileSystemAccessStorage,
     type CreateFileSystemAccessStorageOptions,
@@ -159,7 +163,10 @@ const contextContract: ServiceContextContract = context;
 const untranslated: string = passthroughMessageTranslator("moduleLocalDatabase.logWaitingForReady");
 const split = splitPieces2Worker(new Blob(["content"], { type: "text/plain" }), 4, false, 1);
 const directOptions = {} as DirectFileManipulatorOptions;
+const directRuntimeOptions: DirectFileManipulatorRuntimeOptions = { fetch: globalThis.fetch };
 const directType: typeof DirectFileManipulator = DirectFileManipulator;
+const createDirect = (options: DirectFileManipulatorOptions): DirectFileManipulator =>
+    new DirectFileManipulator(options, directRuntimeOptions);
 const fileSystemAccessOptions = {} as CreateFileSystemAccessStorageOptions;
 const fileSystemAccessFactory: typeof createFileSystemAccessStorage = createFileSystemAccessStorage;
 const prepared = prepareSettingsForLoad(undefined);
@@ -174,7 +181,9 @@ void contextContract;
 void untranslated;
 void split;
 void directOptions;
+void directRuntimeOptions;
 void directType;
+void createDirect;
 void fileSystemAccessOptions;
 void fileSystemAccessFactory;
 void migrationState;

--- a/docs/proven-in-use.md
+++ b/docs/proven-in-use.md
@@ -46,6 +46,12 @@ The Obsidian plug-in, CLI, WebApp, and WebPeer compose P2P ownership through `us
 
 This is evidence that the current package boundary can be consumed without the Obsidian host, but it is not yet a recommended standalone Commonlib client factory. The high-level lifecycle, readiness, error, and disposal contract remains future package work after Self-hosted LiveSync 1.0 rather than a gate for that release.
 
+## LiveSync Bridge
+
+[LiveSync Bridge](https://github.com/vrtmrz/livesync-bridge) uses the root `DirectFileManipulator` entry to access CouchDB directly from Deno. The host supplies its fetch implementation, owns reachability probes, retries, and process health, and waits for the manipulator's readiness result before starting its watch. It does not compose the full LiveSync application Service Hub or use the planned file-client factory.
+
+The downstream Deno checks and unit tests run against the installed package. Its Compose integration starts a real CouchDB instance and verifies create, read, update, and deletion between two Bridge peers. This is evidence for the existing direct-access migration path. Commonlib's focused tests separately cover host fetch injection and initialisation failure reporting. This evidence does not make `DirectFileManipulator` a stable high-level SDK contract or establish the semantics still reserved for `createLiveSyncFileClient`.
+
 ## Verification ownership
 
 Commonlib tests the result and lifecycle contracts of the real implementations it publishes. A maintained host tests only its own composition, persistence, presentation, restart, and policy. When a current host test needs isolation, the host may inject the narrow structural capability it consumes and provide a small fake or spy for that test; Commonlib does not publish test-runner-specific mocks or expose its private service graph.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.1-rc.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.1-rc.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.1",
+  "version": "0.1.1-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.1",
+      "version": "0.1.1-rc.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.1",
+  "version": "0.1.1-rc.0",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.1-rc.0",
+  "version": "0.1.1",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Self-hosted LiveSync Commonlib
 
-Commonlib is the ESM package which provides shared data, storage, replication, and host-context primitives for Self-hosted LiveSync, its CLI, Webapp, and WebPeer.
+Commonlib is the ESM package which provides shared data, storage, replication, and host-context primitives for Self-hosted LiveSync, its CLI, WebApp, WebPeer, and LiveSync Bridge.
 
 This package is primarily for maintainers of those clients and for integrations which deliberately reuse a reviewed Commonlib contract. It is not yet a general-purpose LiveSync SDK: the package does not provide a stable end-to-end client factory or own host UI, permissions, credentials, process lifecycle, or application persistence.
 

--- a/src/API/DirectFileManipulator.ts
+++ b/src/API/DirectFileManipulator.ts
@@ -1,2 +1,5 @@
 export { DirectFileManipulator } from "./DirectFileManipulatorV2.ts";
-export type { DirectFileManipulatorOptions } from "./DirectFileManipulatorV2.ts";
+export type {
+    DirectFileManipulatorOptions,
+    DirectFileManipulatorRuntimeOptions,
+} from "./DirectFileManipulatorV2.ts";

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -401,7 +401,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
         // return;
     }
     async *_enumerate(startKey: string, endKey: string, opt: { metaOnly: boolean }) {
-        if (opt.metaOnly) return this.liveSyncLocalDB.findEntries(startKey, endKey, {});
+        if (opt.metaOnly) return yield* this.liveSyncLocalDB.findEntries(startKey, endKey, {});
         for await (const f of this.liveSyncLocalDB.findEntries(startKey, endKey, {})) {
             yield await this.getByMeta(f);
         }

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -277,6 +277,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
                 enableCompression: this.options.enableCompression ?? DEFAULT_SETTINGS.enableCompression,
                 handleFilenameCaseSensitive:
                     this.options.handleFilenameCaseSensitive ?? DEFAULT_SETTINGS.handleFilenameCaseSensitive,
+                usePathObfuscation: !!this.options.obfuscatePassphrase,
                 E2EEAlgorithm: this.options.E2EEAlgorithm ?? E2EEAlgorithms.V2,
             },
         };

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -152,8 +152,13 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
         });
         // this.services.database.createPouchDBInstance.setHandler(this.$$createPouchDBInstance.bind(this));
         (this.services.API as InjectableAPIService<ServiceContext>).addLog.setHandler(() => {});
+        // Initialize settings on the service so managers can access them during construction.
+        this.services.setting.settings = this.settings as any;
         this.services.databaseEvents.onDatabaseInitialisation.addHandler(this.$everyOnInitializeDatabase.bind(this));
         this.liveSyncLocalDB = new LiveSyncLocalDB(this.options.url, this);
+        // Register the LiveSyncLocalDB with the database service so LiveSyncManagers
+        // can access it via databaseService.localDatabase during initialization.
+        (this.services.database as any)._localDatabase = this.liveSyncLocalDB;
         void this.init();
     }
 

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -463,7 +463,14 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
                     }
                 }
                 Logger(`WATCH: PROCESSING: ${doc.path}`, LEVEL_VERBOSE, "watch");
-                const docX = await this.getByMeta(doc);
+                let docX;
+                try {
+                    docX = await this.getByMeta(doc);
+                } catch (ex) {
+                    Logger(`WATCH: DECRYPT FAILED: ${doc.path}`, LEVEL_INFO, "watch");
+                    Logger(ex, LEVEL_VERBOSE, "watch");
+                    return;
+                }
                 try {
                     await callback(docX, change.seq);
                     Logger(`WATCH: PROCESS DONE: ${doc.path}`, LEVEL_INFO, "watch");

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -151,6 +151,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
             return Promise.resolve(getSettings());
         });
         // this.services.database.createPouchDBInstance.setHandler(this.$$createPouchDBInstance.bind(this));
+        (this.services.API as InjectableAPIService<ServiceContext>).addLog.setHandler(() => {});
         this.services.databaseEvents.onDatabaseInitialisation.addHandler(this.$everyOnInitializeDatabase.bind(this));
         this.liveSyncLocalDB = new LiveSyncLocalDB(this.options.url, this);
         void this.init();

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -166,6 +166,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
         this.services = new HeadlessServiceHub(context, {
             pouchDB: PouchDB,
             database: this.getBoundDatabaseService(() => this.options, this.runtimeOptions),
+            getPathObfuscationPassphrase: () => this.options.obfuscatePassphrase ?? false,
             databaseLifecycleMode: "direct-access",
         });
 
@@ -497,7 +498,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
                 try {
                     docX = await this.getByMeta(doc);
                 } catch (ex) {
-                    Logger(`WATCH: DECRYPT FAILED: ${doc.path}`, LEVEL_INFO, "watch");
+                    Logger(`WATCH: DOCUMENT LOAD FAILED: ${doc.path}`, LEVEL_INFO, "watch");
                     Logger(ex, LEVEL_VERBOSE, "watch");
                     return;
                 }

--- a/src/API/DirectFileManipulatorV2.ts
+++ b/src/API/DirectFileManipulatorV2.ts
@@ -12,6 +12,7 @@ import {
     type LoadedEntry,
     DEFAULT_SETTINGS,
     type HashAlgorithm,
+    type ObsidianLiveSyncSettings,
     type RemoteDBSettings,
     type ChunkSplitterVersion,
     type SyncParameters,
@@ -80,6 +81,12 @@ export type DirectFileManipulatorOptions = {
     E2EEAlgorithm?: E2EEAlgorithm;
 };
 
+/** Host runtime capabilities used by a direct CouchDB connection. */
+export type DirectFileManipulatorRuntimeOptions = Readonly<{
+    /** Fetch implementation passed to PouchDB. Omit it to use PouchDB's default transport. */
+    fetch?: typeof globalThis.fetch;
+}>;
+
 export type ReadyEntry = (NewEntry | PlainEntry) & { data: string[] };
 export type MetaEntry = (NewEntry | PlainEntry) & { children: string[] };
 
@@ -112,36 +119,54 @@ export type EnumerateConditions = {
 export class DirectFileManipulator implements LiveSyncLocalDBEnv {
     liveSyncLocalDB: LiveSyncLocalDB;
     options: DirectFileManipulatorOptions;
+    readonly runtimeOptions: DirectFileManipulatorRuntimeOptions;
     ready = promiseWithResolvers<void>();
     services: HeadlessServiceHub<ServiceContext>;
     public async init() {
-        await this.services.appLifecycle.onReady();
-        await this.liveSyncLocalDB.initializeDatabase();
-        this.ready.resolve();
-        this.liveSyncLocalDB.refreshSettings();
+        try {
+            await this.services.appLifecycle.onReady();
+            await this.liveSyncLocalDB.initializeDatabase();
+            this.liveSyncLocalDB.refreshSettings();
+            this.ready.resolve();
+        } catch (error) {
+            this.ready.reject(error);
+        }
     }
-    getBoundDatabaseService(options: () => DirectFileManipulatorOptions): typeof HeadlessDatabaseService {
+    getBoundDatabaseService(
+        options: () => DirectFileManipulatorOptions,
+        runtimeOptions: DirectFileManipulatorRuntimeOptions
+    ): typeof HeadlessDatabaseService {
         const _option = options;
+        const _runtimeOptions = runtimeOptions;
         return class HeadlessDatabaseServiceExt<T extends ServiceContext> extends HeadlessDatabaseService<T> {
             override createPouchDBInstance<T extends object>(
                 _name?: string,
                 _options?: PouchDB.Configuration.DatabaseConfiguration
             ): PouchDB.Database<T> {
                 const option = _option();
-                return new PouchDB(option.url + "/" + option.database, {
+                const pouchDBOptions: PouchDB.Configuration.DatabaseConfiguration = {
                     auth: { username: option.username, password: option.password },
-                });
+                };
+                if (_runtimeOptions.fetch) {
+                    pouchDBOptions.fetch = _runtimeOptions.fetch;
+                }
+                return new PouchDB(option.url + "/" + option.database, pouchDBOptions);
             }
         };
     }
 
-    constructor(options: DirectFileManipulatorOptions) {
+    constructor(
+        options: DirectFileManipulatorOptions,
+        runtimeOptions: DirectFileManipulatorRuntimeOptions = {}
+    ) {
         this.options = options;
-        const getSettings = () => this.settings as any;
+        this.runtimeOptions = runtimeOptions;
+        const getSettings = () => this.settings;
         const context = new ServiceContext();
         this.services = new HeadlessServiceHub(context, {
             pouchDB: PouchDB,
-            database: this.getBoundDatabaseService(() => this.options),
+            database: this.getBoundDatabaseService(() => this.options, this.runtimeOptions),
+            databaseLifecycleMode: "direct-access",
         });
 
         // (this.services.setting as InjectableSettingService<ServiceContext>).currentSettings.setHandler(
@@ -155,9 +180,14 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
             console.warn("Loading settings is not supported in DirectFileManipulator.");
             return Promise.resolve(getSettings());
         });
+        this.services.setting.settings = getSettings();
         // this.services.database.createPouchDBInstance.setHandler(this.$$createPouchDBInstance.bind(this));
         this.services.databaseEvents.onDatabaseInitialisation.addHandler(this.$everyOnInitializeDatabase.bind(this));
         this.liveSyncLocalDB = new LiveSyncLocalDB(this.options.url, this);
+        // Callers observe constructor-started initialisation through `ready`. Register a
+        // handler immediately so a failure cannot become an unhandled rejection before
+        // the host starts awaiting that promise.
+        void this.ready.promise.catch((): void => {});
         void this.init();
     }
 
@@ -244,7 +274,7 @@ export class DirectFileManipulator implements LiveSyncLocalDBEnv {
     }
 
     get settings() {
-        const retObj: RemoteDBSettings = {
+        const retObj: ObsidianLiveSyncSettings = {
             ...DEFAULT_SETTINGS,
             ...{
                 minimumChunkSize: this.options.minimumChunkSize ?? DEFAULT_SETTINGS.minimumChunkSize,

--- a/src/API/DirectFileManipulatorV2.unit.spec.ts
+++ b/src/API/DirectFileManipulatorV2.unit.spec.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
 import { promiseWithResolvers } from "octagonal-wheels/promises";
 
+import type { FilePath } from "@lib/common/types.ts";
+import { path2id_base } from "@lib/string_and_binary/path.ts";
 import type { HeadlessDatabaseService } from "@lib/services/implements/headless/HeadlessDatabaseService.ts";
 import { ServiceContext } from "@lib/services/base/ServiceBase.ts";
 
+const loggerCalls = vi.hoisted(() => vi.fn());
 const pouchDBCalls = vi.hoisted(
     () => [] as Array<{ name: string; options: PouchDB.Configuration.DatabaseConfiguration }>
 );
+
+vi.mock("octagonal-wheels/common/logger", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("octagonal-wheels/common/logger")>()),
+    Logger: loggerCalls,
+}));
 
 vi.mock("@lib/pouchdb/pouchdb-http.ts", () => ({
     PouchDB: class {
@@ -119,7 +127,26 @@ describe("DirectFileManipulator", () => {
         expect(settings.usePathObfuscation).toBe(true);
     });
 
-    it("keeps its watch callback contained when a changed document cannot be decrypted", async () => {
+    it("uses the dedicated path-obfuscation passphrase when it differs from the encryption passphrase", async () => {
+        const options: DirectFileManipulatorOptions = {
+            url: "https://example.com/couchdb",
+            database: "vault",
+            username: "alice",
+            password: "secret",
+            passphrase: "encryption-secret",
+            obfuscatePassphrase: "path-secret",
+            handleFilenameCaseSensitive: true,
+        };
+        const path = "note.md" as FilePath;
+        const manipulator = new DirectFileManipulator(options);
+        const expected = await path2id_base(path, "path-secret", false);
+        const encryptionDerived = await path2id_base(path, "encryption-secret", false);
+
+        await expect(manipulator.path2id(path)).resolves.toBe(expected);
+        expect(expected).not.toBe(encryptionDerived);
+    });
+
+    it("keeps its watch callback contained and reports a generic document-load failure", async () => {
         const changes = {
             on: vi.fn().mockReturnThis(),
             cancel: vi.fn(),
@@ -133,9 +160,10 @@ describe("DirectFileManipulator", () => {
                     changes: vi.fn(() => changes),
                 },
             },
-            getByMeta: vi.fn().mockRejectedValue(new Error("decryption failed")),
+            getByMeta: vi.fn().mockRejectedValue(new Error("chunk unavailable")),
         } as unknown as DirectFileManipulator;
 
+        loggerCalls.mockClear();
         DirectFileManipulator.prototype.beginWatch.call(manipulator, callback);
         const changeHandler = changes.on.mock.calls.find(([event]) => event === "change")?.[1] as
             | ((change: { doc: { type: "plain"; path: string }; seq: number }) => Promise<void>)
@@ -146,5 +174,10 @@ describe("DirectFileManipulator", () => {
             changeHandler({ doc: { type: "plain", path: "encrypted.md" }, seq: 1 })
         ).resolves.toBeUndefined();
         expect(callback).not.toHaveBeenCalled();
+        expect(loggerCalls).toHaveBeenCalledWith(
+            "WATCH: DOCUMENT LOAD FAILED: encrypted.md",
+            expect.anything(),
+            "watch"
+        );
     });
 });

--- a/src/API/DirectFileManipulatorV2.unit.spec.ts
+++ b/src/API/DirectFileManipulatorV2.unit.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { promiseWithResolvers } from "octagonal-wheels/promises";
+
+import type { HeadlessDatabaseService } from "@lib/services/implements/headless/HeadlessDatabaseService.ts";
+import { ServiceContext } from "@lib/services/base/ServiceBase.ts";
+
+const pouchDBCalls = vi.hoisted(
+    () => [] as Array<{ name: string; options: PouchDB.Configuration.DatabaseConfiguration }>
+);
+
+vi.mock("@lib/pouchdb/pouchdb-http.ts", () => ({
+    PouchDB: class {
+        constructor(name: string, options: PouchDB.Configuration.DatabaseConfiguration) {
+            pouchDBCalls.push({ name, options });
+        }
+    },
+}));
+
+import {
+    DirectFileManipulator,
+    type DirectFileManipulatorOptions,
+    type DirectFileManipulatorRuntimeOptions,
+} from "./DirectFileManipulatorV2.ts";
+
+type GetBoundDatabaseService = (
+    options: () => DirectFileManipulatorOptions,
+    runtime: DirectFileManipulatorRuntimeOptions
+) => typeof HeadlessDatabaseService;
+
+describe("DirectFileManipulator", () => {
+    it("reports initialisation failures through the ready promise", async () => {
+        const failure = new Error("CouchDB initialisation failed");
+        const ready = promiseWithResolvers<void>();
+        const refreshSettings = vi.fn();
+        const manipulator = {
+            services: {
+                appLifecycle: {
+                    onReady: vi.fn().mockResolvedValue(undefined),
+                },
+            },
+            liveSyncLocalDB: {
+                initializeDatabase: vi.fn().mockRejectedValue(failure),
+                refreshSettings,
+            },
+            ready,
+        } as unknown as DirectFileManipulator;
+
+        await expect(DirectFileManipulator.prototype.init.call(manipulator)).resolves.toBeUndefined();
+        await expect(ready.promise).rejects.toBe(failure);
+        expect(refreshSettings).not.toHaveBeenCalled();
+    });
+
+    it("passes the host fetch implementation to its direct CouchDB connection", () => {
+        const fetch = vi.fn<typeof globalThis.fetch>();
+        const options: DirectFileManipulatorOptions = {
+            url: "https://example.com/couchdb",
+            database: "vault",
+            username: "alice",
+            password: "secret",
+            passphrase: undefined,
+            obfuscatePassphrase: undefined,
+        };
+        const getBoundDatabaseService = DirectFileManipulator.prototype
+            .getBoundDatabaseService as unknown as GetBoundDatabaseService;
+        const BoundDatabaseService = getBoundDatabaseService(() => options, { fetch });
+        const database = new BoundDatabaseService(new ServiceContext(), {} as never);
+
+        database.createPouchDBInstance();
+
+        expect(pouchDBCalls).toEqual([
+            {
+                name: "https://example.com/couchdb/vault",
+                options: {
+                    auth: { username: "alice", password: "secret" },
+                    fetch,
+                },
+            },
+        ]);
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
-export { DirectFileManipulator, type DirectFileManipulatorOptions } from "./API/DirectFileManipulator.ts";
+export {
+    DirectFileManipulator,
+    type DirectFileManipulatorOptions,
+    type DirectFileManipulatorRuntimeOptions,
+} from "./API/DirectFileManipulator.ts";

--- a/src/managers/LiveSyncManagers.ts
+++ b/src/managers/LiveSyncManagers.ts
@@ -77,7 +77,7 @@ export class LiveSyncManagers {
 
     protected getManagerMembers() {
         this.log("Creating LiveSync Managers...");
-        const database = this.options.databaseService.localDatabase.localDatabase;
+        const database = this.options.database;
 
         const changeManager = new ChangeManager<EntryDoc>({
             database,

--- a/src/managers/LiveSyncManagers.unit.spec.ts
+++ b/src/managers/LiveSyncManagers.unit.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@lib/managers/ChangeManager.ts", () => ({ ChangeManager: class {} }));
+vi.mock("@lib/managers/ChunkFetcher.ts", () => ({ ChunkFetcher: class {} }));
+vi.mock("@lib/managers/ChunkManager.ts", () => ({ ChunkManager: class {} }));
+vi.mock("@lib/managers/ConflictManager.ts", () => ({ ConflictManager: class {} }));
+vi.mock("@lib/managers/EntryManager/EntryManager.ts", () => ({ EntryManager: class {} }));
+vi.mock("@lib/managers/HashManager/HashManager.ts", () => ({ HashManager: class {} }));
+vi.mock("@lib/ContentSplitter/ContentSplitters.ts", () => ({ ContentSplitter: class {} }));
+
+import { LiveSyncManagers } from "./LiveSyncManagers";
+
+describe("LiveSyncManagers", () => {
+    it("uses the database instance supplied by its owner", () => {
+        const databaseService = Object.defineProperty({}, "localDatabase", {
+            get() {
+                throw new Error("The owning DatabaseService has no local database");
+            },
+        });
+
+        expect(
+            () =>
+                new LiveSyncManagers({
+                    database: {} as never,
+                    databaseService: databaseService as never,
+                    settingService: {} as never,
+                    pathService: {} as never,
+                    replicatorService: { finiteReplicationActivityCount: 0 } as never,
+                    APIService: { addLog() {} } as never,
+                })
+        ).not.toThrow();
+    });
+});

--- a/src/services/HeadlessServices.ts
+++ b/src/services/HeadlessServices.ts
@@ -77,9 +77,13 @@ export class HeadlessServiceHub<T extends ServiceContext> extends InjectableServ
             database?: Constructor<DatabaseService<T>>;
             openKeyValueDatabase?: KeyValueDatabaseFactory;
             onDisplayLanguageChanged?: (language: ObsidianLiveSyncSettings["displayLanguage"]) => void;
+            /** Direct database clients do not run application-level replication or key-value database lifecycles. */
+            databaseLifecycleMode?: "application" | "direct-access";
         }
     ) {
         const context = (_context ?? new ServiceContext()) as T;
+        const registerApplicationDatabaseLifecycle =
+            (overrideServiceConstructor.databaseLifecycleMode ?? "application") === "application";
         const API = new HeadlessAPIService<T>(context);
         const conflict = new InjectableConflictService(context);
         const fileProcessing = new InjectableFileProcessingService(context);
@@ -122,6 +126,7 @@ export class HeadlessServiceHub<T extends ServiceContext> extends InjectableServ
             settingService: setting,
             appLifecycleService: appLifecycle,
             databaseEventService: databaseEvents,
+            registerLifecycleHandlers: registerApplicationDatabaseLifecycle,
         });
         const replication = new InjectableReplicationService(context, {
             APIService: API,
@@ -138,6 +143,7 @@ export class HeadlessServiceHub<T extends ServiceContext> extends InjectableServ
             appLifecycle: appLifecycle,
             databaseEvents: databaseEvents,
             vault: vault,
+            registerLifecycleHandlers: registerApplicationDatabaseLifecycle,
         });
         const control = new ControlService(context, {
             appLifecycleService: appLifecycle,

--- a/src/services/HeadlessServices.ts
+++ b/src/services/HeadlessServices.ts
@@ -77,6 +77,8 @@ export class HeadlessServiceHub<T extends ServiceContext> extends InjectableServ
             database?: Constructor<DatabaseService<T>>;
             openKeyValueDatabase?: KeyValueDatabaseFactory;
             onDisplayLanguageChanged?: (language: ObsidianLiveSyncSettings["displayLanguage"]) => void;
+            /** Optional host capability when path obfuscation uses a secret distinct from content encryption. */
+            getPathObfuscationPassphrase?: () => string | false;
             /** Direct database clients do not run application-level replication or key-value database lifecycles. */
             databaseLifecycleMode?: "application" | "direct-access";
         }
@@ -110,6 +112,7 @@ export class HeadlessServiceHub<T extends ServiceContext> extends InjectableServ
         const databaseEvents = new InjectableDatabaseEventService(context);
         const path = new PathServiceCompat(context, {
             settingService: setting,
+            getPathObfuscationPassphrase: overrideServiceConstructor.getPathObfuscationPassphrase,
         });
         const database = new (overrideServiceConstructor.database ?? HeadlessDatabaseService<T>)(context, {
             pouchDB: overrideServiceConstructor.pouchDB,

--- a/src/services/base/KeyValueDBService.ts
+++ b/src/services/base/KeyValueDBService.ts
@@ -13,6 +13,7 @@ export interface KeyValueDBDependencies<T extends ServiceContext = ServiceContex
     databaseEvents: InjectableDatabaseEventService<T>;
     vault: IVaultService;
     appLifecycle: AppLifecycleServiceBase<T>;
+    registerLifecycleHandlers?: boolean;
 }
 /**
  * The KeyValueDBService provides methods for managing the local key-value database.
@@ -119,11 +120,13 @@ export abstract class KeyValueDBService<T extends ServiceContext = ServiceContex
         this.vault = dependencies.vault;
         this.appLifecycle = dependencies.appLifecycle;
         this.openKeyValueDatabase = dependencies.openKeyValueDatabase;
-        this.databaseEvents.onResetDatabase.addHandler(this._everyOnResetDatabase.bind(this));
-        this.appLifecycle.onSettingLoaded.addHandler(this._everyOnloadAfterLoadSettings.bind(this));
-        this.databaseEvents.onDatabaseInitialisation.addHandler(this._everyOnInitializeDatabase.bind(this));
-        this.databaseEvents.onUnloadDatabase.addHandler(this._onOtherDatabaseUnload.bind(this));
-        this.databaseEvents.onCloseDatabase.addHandler(this._onOtherDatabaseClose.bind(this));
+        if (dependencies.registerLifecycleHandlers ?? true) {
+            this.databaseEvents.onResetDatabase.addHandler(this._everyOnResetDatabase.bind(this));
+            this.appLifecycle.onSettingLoaded.addHandler(this._everyOnloadAfterLoadSettings.bind(this));
+            this.databaseEvents.onDatabaseInitialisation.addHandler(this._everyOnInitializeDatabase.bind(this));
+            this.databaseEvents.onUnloadDatabase.addHandler(this._onOtherDatabaseUnload.bind(this));
+            this.databaseEvents.onCloseDatabase.addHandler(this._onOtherDatabaseClose.bind(this));
+        }
     }
 
     openSimpleStore<T>(kind: string) {

--- a/src/services/base/KeyValueDBService.unit.spec.ts
+++ b/src/services/base/KeyValueDBService.unit.spec.ts
@@ -15,6 +15,34 @@ vi.mock("octagonal-wheels/promises", async (importOriginal) => {
 class TestKeyValueDBService extends KeyValueDBService {}
 
 describe("KeyValueDBService factory boundary", () => {
+    it("does not register application database lifecycle handlers for direct access", () => {
+        const onSettingLoaded = vi.fn();
+        const onResetDatabase = vi.fn();
+        const onDatabaseInitialisation = vi.fn();
+        const onUnloadDatabase = vi.fn();
+        const onCloseDatabase = vi.fn();
+        const dependencies = {
+            openKeyValueDatabase: vi.fn(),
+            vault: { getVaultName: () => "test-vault" },
+            appLifecycle: { onSettingLoaded: { addHandler: onSettingLoaded } },
+            databaseEvents: {
+                onResetDatabase: { addHandler: onResetDatabase },
+                onDatabaseInitialisation: { addHandler: onDatabaseInitialisation },
+                onUnloadDatabase: { addHandler: onUnloadDatabase },
+                onCloseDatabase: { addHandler: onCloseDatabase },
+            },
+            registerLifecycleHandlers: false,
+        } as unknown as KeyValueDBDependencies;
+
+        new TestKeyValueDBService(createServiceContext(), dependencies);
+
+        expect(onSettingLoaded).not.toHaveBeenCalled();
+        expect(onResetDatabase).not.toHaveBeenCalled();
+        expect(onDatabaseInitialisation).not.toHaveBeenCalled();
+        expect(onUnloadDatabase).not.toHaveBeenCalled();
+        expect(onCloseDatabase).not.toHaveBeenCalled();
+    });
+
     it("creates a namespaced store handle before the backing database is initialised", () => {
         const dependencies = {
             openKeyValueDatabase: vi.fn(),

--- a/src/services/base/PathService.ts
+++ b/src/services/base/PathService.ts
@@ -15,6 +15,11 @@ import type { BASE_IS_NEW, EVEN, TARGET_IS_NEW } from "@lib/common/models/shared
 
 export interface PathServiceDependencies {
     settingService: ISettingService;
+    /**
+     * Optional host capability for consumers which keep content encryption and
+     * path-obfuscation passphrases separate.
+     */
+    getPathObfuscationPassphrase?: () => string | false;
 }
 /**
  * The PathService provides methods for converting between file paths and document IDs.
@@ -25,6 +30,7 @@ export abstract class PathService<T extends ServiceContext = ServiceContext>
     implements IPathService
 {
     protected settingService: ISettingService;
+    private readonly getPathObfuscationPassphrase?: () => string | false;
     protected abstract normalizePath(path: string): string;
     get settings() {
         return this.settingService.currentSettings();
@@ -32,6 +38,7 @@ export abstract class PathService<T extends ServiceContext = ServiceContext>
     constructor(context: T, dependencies: PathServiceDependencies) {
         super(context);
         this.settingService = dependencies.settingService;
+        this.getPathObfuscationPassphrase = dependencies.getPathObfuscationPassphrase;
     }
     private _id2path(id: DocumentID, entry?: EntryHasPath): FilePathWithPrefix {
         const filename = id2path_base(id, entry);
@@ -80,9 +87,12 @@ export abstract class PathService<T extends ServiceContext = ServiceContext>
     async path2id(filename: FilePathWithPrefix | FilePath, prefix?: string): Promise<DocumentID> {
         const destPath = addPrefix(filename, prefix ?? "");
         const setting = this.settings;
+        const pathObfuscationPassphrase =
+            this.getPathObfuscationPassphrase?.() ??
+            (setting.usePathObfuscation ? setting.passphrase : false);
         return await this._path2id(
             destPath,
-            setting.usePathObfuscation ? setting.passphrase : "",
+            pathObfuscationPassphrase,
             !setting.handleFilenameCaseSensitive
         );
     }

--- a/src/services/base/PathService.unit.spec.ts
+++ b/src/services/base/PathService.unit.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_SETTINGS, type FilePath, type ObsidianLiveSyncSettings } from "@lib/common/types.ts";
+import { path2id_base } from "@lib/string_and_binary/path.ts";
+import { PathServiceCompat } from "@lib/services/implements/injectable/InjectablePathService.ts";
+import type { ISettingService } from "./IService.ts";
+import { ServiceContext } from "./ServiceBase.ts";
+
+describe("PathService", () => {
+    it("uses an optional host path-obfuscation passphrase without changing the settings default", async () => {
+        const settings: ObsidianLiveSyncSettings = {
+            ...DEFAULT_SETTINGS,
+            usePathObfuscation: true,
+            passphrase: "content-secret",
+            handleFilenameCaseSensitive: true,
+        };
+        const settingService = {
+            currentSettings: () => settings,
+        } as unknown as ISettingService;
+        const path = "note.md" as FilePath;
+        const defaultService = new PathServiceCompat(new ServiceContext(), { settingService });
+        const hostService = new PathServiceCompat(new ServiceContext(), {
+            settingService,
+            getPathObfuscationPassphrase: () => "path-secret",
+        });
+
+        await expect(defaultService.path2id(path)).resolves.toBe(
+            await path2id_base(path, "content-secret", false)
+        );
+        await expect(hostService.path2id(path)).resolves.toBe(await path2id_base(path, "path-secret", false));
+    });
+});

--- a/src/services/base/ReplicatorService.ts
+++ b/src/services/base/ReplicatorService.ts
@@ -23,6 +23,7 @@ export interface ReplicatorServiceDependencies {
     appLifecycleService: AppLifecycleService;
     databaseEventService: DatabaseEventService;
     activityRunner?: AsyncActivityRunner;
+    registerLifecycleHandlers?: boolean;
 }
 /**
  * The ReplicatorService provides methods for managing replication.
@@ -49,13 +50,15 @@ export abstract class ReplicatorService<T extends ServiceContext = ServiceContex
         this.appLifecycleService = dependencies.appLifecycleService;
         this._unresolvedErrorManager = new UnresolvedErrorManager(dependencies.appLifecycleService, this.context.events);
         this.settingService = dependencies.settingService;
-        this.settingService.onRealiseSetting.addHandler(this._initialiseReplicator.bind(this));
         this.databaseEventService = dependencies.databaseEventService;
-        this.databaseEventService.onResetDatabase.addHandler(this.disposeReplicator.bind(this));
-        this.databaseEventService.onDatabaseInitialisation.addHandler(this.disposeReplicator.bind(this));
-        this.databaseEventService.onDatabaseInitialised.addHandler(this.reinitialiseReplicator.bind(this));
-        this.databaseEventService.onDatabaseHasReady.addHandler(this.reinitialiseReplicator.bind(this));
-        this.appLifecycleService.onSuspending.addHandler(this.suspendReplication.bind(this));
+        if (dependencies.registerLifecycleHandlers ?? true) {
+            this.settingService.onRealiseSetting.addHandler(this._initialiseReplicator.bind(this));
+            this.databaseEventService.onResetDatabase.addHandler(this.disposeReplicator.bind(this));
+            this.databaseEventService.onDatabaseInitialisation.addHandler(this.disposeReplicator.bind(this));
+            this.databaseEventService.onDatabaseInitialised.addHandler(this.reinitialiseReplicator.bind(this));
+            this.databaseEventService.onDatabaseHasReady.addHandler(this.reinitialiseReplicator.bind(this));
+            this.appLifecycleService.onSuspending.addHandler(this.suspendReplication.bind(this));
+        }
     }
 
     /**

--- a/src/services/base/ReplicatorService.unit.spec.ts
+++ b/src/services/base/ReplicatorService.unit.spec.ts
@@ -31,6 +31,42 @@ function createService(activityRunner?: AsyncActivityRunner) {
 }
 
 describe("ReplicatorService bounded remote activity", () => {
+    it("does not register application database lifecycle handlers for direct access", () => {
+        const onRealiseSetting = eventHook();
+        const onResetDatabase = eventHook();
+        const onDatabaseInitialisation = eventHook();
+        const onDatabaseInitialised = eventHook();
+        const onDatabaseHasReady = eventHook();
+        const onSuspending = eventHook();
+        const dependencies = {
+            settingService: { onRealiseSetting },
+            appLifecycleService: {
+                getUnresolvedMessages: Object.assign(vi.fn().mockResolvedValue([]), eventHook()),
+                onSuspending,
+            },
+            databaseEventService: {
+                onResetDatabase,
+                onDatabaseInitialisation,
+                onDatabaseInitialised,
+                onDatabaseHasReady,
+            },
+            registerLifecycleHandlers: false,
+        } as unknown as ReplicatorServiceDependencies;
+
+        new TestReplicatorService(new ServiceContext(), dependencies);
+
+        for (const hook of [
+            onRealiseSetting,
+            onResetDatabase,
+            onDatabaseInitialisation,
+            onDatabaseInitialised,
+            onDatabaseHasReady,
+            onSuspending,
+        ]) {
+            expect(hook.addHandler).not.toHaveBeenCalled();
+        }
+    });
+
     it("runs the task through an injected host activity policy", async () => {
         const run = vi.fn<(task: () => unknown, options?: AsyncActivityOptions) => void>();
         const service = createService({

--- a/src/services/implements/headless/HeadlessAPIService.ts
+++ b/src/services/implements/headless/HeadlessAPIService.ts
@@ -6,6 +6,7 @@ import type { Confirm, ConfirmActionLayout } from "@lib/interfaces/Confirm";
 // const module = await import("node:crypto");
 import module from "node:crypto";
 import { _activeDocument } from "@lib/common/coreEnvFunctions.ts";
+import { Logger } from "@lib/common/logger";
 
 declare const MANIFEST_VERSION: string | undefined;
 // declare const PACKAGE_VERSION: string | undefined;
@@ -69,6 +70,7 @@ export class HeadlessAPIService<T extends ServiceContext> extends InjectableAPIS
     constructor(context: T) {
         super(context);
         this._confirmInstance = new HeadlessConfirm();
+        this.addLog.setHandler(Logger);
     }
     get confirm(): Confirm {
         return this._confirmInstance;

--- a/src/services/implements/headless/HeadlessAPIService.unit.spec.ts
+++ b/src/services/implements/headless/HeadlessAPIService.unit.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { LOG_LEVEL_INFO } from "octagonal-wheels/common/logger";
+import { ServiceContext } from "../../base/ServiceBase";
+import { HeadlessAPIService } from "./HeadlessAPIService";
+
+describe("HeadlessAPIService", () => {
+    it("accepts service log messages without a host-provided handler", () => {
+        const service = new HeadlessAPIService(new ServiceContext());
+
+        expect(() => service.addLog("Headless service initialised", LOG_LEVEL_INFO, "test")).not.toThrow();
+    });
+});

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Improved
+
+- `DirectFileManipulator` can receive a host fetch implementation for direct CouchDB access in runtimes such as Deno.
+- Direct file manipulation now reports initialisation failures through its readiness promise and avoids application-owned replication and key-value database lifecycle work.
+- Headless logging and manager construction use the capabilities supplied by their composition.
+
 ### Deprecated
 
 - `SvelteDialogMixIn` remains available for compatibility, but maintained hosts should compose their dialogue lifecycle explicitly.

--- a/updates.md
+++ b/updates.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- `DirectFileManipulator` now yields metadata-only enumeration results, restores path obfuscation from its passphrase option, and contains decryption failures observed while watching changes (PR #22). Thank you to @es617 for the fixes!
+- `DirectFileManipulator` now yields metadata-only enumeration results, restores its dedicated path-obfuscation passphrase, and contains document loading failures observed while watching changes (PR #22). Thank you to @es617 for the fixes!
 - `DirectFileManipulator` now reports initialisation failures through its readiness promise, and headless logging and manager construction use the capabilities supplied by their composition. This also addresses the start-up failures independently identified in PR #50. Thank you to @adriy-be for the diagnosis and proposed fixes!
 
 ### Deprecated


### PR DESCRIPTION
This patch release makes `DirectFileManipulator` usable from Deno-based direct CouchDB hosts, restores behaviours lost during the service refactor, and prepares Commonlib 0.1.1.

## Summary

- accept a host-provided `fetch` implementation through `DirectFileManipulatorRuntimeOptions`;
- report constructor-started initialisation failures through the existing readiness promise;
- keep application-owned replication and key-value database lifecycles out of direct database access;
- connect headless logging and construct LiveSync managers from the database supplied by their owner;
- restore metadata-only enumeration and the dedicated path-obfuscation passphrase, and contain document-loading failures while watching changes;
- document LiveSync Bridge as a maintained direct-access consumer; and
- prepare `@vrtmrz/livesync-commonlib` 0.1.1.

## Related contributions

This branch incorporates PR #22 as a parent and preserves all commits from @es617. Its `DirectFileManipulator` wiring is resolved through the current typed service composition rather than private database fields.

The readiness and headless-handler failure paths were also identified independently by @adriy-be in PR #50. That PR's file-move and controlled-shutdown changes remain separate from this release, while the relevant diagnosis and proposed fixes are credited in `updates.md`.

## Design boundary

LiveSync Bridge continues to use `DirectFileManipulator` directly against CouchDB. This change does not introduce `createLiveSyncFileClient`, turn the Service Hub into a consumer-owned composition root, or make the manipulator a stable high-level SDK contract.

LiveSync Bridge already owns reachability probes, retry policy, and process health. Commonlib now accepts its native `fetch` capability and owns database initialisation, readiness reporting, and the direct-access lifecycle profile.

## Verification

- `npm ci`
- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package`
- 69 test files and 1,214 tests
- seven package-boundary tests
- 20 release-selection tests
- packed-package type and bundle consumers
- package build with 109 explicit compatibility exports

The earlier LiveSync Bridge consumer validation covered Deno check, lint, unit tests, and a Compose integration against CouchDB 3.5.0. The exact published 0.1.1 registry artefact will be validated in LiveSync Bridge before publication is considered complete.
