### PR TITLE
Prepare @vrtmrz/livesync-commonlib 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.2-rc.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.2-rc.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.2-rc.0",
+  "version": "0.1.2",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.1.2-rc.0
+## 0.1.2
 
 ### Fixed
 


### PR DESCRIPTION
This stable release preparation promotes the validated `@vrtmrz/livesync-commonlib@0.1.2-rc.0` contents to version `0.1.2`, enabling the exact reviewed main commit to be staged and validated before `latest` promotion.

## Summary

- Change the source manifest and lockfile version from `0.1.2-rc.0` to `0.1.2`.
- Publish the two validated fixes under the stable `0.1.2` heading in `updates.md`.
- Keep the generated package configured for public publication on `next`; this pull request does not publish the package or change any registry dist-tag.

## Rationale

The exact `0.1.2-rc.0` registry artefact passed downstream checks and focused real-Obsidian validation before [#87](https://github.com/vrtmrz/livesync-commonlib/pull/87) was merged. The stable staged-publishing workflow requires the package source and trusted workflow commit to be the same exact commit on `main`, so this version-only pull request creates that reviewable release commit.

## Verification

- [x] Reviewed toolchain: Node.js `24.18.0` and npm `11.18.0`.
- [x] `npm install --package-lock-only --ignore-scripts --no-audit --no-fund`
- [x] `npm ci`
- [x] `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package`
  - 69 test files and 1,216 tests passed.
  - Type, package-boundary, release-selection, build, and isolated packed-consumer checks passed.
  - The package build retained 109 explicit compatibility exports.
- [x] `npm publish --dry-run .package --tag next --access public`
  - Package: `@vrtmrz/livesync-commonlib@0.1.2`
  - Files: 500
  - Packed size: 393,729 bytes
  - Local candidate SHA-256: `b302529cd88b8397f918b0be6adb57deca65dc3d86d006b8ece66a8f336e8ae3`
  - npm shasum: `16db730f4fa5428c7a9704e192d1e50e1fd463fa`
  - Integrity: `sha512-nGwSbA1cm4kyfuRXjODGLEVPtV0q5h7CrIrcXbchb03zKciUyilHMACqK9v8ETXQ5BNIsw6aDPF68GwhN0rzmA==`

## Remaining release gates

- [x] Merge the exact reviewed release commit into `main`.
- [ ] Stage `0.1.2` from that exact `main` commit through the trusted workflow on the `next` tag.
- [ ] Inspect the staged package name, version, access, dist-tag, provenance, checksum, files, source ref, and source commit before approval.
- [ ] Approve the staged package and compare the published registry artefact with the reviewed stage.
- [ ] Validate the exact registry `0.1.2` artefact in Self-hosted LiveSync through clean installation, builds, focused automated tests, and real-Obsidian E2E.
- [ ] Promote the already validated `0.1.2` version from `next` to `latest` as a separate operation.
