### PR TITLE
Defer local node initialisation until replicator activation

### DIFF
--- a/src/replication/couchdb/LiveSyncReplicator.ts
+++ b/src/replication/couchdb/LiveSyncReplicator.ts
@@ -137,11 +137,6 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
     constructor(env: LiveSyncCouchDBReplicatorEnv) {
         super(env);
         this.env = env;
-        // initialize local node information.
-        void this.initializeDatabaseForReplication();
-        this.rawDatabase.on("close", () => {
-            this.closeReplication();
-        });
     }
 
     getInitialSyncParameters(setting: RemoteDBSettings): Promise<SyncParameters> {
@@ -211,7 +206,9 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         showResult: boolean,
         ignoreCleanLock: boolean
     ) {
-        await this.initializeDatabaseForReplication();
+        if (!(await this.initializeDatabaseForReplication())) {
+            return false;
+        }
         if (keepAlive) {
             void this.openContinuousReplication(setting, showResult, false);
         } else {

--- a/src/replication/couchdb/LiveSyncReplicator.unit.spec.ts
+++ b/src/replication/couchdb/LiveSyncReplicator.unit.spec.ts
@@ -3,6 +3,35 @@ import type { DocumentID, EntryLeaf, RemoteDBSettings } from "@lib/common/types.
 import { createServiceContext } from "@lib/services/base/ServiceBase";
 import { LiveSyncCouchDBReplicator } from "./LiveSyncReplicator.ts";
 
+describe("LiveSyncCouchDBReplicator initialisation", () => {
+    it("allows a remote-only connection check before the local database is ready", async () => {
+        const getLocalDatabase = vi.fn(() => {
+            throw new Error("Local database is not ready yet.");
+        });
+        const env = {
+            services: {
+                API: {
+                    isMobile: () => false,
+                },
+                database: {
+                    get localDatabase() {
+                        return getLocalDatabase();
+                    },
+                },
+            },
+        } as unknown as ConstructorParameters<typeof LiveSyncCouchDBReplicator>[0];
+
+        const replicator = new LiveSyncCouchDBReplicator(env);
+        vi.spyOn(replicator, "connectRemoteCouchDBWithSetting").mockResolvedValue({
+            db: {},
+            info: { db_name: "remote" },
+        } as never);
+
+        await expect(replicator.tryConnectRemote({} as RemoteDBSettings, false)).resolves.toBe(true);
+        expect(getLocalDatabase).not.toHaveBeenCalled();
+    });
+});
+
 describe("LiveSyncCouchDBReplicator continuous catch-up", () => {
     it("exposes the initial pull-only catch-up as finite replication activity", async () => {
         const runFiniteReplicationActivity = vi.fn(async <T>(task: () => Promise<T>) => await task());

--- a/src/replication/journal/LiveSyncJournalReplicator.ts
+++ b/src/replication/journal/LiveSyncJournalReplicator.ts
@@ -19,7 +19,7 @@ import { MinioStorageAdapter } from "./objectstore/MinioStorageAdapter.ts";
 import { LiveSyncAbstractReplicator, type RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";
 import { ensureRemoteIsCompatible, type ENSURE_DB_RESULT } from "@lib/pouchdb/LiveSyncDBFunctions.ts";
 import type { CheckPointInfo } from "./JournalSyncTypes.ts";
-import { fireAndForget, type SimpleStore } from "@lib/common/utils.ts";
+import type { SimpleStore } from "@lib/common/utils.ts";
 
 import { extractObject } from "@lib/common/utils.ts";
 import { clearHandlers } from "@lib/replication/SyncParamsHandler.ts";
@@ -95,11 +95,6 @@ export class LiveSyncJournalReplicator extends LiveSyncAbstractReplicator {
     constructor(env: LiveSyncJournalReplicatorEnv) {
         super(env);
         this.env = env;
-        // initialize local node information.
-        fireAndForget(() => this.initializeDatabaseForReplication());
-        this.rawDatabase.on("close", () => {
-            this.closeReplication();
-        });
     }
 
     async migrate(from: number, to: number): Promise<boolean> {

--- a/src/replication/journal/LiveSyncJournalReplicator.unit.spec.ts
+++ b/src/replication/journal/LiveSyncJournalReplicator.unit.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { LiveSyncJournalReplicator } from "./LiveSyncJournalReplicator.ts";
+
+describe("LiveSyncJournalReplicator initialisation", () => {
+    it("does not access the local database while constructing a remote-only replicator", () => {
+        const getLocalDatabase = vi.fn(() => {
+            throw new Error("Local database is not ready yet.");
+        });
+        const env = {
+            services: {
+                database: {
+                    get localDatabase() {
+                        return getLocalDatabase();
+                    },
+                },
+            },
+        } as unknown as ConstructorParameters<typeof LiveSyncJournalReplicator>[0];
+
+        expect(() => new LiveSyncJournalReplicator(env)).not.toThrow();
+        expect(getLocalDatabase).not.toHaveBeenCalled();
+    });
+});

--- a/src/services/base/ReplicatorService.ts
+++ b/src/services/base/ReplicatorService.ts
@@ -181,6 +181,13 @@ export abstract class ReplicatorService<T extends ServiceContext = ServiceContex
             // Probably we need to clear all synchronising parameters handlers
             // Note that parameters handler keeps an key-deriving salt in memory,
             // so we need to clear them when the replicator changes, to avoid potential database corruption.
+            if (!(await newReplicator.initializeDatabaseForReplication())) {
+                this._log("Failed to initialise the replicator's local node information.");
+                this._activeReplicator = undefined;
+                this._replicatorType = undefined;
+                this._unresolvedErrorManager.showError(message, LOG_LEVEL_NOTICE);
+                return false;
+            }
             if (!(await this.onReplicatorInitialised())) {
                 this._log("Failed to initialise the replicator, onReplicatorInitialised reported some problems.");
                 this._activeReplicator = undefined;

--- a/src/services/base/ReplicatorService.unit.spec.ts
+++ b/src/services/base/ReplicatorService.unit.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import { ReplicatorService, type ReplicatorServiceDependencies } from "./ReplicatorService.ts";
 import { ServiceContext } from "./ServiceBase.ts";
 import type { AsyncActivityOptions, AsyncActivityRunner } from "@lib/interfaces/AsyncActivityRunner.ts";
+import { REMOTE_COUCHDB } from "@lib/common/types.ts";
+import type { LiveSyncAbstractReplicator } from "@lib/replication/LiveSyncAbstractReplicator.ts";
 
 class TestReplicatorService extends ReplicatorService<ServiceContext> {}
 
@@ -29,6 +31,57 @@ function createService(activityRunner?: AsyncActivityRunner) {
     } as unknown as ReplicatorServiceDependencies;
     return new TestReplicatorService(new ServiceContext(), dependencies);
 }
+
+describe("ReplicatorService lifecycle", () => {
+    it("initialises local node information only when a replicator becomes active", async () => {
+        let realiseSettings!: () => Promise<boolean>;
+        const initialiseLocalNode = vi.fn(async () => true);
+        const initialisationOrder: string[] = [];
+        initialiseLocalNode.mockImplementation(async () => {
+            initialisationOrder.push("local-node");
+            return true;
+        });
+        const replicator = {
+            initializeDatabaseForReplication: initialiseLocalNode,
+        } as unknown as LiveSyncAbstractReplicator;
+        const dependencies = {
+            settingService: {
+                currentSettings: () => ({
+                    remoteType: REMOTE_COUCHDB,
+                    couchDB_URI: "https://example.com",
+                    couchDB_DBNAME: "vault",
+                }),
+                onRealiseSetting: {
+                    addHandler: vi.fn((handler: () => Promise<boolean>) => {
+                        realiseSettings = handler;
+                    }),
+                },
+            },
+            appLifecycleService: {
+                getUnresolvedMessages: Object.assign(vi.fn().mockResolvedValue([]), eventHook()),
+                onSuspending: eventHook(),
+            },
+            databaseEventService: {
+                onResetDatabase: eventHook(),
+                onDatabaseInitialisation: eventHook(),
+                onDatabaseInitialised: eventHook(),
+                onDatabaseHasReady: eventHook(),
+            },
+        } as unknown as ReplicatorServiceDependencies;
+        const service = new TestReplicatorService(new ServiceContext(), dependencies);
+        service.getNewReplicator.addHandler(() => Promise.resolve(replicator));
+        service.onReplicatorInitialised.addHandler(() => {
+            initialisationOrder.push("host-handlers");
+            return Promise.resolve(true);
+        });
+
+        await expect(realiseSettings()).resolves.toBe(true);
+
+        expect(initialiseLocalNode).toHaveBeenCalledOnce();
+        expect(initialisationOrder).toEqual(["local-node", "host-handlers"]);
+        expect(service.getActiveReplicator()).toBe(replicator);
+    });
+});
 
 describe("ReplicatorService bounded remote activity", () => {
     it("does not register application database lifecycle handlers for direct access", () => {

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Remote-only connection and configuration checks no longer access the local database while constructing a replicator, preventing start-up failures before local database initialisation ([Self-hosted LiveSync issue #1064](https://github.com/vrtmrz/obsidian-livesync/issues/1064)).
+
 ## 0.1.2
 
 ### Fixed


### PR DESCRIPTION
Fix replicator construction so remote-only configuration checks can run before the local database is ready.

## Summary

- Remove eager local node initialisation and local database close-handler registration from the CouchDB and journal replicator constructors.
- Initialise local node information when `ReplicatorService` activates the selected replicator, before host initialisation handlers run.
- Stop CouchDB replication cleanly when local node initialisation fails.
- Add focused regression coverage for CouchDB, journal, and service lifecycle behaviour.

## Root cause

The CouchDB and journal replicator constructors accessed `rawDatabase` unconditionally. Onboarding and configuration checks create temporary replicators before the local database is ready, so construction could raise `Local database is not ready yet.` before the remote check began.

The maintained LiveSync host already owns replication shutdown through its local database lifecycle. Moving node initialisation to active-replicator setup therefore removes the premature database access without weakening shutdown handling.

## Impact

Remote-only connection and configuration checks no longer require an initialised local database. Replicators selected for active use still receive their local node identity before host-specific initialisation. This changes no public API.

Related to vrtmrz/obsidian-livesync#1064.

## Verification

- Confirmed that the new regression tests fail against unmodified `origin/main` for the reported behavioural reason, including the unhandled `Local database is not ready yet.` rejection.
- Focused regression tests: 10 passed.
- Full Commonlib unit suite: 1,219 passed.
- TypeScript check passed.
- Package boundary tests: 7 passed.
- Release-selection tests: 20 passed.
- Package boundary audit passed.
- Packed-package build and clean-consumer verification passed.
- [Downstream CI](https://github.com/vrtmrz/livesync-commonlib/actions/runs/30916849899) passed against Commonlib `75a2112f` and Self-hosted LiveSync `e9b2477b`; it installed the exact Commonlib tarball, ran the LiveSync type and unit checks, built the plug-in, CLI, WebApp, and WebPeer, and completed CLI E2E.
- The focused real-Obsidian `couchdb-manual-setup-workflow` passed with Obsidian 1.12.7 against the exact Commonlib `75a2112f` tarball (SHA-256 `73a267b670dfd82af56ce7e017964589ca7e0e41d8c1577b1977a7f51b5ee918`) and Self-hosted LiveSync `e9b2477b`. Starting from an unconfigured fresh Vault, it completed manual CouchDB setup and database creation, Rebuild, second-device provisioning through a Setup URI and Fetch, and a bidirectional note round-trip.
