### PR TITLE
Prepare Commonlib 0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.4
+
 ### Added
 
 - The settings schema now includes controls for allowing operating-system sleep during finite synchronisation operations on every platform or on desktop only. Setup URIs preserve both preferences.


### PR DESCRIPTION
Prepares `@vrtmrz/livesync-commonlib` 0.1.4 so the platform-aware sleep settings merged in #91 can be published for consumer integration.

## Summary

- Update the source package and lockfile versions from 0.1.3 to 0.1.4.
- Record the synchronisation sleep controls under the 0.1.4 release heading.
- Keep dependency versions and the generated package boundary unchanged.

## Release notes

### Added

- The settings schema now includes controls for allowing operating-system sleep during finite synchronisation operations on every platform or on desktop only. Setup URIs preserve both preferences.

## Verification

- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package` — 1,220 tests passed, with type, boundary, release-selection, and package checks successful
- `npx --yes npm@11.18.0 publish --dry-run .package --tag next --access public`
- Dry-run package: `@vrtmrz/livesync-commonlib@0.1.4`
- Dry-run integrity: `sha512-a6+NmjLE+kn76wTu8iHDal99eOktrrfWUxKK5rSxJH80uWcKvRrGru9aOYpxu1lFLDDNg3Eq15cDR5pWyTvJrQ==`
- Dry-run contents: 500 files, 394.6 kB packed, and 1.7 MB unpacked
