### PR TITLE
Prepare @vrtmrz/livesync-commonlib 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",
@@ -1908,9 +1908,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.3
+
 ### Fixed
 
 - Remote-only connection and configuration checks no longer access the local database while constructing a replicator, preventing start-up failures before local database initialisation ([Self-hosted LiveSync issue #1064](https://github.com/vrtmrz/obsidian-livesync/issues/1064)).


### PR DESCRIPTION
This stable release preparation packages the merged remote-only replicator initialisation fix as `@vrtmrz/livesync-commonlib@0.1.3` and refreshes a vulnerable transitive dependency before staged publication.

## Summary

- Change the source manifest and lockfile version from `0.1.2` to `0.1.3`.
- Publish the merged issue #1064 fix under the stable `0.1.3` heading in `updates.md`.
- Resolve `brace-expansion` from `5.0.8` to `5.0.9` inside the existing dependency range.
- Keep the generated package configured for public publication on `next`; this pull request does not publish the package or change any registry dist-tag.

## Rationale

[#89](https://github.com/vrtmrz/livesync-commonlib/pull/89) moved local node initialisation from temporary replicator construction to active-replicator setup. Remote-only connection and configuration checks can therefore run before the local database is ready, while an active replicator still receives its local node identity before host initialisation handlers run.

The stable staged-publishing workflow requires the package source and trusted workflow commit to be the same exact commit on `main`, so this pull request creates the reviewable 0.1.3 release commit. Release preparation also exposed a High-severity denial-of-service advisory in the locked `brace-expansion 5.0.8`; the patched 5.0.9 release satisfies the existing parent range and requires no public API or direct dependency change.

## Verification

- [x] Reviewed toolchain: Node.js `24.18.0` and npm `11.18.0`.
- [x] `npm update brace-expansion --package-lock-only --ignore-scripts --no-audit --no-fund`
  - The dependency diff is limited to `brace-expansion 5.0.8 -> 5.0.9`.
- [x] `npm ci`
- [x] `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package`
  - 70 test files and 1,219 tests passed.
  - Type, package-boundary, release-selection, build, and isolated packed-consumer checks passed.
  - The package build retained 109 explicit compatibility exports.
- [x] `npm audit --omit=dev`
  - High and Critical findings: 0.
  - The existing PouchDB and `uuid` graph retains 18 Moderate dependency entries and is outside this release change.
- [x] Complete `npm audit`
  - High and Critical findings: 0.
  - The full graph retains 19 Moderate dependency entries, including one development-only PostCSS entry.
- [x] [#89 downstream CI](https://github.com/vrtmrz/livesync-commonlib/actions/runs/30916849899) passed against the exact fix commit and Self-hosted LiveSync `e9b2477b`, including LiveSync type and unit checks, plug-in and application builds, and CLI E2E.
- [x] The focused real-Obsidian `couchdb-manual-setup-workflow` passed against the exact fix tarball and Self-hosted LiveSync `e9b2477b`.
- [x] `npm publish --dry-run .package --tag next --access public`
  - Package: `@vrtmrz/livesync-commonlib@0.1.3`
  - Files: 500
  - Packed size: 393,920 bytes
  - Local candidate SHA-256: `d74deb4fbd13f262a4f3e538cbe76c7e5a7c826fad82d1aaaa1435f4660517d6`
  - npm shasum: `c34e413480dc080f59431edc6518e13c29ef47c3`
  - Integrity: `sha512-CbzQT87X7CdoehoJmjE9IhHdVhjQX066SNWEciZpr2U0KNhVb+H0EwzHRKj6/SffQNSWEpTjFcJteaCD1vqKrw==`

## Remaining release gates

- [ ] Merge the exact reviewed release commit into `main`.
- [ ] Stage `0.1.3` from that exact `main` commit through the trusted workflow on the `next` tag.
- [ ] Inspect the staged package name, version, access, dist-tag, provenance, checksum, files, source ref, and source commit before approval.
- [ ] Approve the staged package and compare the published registry artefact with the reviewed stage.
- [ ] Validate the exact registry `0.1.3` artefact in Self-hosted LiveSync through clean installation, builds, focused automated tests, a refreshed consumer lockfile audit, and real-Obsidian E2E.
- [ ] Promote the already validated `0.1.3` version from `next` to `latest` as a separate operation.

