### PR TITLE
Distinguish remote preferred setting results

### DIFF
--- a/docs/proven-in-use.md
+++ b/docs/proven-in-use.md
@@ -20,6 +20,8 @@ Commonlib's chunk-reachability tests use real PouchDB revision trees. They verif
 
 Commonlib's injected CouchDB tests verify that a mixed remote chunk batch preserves available documents when another requested ID is absent. Its chunk-delivery tests separately verify that available chunks reach local storage and only absent IDs are marked unavailable. Self-hosted LiveSync supplies the real CouchDB connection and start-up composition, so device-specific replication timing remains downstream integration evidence rather than Commonlib unit coverage.
 
+Commonlib's remote-preference result contract distinguishes available synchronisation settings, a remote which has not stored those settings yet, a failed read, and a remote type which does not support central preferences. Focused CouchDB and Object Storage tests cover absent milestone data separately from transport failures, while Self-hosted LiveSync owns the initialisation choices, cancellation policy, and user-facing explanation.
+
 Most replication and storage services used by the plug-in still enter through explicit `compat/*` paths. Those imports prove that the published compatibility boundary supports the current migration; they are not examples of a finished high-level client API.
 
 The plug-in's manual onboarding and Remote Databases pane use the focused `/remote-configurations` entry to create opaque profile IDs, retain user-visible names, and select main and P2P remotes. Commonlib owns the in-memory profile result contract; Self-hosted LiveSync adds dialogue, Setup URI classification, Fetch or Rebuild scheduling, persistence, restart ordering, and real-Obsidian presentation checks.

--- a/src/common/models/tweak.definition.ts
+++ b/src/common/models/tweak.definition.ts
@@ -88,3 +88,38 @@ export const TweakValuesTemplate = {
 export type TweakValues = Partial<typeof TweakValuesTemplate>;
 
 export const DEVICE_ID_PREFERRED = "PREFERRED";
+
+export const RemotePreferredTweakStatuses = {
+    AVAILABLE: "available",
+    NOT_CONFIGURED: "not-configured",
+    UNAVAILABLE: "unavailable",
+    UNSUPPORTED: "unsupported",
+} as const;
+
+export type RemotePreferredTweakStatus =
+    (typeof RemotePreferredTweakStatuses)[keyof typeof RemotePreferredTweakStatuses];
+
+export const RemotePreferredTweakNotConfiguredReasons = {
+    MILESTONE_MISSING: "milestone-missing",
+    PREFERRED_VALUES_MISSING: "preferred-values-missing",
+} as const;
+
+export type RemotePreferredTweakNotConfiguredReason =
+    (typeof RemotePreferredTweakNotConfiguredReasons)[keyof typeof RemotePreferredTweakNotConfiguredReasons];
+
+export type RemotePreferredTweakResult =
+    | {
+          status: typeof RemotePreferredTweakStatuses.AVAILABLE;
+          values: TweakValues;
+      }
+    | {
+          status: typeof RemotePreferredTweakStatuses.NOT_CONFIGURED;
+          reason: RemotePreferredTweakNotConfiguredReason;
+      }
+    | {
+          status: typeof RemotePreferredTweakStatuses.UNAVAILABLE;
+          error: unknown;
+      }
+    | {
+          status: typeof RemotePreferredTweakStatuses.UNSUPPORTED;
+      };

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -204,6 +204,11 @@ import {
     TweakValuesTemplate,
     type TweakValues,
     DEVICE_ID_PREFERRED,
+    RemotePreferredTweakStatuses,
+    type RemotePreferredTweakStatus,
+    RemotePreferredTweakNotConfiguredReasons,
+    type RemotePreferredTweakNotConfiguredReason,
+    type RemotePreferredTweakResult,
 } from "./models/tweak.definition.ts";
 import type {
     diff_result_leaf,
@@ -344,6 +349,11 @@ export { confDesc };
 export { TweakValuesTemplate };
 export type { TweakValues };
 export { DEVICE_ID_PREFERRED };
+export { RemotePreferredTweakStatuses };
+export type { RemotePreferredTweakStatus };
+export { RemotePreferredTweakNotConfiguredReasons };
+export type { RemotePreferredTweakNotConfiguredReason };
+export type { RemotePreferredTweakResult };
 
 export type { NodeKey };
 export type { DeviceInfo };

--- a/src/replication/LiveSyncAbstractReplicator.ts
+++ b/src/replication/LiveSyncAbstractReplicator.ts
@@ -6,6 +6,7 @@ import {
     type EntryNodeInfo,
     NODEINFO_DOCID,
     type TweakValues,
+    type RemotePreferredTweakResult,
     type NodeData,
 } from "@lib/common/types.ts";
 
@@ -176,7 +177,7 @@ export abstract class LiveSyncAbstractReplicator {
     abstract fetchRemoteChunks(missingChunks: string[], showResult: boolean): Promise<false | EntryLeaf[]>;
 
     abstract getRemoteStatus(setting: RemoteDBSettings): Promise<false | RemoteDBStatus>;
-    abstract getRemotePreferredTweakValues(setting: RemoteDBSettings): Promise<false | TweakValues>;
+    abstract getRemotePreferredTweakValues(setting: RemoteDBSettings): Promise<RemotePreferredTweakResult>;
 
     abstract countCompromisedChunks(setting?: RemoteDBSettings): Promise<number | boolean>;
 

--- a/src/replication/couchdb/LiveSyncReplicator.ts
+++ b/src/replication/couchdb/LiveSyncReplicator.ts
@@ -23,6 +23,9 @@ import {
     ProtocolVersions,
     type NodeData,
     type DeviceInfo,
+    RemotePreferredTweakNotConfiguredReasons,
+    type RemotePreferredTweakResult,
+    RemotePreferredTweakStatuses,
 } from "@lib/common/types.ts";
 import {
     resolveWithIgnoreKnownError,
@@ -35,6 +38,7 @@ import {
 } from "@lib/common/utils.ts";
 import { Logger } from "@lib/common/logger.ts";
 import { checkRemoteVersion, countCompromisedChunks } from "@lib/pouchdb/negotiation.ts";
+import { isErrorOfMissingDoc } from "@lib/pouchdb/utils_couchdb.ts";
 import { preprocessOutgoing } from "@lib/pouchdb/encryption.ts";
 
 import { ensureDatabaseIsCompatible } from "@lib/pouchdb/LiveSyncDBFunctions.ts";
@@ -1279,29 +1283,78 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         }
     }
 
-    async getRemotePreferredTweakValues(setting: RemoteDBSettings): Promise<TweakValues | false> {
+    async getRemotePreferredTweakValues(setting: RemoteDBSettings): Promise<RemotePreferredTweakResult> {
         const uri =
             setting.couchDB_URI.replace(/\/+$/, "") +
             (setting.couchDB_DBNAME == "" ? "" : "/" + setting.couchDB_DBNAME);
-        const dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
+        let dbRet: Awaited<ReturnType<typeof this.connectRemoteCouchDBWithSetting>>;
+        try {
+            dbRet = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
+        } catch (ex) {
+            Logger(`Could not connect to the remote database`, LOG_LEVEL_NOTICE);
+            Logger(ex, LOG_LEVEL_VERBOSE);
+            return {
+                status: RemotePreferredTweakStatuses.UNAVAILABLE,
+                error: ex,
+            };
+        }
         if (typeof dbRet === "string") {
             Logger(this.translate("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
-            return false;
+            return {
+                status: RemotePreferredTweakStatuses.UNAVAILABLE,
+                error: new Error(dbRet),
+            };
         }
-        if (!(await checkRemoteVersion(dbRet.db, this.migrate.bind(this), VER))) {
-            Logger(this.translate("liveSyncReplicator.remoteDbCorrupted"), LOG_LEVEL_NOTICE);
-            return false;
+        try {
+            if (!(await checkRemoteVersion(dbRet.db, this.migrate.bind(this), VER))) {
+                const error = new Error("The remote database version is not compatible");
+                Logger(this.translate("liveSyncReplicator.remoteDbCorrupted"), LOG_LEVEL_NOTICE);
+                return {
+                    status: RemotePreferredTweakStatuses.UNAVAILABLE,
+                    error,
+                };
+            }
+        } catch (ex) {
+            Logger(`Could not check the remote database version`, LOG_LEVEL_NOTICE);
+            Logger(ex, LOG_LEVEL_VERBOSE);
+            return {
+                status: RemotePreferredTweakStatuses.UNAVAILABLE,
+                error: ex,
+            };
         }
-        // check local database hash status and remote replicate hash status
+
         try {
             const remoteMilestone = (await dbRet.db.get(MILESTONE_DOCID)) as EntryMilestoneInfo;
-            if (!remoteMilestone) throw new Error("Remote milestone not found");
-            return remoteMilestone?.tweak_values?.[DEVICE_ID_PREFERRED] || false;
+            if (!remoteMilestone) {
+                return {
+                    status: RemotePreferredTweakStatuses.NOT_CONFIGURED,
+                    reason: RemotePreferredTweakNotConfiguredReasons.MILESTONE_MISSING,
+                };
+            }
+            const preferred = remoteMilestone.tweak_values?.[DEVICE_ID_PREFERRED];
+            if (!preferred) {
+                return {
+                    status: RemotePreferredTweakStatuses.NOT_CONFIGURED,
+                    reason: RemotePreferredTweakNotConfiguredReasons.PREFERRED_VALUES_MISSING,
+                };
+            }
+            return {
+                status: RemotePreferredTweakStatuses.AVAILABLE,
+                values: preferred,
+            };
         } catch (ex) {
-            // While trying unlocking and not exist on the remote, it is not normal.
+            if (isErrorOfMissingDoc(ex)) {
+                return {
+                    status: RemotePreferredTweakStatuses.NOT_CONFIGURED,
+                    reason: RemotePreferredTweakNotConfiguredReasons.MILESTONE_MISSING,
+                };
+            }
             Logger(`Could not retrieve remote milestone`, LOG_LEVEL_NOTICE);
             Logger(ex, LOG_LEVEL_VERBOSE);
-            return false;
+            return {
+                status: RemotePreferredTweakStatuses.UNAVAILABLE,
+                error: ex,
+            };
         }
     }
 

--- a/src/replication/couchdb/LiveSyncReplicator.unit.spec.ts
+++ b/src/replication/couchdb/LiveSyncReplicator.unit.spec.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
-import type { DocumentID, EntryLeaf, RemoteDBSettings } from "@lib/common/types.ts";
+import {
+    DEVICE_ID_PREFERRED,
+    MILESTONE_DOCID,
+    VER,
+    VERSIONING_DOCID,
+    type DocumentID,
+    type EntryLeaf,
+    type RemoteDBSettings,
+} from "@lib/common/types.ts";
 import { createServiceContext } from "@lib/services/base/ServiceBase";
 import { LiveSyncCouchDBReplicator } from "./LiveSyncReplicator.ts";
 
@@ -29,6 +37,110 @@ describe("LiveSyncCouchDBReplicator initialisation", () => {
 
         await expect(replicator.tryConnectRemote({} as RemoteDBSettings, false)).resolves.toBe(true);
         expect(getLocalDatabase).not.toHaveBeenCalled();
+    });
+});
+
+describe("LiveSyncCouchDBReplicator remote preferred tweak values", () => {
+    const setting = {
+        couchDB_URI: "https://example.invalid",
+        couchDB_DBNAME: "remote",
+    } as RemoteDBSettings;
+
+    function createReplicator(get: ReturnType<typeof vi.fn>) {
+        const env = {
+            services: {
+                API: {
+                    isMobile: () => false,
+                },
+            },
+        } as unknown as ConstructorParameters<typeof LiveSyncCouchDBReplicator>[0];
+        const replicator = new LiveSyncCouchDBReplicator(env);
+        vi.spyOn(replicator, "connectRemoteCouchDBWithSetting").mockResolvedValue({
+            db: { get },
+            info: { db_name: "remote" },
+        } as never);
+        return replicator;
+    }
+
+    function createRemoteGet(milestone: unknown | (() => never)) {
+        return vi.fn(async (id: string) => {
+            if (id === VERSIONING_DOCID) {
+                return { _id: VERSIONING_DOCID, type: "versioninfo", version: VER };
+            }
+            if (id === MILESTONE_DOCID) {
+                if (typeof milestone === "function") return milestone();
+                return milestone;
+            }
+            throw new Error(`Unexpected document: ${id}`);
+        });
+    }
+
+    it("distinguishes a remote database without a milestone from an unavailable remote", async () => {
+        const missing = { status: 404, name: "not_found", message: "missing" };
+        const replicator = createReplicator(
+            createRemoteGet(() => {
+                throw missing;
+            })
+        );
+
+        await expect(replicator.getRemotePreferredTweakValues(setting)).resolves.toEqual({
+            status: "not-configured",
+            reason: "milestone-missing",
+        });
+    });
+
+    it("reports a remote read failure as unavailable", async () => {
+        const failure = new Error("network failed");
+        const replicator = createReplicator(
+            createRemoteGet(() => {
+                throw failure;
+            })
+        );
+
+        await expect(replicator.getRemotePreferredTweakValues(setting)).resolves.toEqual({
+            status: "unavailable",
+            error: failure,
+        });
+    });
+
+    it("does not treat a missing remote database as an unconfigured milestone", async () => {
+        const failure = { status: 404, name: "not_found", message: "Database does not exist" };
+        const replicator = createReplicator(createRemoteGet({}));
+        vi.mocked(replicator.connectRemoteCouchDBWithSetting).mockRejectedValueOnce(failure);
+
+        await expect(replicator.getRemotePreferredTweakValues(setting)).resolves.toEqual({
+            status: "unavailable",
+            error: failure,
+        });
+    });
+
+    it("distinguishes a milestone without preferred values", async () => {
+        const replicator = createReplicator(
+            createRemoteGet({
+                _id: MILESTONE_DOCID,
+                tweak_values: {},
+            })
+        );
+
+        await expect(replicator.getRemotePreferredTweakValues(setting)).resolves.toEqual({
+            status: "not-configured",
+            reason: "preferred-values-missing",
+        });
+    });
+
+    it("returns available preferred values explicitly", async () => {
+        const values = { encrypt: true };
+        const replicator = createReplicator(
+            createRemoteGet({
+                _id: MILESTONE_DOCID,
+                tweak_values: { [DEVICE_ID_PREFERRED]: values },
+            })
+        );
+
+        await expect(replicator.getRemotePreferredTweakValues(setting)).resolves.toEqual({
+            status: "available",
+            values,
+        });
     });
 });
 

--- a/src/replication/journal/JournalSyncCore.ts
+++ b/src/replication/journal/JournalSyncCore.ts
@@ -28,7 +28,11 @@ import { shareRunningResult } from "octagonal-wheels/concurrency/lock";
 import { wrappedDeflate, wrappedInflate } from "@lib/pouchdb/compress.ts";
 import { type CheckPointInfo, CheckPointInfoDefault } from "./JournalSyncTypes.ts";
 import type { LiveSyncJournalReplicatorEnv } from "./LiveSyncJournalReplicatorEnv.ts";
-import type { IJournalStorage } from "./objectstore/JournalStorageAdapter.ts";
+import {
+    JournalStorageReadStatuses,
+    type IJournalStorage,
+    type JournalStorageReadResult,
+} from "./objectstore/JournalStorageAdapter.ts";
 
 import {
     clearHandlers,
@@ -144,6 +148,24 @@ export class JournalSyncCore {
             Logger(`Could not download json ${key}`);
             Logger(ex, LOG_LEVEL_VERBOSE);
             return false;
+        }
+    }
+
+    async downloadJsonWithResult<T>(key: string): Promise<JournalStorageReadResult<T>> {
+        const result = await this.storage.downloadWithResult(key, true);
+        if (result.status !== JournalStorageReadStatuses.AVAILABLE) return result;
+        try {
+            return {
+                status: JournalStorageReadStatuses.AVAILABLE,
+                value: JSON.parse(new TextDecoder().decode(result.value)) as T,
+            };
+        } catch (ex) {
+            Logger(`Could not parse downloaded json ${key}`);
+            Logger(ex, LOG_LEVEL_VERBOSE);
+            return {
+                status: JournalStorageReadStatuses.UNAVAILABLE,
+                error: ex,
+            };
         }
     }
 

--- a/src/replication/journal/JournalSyncCore.unit.spec.ts
+++ b/src/replication/journal/JournalSyncCore.unit.spec.ts
@@ -47,6 +47,11 @@ describe("JournalSyncCore", () => {
                 if (data === undefined) return false;
                 return data;
             }),
+            downloadWithResult: vi.fn(async (file: string) => {
+                const data = virtualStorage.get(file);
+                if (data === undefined) return { status: "not-found" as const };
+                return { status: "available" as const, value: data };
+            }),
             listFiles: vi.fn(async () => {
                 return Array.from(virtualStorage.keys());
             }),
@@ -108,6 +113,30 @@ describe("JournalSyncCore", () => {
 
             const fetched = await core.getSyncParameters();
             expect(fetched.pbkdf2salt).toBe("salt");
+        });
+    });
+
+    describe("downloadJsonWithResult", () => {
+        it("preserves a missing-object result", async () => {
+            await expect(core.downloadJsonWithResult("missing.json")).resolves.toEqual({ status: "not-found" });
+        });
+
+        it("parses available JSON", async () => {
+            virtualStorage.set("available.json", new TextEncoder().encode('{"value":42}'));
+
+            await expect(core.downloadJsonWithResult<{ value: number }>("available.json")).resolves.toEqual({
+                status: "available",
+                value: { value: 42 },
+            });
+        });
+
+        it("reports invalid JSON as unavailable", async () => {
+            virtualStorage.set("invalid.json", new TextEncoder().encode("not-json"));
+
+            const result = await core.downloadJsonWithResult("invalid.json");
+
+            expect(result.status).toBe("unavailable");
+            if (result.status === "unavailable") expect(result.error).toBeInstanceOf(SyntaxError);
         });
     });
 

--- a/src/replication/journal/LiveSyncJournalReplicator.ts
+++ b/src/replication/journal/LiveSyncJournalReplicator.ts
@@ -10,6 +10,9 @@ import {
     TweakValuesTemplate,
     type TweakValues,
     type NodeData,
+    RemotePreferredTweakNotConfiguredReasons,
+    type RemotePreferredTweakResult,
+    RemotePreferredTweakStatuses,
 } from "@lib/common/types.ts";
 import { Logger } from "@lib/common/logger.ts";
 
@@ -24,6 +27,7 @@ import type { SimpleStore } from "@lib/common/utils.ts";
 import { extractObject } from "@lib/common/utils.ts";
 import { clearHandlers } from "@lib/replication/SyncParamsHandler.ts";
 import type { LiveSyncJournalReplicatorEnv } from "./LiveSyncJournalReplicatorEnv.ts";
+import { JournalStorageReadStatuses } from "./objectstore/JournalStorageAdapter.ts";
 
 const MILSTONE_DOCID = "_00000000-milestone.json";
 
@@ -302,18 +306,31 @@ export class LiveSyncJournalReplicator extends LiveSyncAbstractReplicator {
         }
     }
 
-    async getRemotePreferredTweakValues(setting: RemoteDBSettings): Promise<false | TweakValues> {
-        try {
-            const remoteMilestone = await this.client.downloadJson<EntryMilestoneInfo>(MILSTONE_DOCID);
-            if (!remoteMilestone) {
-                throw new Error("Missing remote milestone");
-            }
-            return remoteMilestone?.tweak_values?.[DEVICE_ID_PREFERRED] || false;
-        } catch (ex) {
-            Logger(`Could not retrieve remote milestone`, LOG_LEVEL_NOTICE);
-            Logger(ex, LOG_LEVEL_VERBOSE);
-            return false;
+    async getRemotePreferredTweakValues(_setting: RemoteDBSettings): Promise<RemotePreferredTweakResult> {
+        const result = await this.client.downloadJsonWithResult<EntryMilestoneInfo>(MILSTONE_DOCID);
+        if (result.status === JournalStorageReadStatuses.NOT_FOUND) {
+            return {
+                status: RemotePreferredTweakStatuses.NOT_CONFIGURED,
+                reason: RemotePreferredTweakNotConfiguredReasons.MILESTONE_MISSING,
+            };
         }
+        if (result.status === JournalStorageReadStatuses.UNAVAILABLE) {
+            return {
+                status: RemotePreferredTweakStatuses.UNAVAILABLE,
+                error: result.error,
+            };
+        }
+        const preferred = result.value.tweak_values?.[DEVICE_ID_PREFERRED];
+        if (!preferred) {
+            return {
+                status: RemotePreferredTweakStatuses.NOT_CONFIGURED,
+                reason: RemotePreferredTweakNotConfiguredReasons.PREFERRED_VALUES_MISSING,
+            };
+        }
+        return {
+            status: RemotePreferredTweakStatuses.AVAILABLE,
+            values: preferred,
+        };
     }
 
     async getRemoteStatus(setting: RemoteDBSettings): Promise<false | RemoteDBStatus> {

--- a/src/replication/journal/LiveSyncJournalReplicator.unit.spec.ts
+++ b/src/replication/journal/LiveSyncJournalReplicator.unit.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { RemoteDBSettings } from "@lib/common/types.ts";
 import { LiveSyncJournalReplicator } from "./LiveSyncJournalReplicator.ts";
 
 describe("LiveSyncJournalReplicator initialisation", () => {
@@ -18,5 +19,57 @@ describe("LiveSyncJournalReplicator initialisation", () => {
 
         expect(() => new LiveSyncJournalReplicator(env)).not.toThrow();
         expect(getLocalDatabase).not.toHaveBeenCalled();
+    });
+});
+
+describe("LiveSyncJournalReplicator remote preferred tweak values", () => {
+    function createReplicator(result: unknown) {
+        const replicator = Object.create(LiveSyncJournalReplicator.prototype) as LiveSyncJournalReplicator;
+        vi.spyOn(replicator, "setupJournalSyncClient").mockReturnValue({
+            downloadJson: vi.fn().mockResolvedValue(false),
+            downloadJsonWithResult: vi.fn().mockResolvedValue(result),
+        } as never);
+        return replicator;
+    }
+
+    it("distinguishes a missing milestone from an unavailable object store", async () => {
+        const replicator = createReplicator({ status: "not-found" });
+
+        await expect(replicator.getRemotePreferredTweakValues({} as RemoteDBSettings)).resolves.toEqual({
+            status: "not-configured",
+            reason: "milestone-missing",
+        });
+    });
+
+    it("reports an object-store read failure as unavailable", async () => {
+        const failure = new Error("network failed");
+        const replicator = createReplicator({ status: "unavailable", error: failure });
+
+        await expect(replicator.getRemotePreferredTweakValues({} as RemoteDBSettings)).resolves.toEqual({
+            status: "unavailable",
+            error: failure,
+        });
+    });
+
+    it("distinguishes a milestone without preferred values", async () => {
+        const replicator = createReplicator({ status: "available", value: { tweak_values: {} } });
+
+        await expect(replicator.getRemotePreferredTweakValues({} as RemoteDBSettings)).resolves.toEqual({
+            status: "not-configured",
+            reason: "preferred-values-missing",
+        });
+    });
+
+    it("returns available preferred values explicitly", async () => {
+        const values = { encrypt: true };
+        const replicator = createReplicator({
+            status: "available",
+            value: { tweak_values: { PREFERRED: values } },
+        });
+
+        await expect(replicator.getRemotePreferredTweakValues({} as RemoteDBSettings)).resolves.toEqual({
+            status: "available",
+            values,
+        });
     });
 });

--- a/src/replication/journal/objectstore/JournalStorageAdapter.ts
+++ b/src/replication/journal/objectstore/JournalStorageAdapter.ts
@@ -1,9 +1,21 @@
 import type { RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";
 import type { BucketSyncSetting } from "@lib/common/types.ts";
 
+export const JournalStorageReadStatuses = {
+    AVAILABLE: "available",
+    NOT_FOUND: "not-found",
+    UNAVAILABLE: "unavailable",
+} as const;
+
+export type JournalStorageReadResult<T> =
+    | { status: typeof JournalStorageReadStatuses.AVAILABLE; value: T }
+    | { status: typeof JournalStorageReadStatuses.NOT_FOUND }
+    | { status: typeof JournalStorageReadStatuses.UNAVAILABLE; error: unknown };
+
 export interface IJournalStorage {
     upload(key: string, data: Uint8Array, mime: string): Promise<boolean>;
     download(key: string, ignoreCache?: boolean): Promise<Uint8Array | false>;
+    downloadWithResult(key: string, ignoreCache?: boolean): Promise<JournalStorageReadResult<Uint8Array>>;
     listFiles(from: string, limit?: number): Promise<string[]>;
     deleteFiles(keys: string[]): Promise<boolean>;
     isAvailable(): Promise<boolean>;

--- a/src/replication/journal/objectstore/MinioStorageAdapter.ts
+++ b/src/replication/journal/objectstore/MinioStorageAdapter.ts
@@ -15,7 +15,11 @@ import { promiseWithResolvers } from "octagonal-wheels/promises";
 import { LOG_LEVEL_NOTICE, LOG_LEVEL_VERBOSE, type BucketSyncSetting } from "@lib/common/types.ts";
 import { Logger } from "@lib/common/logger.ts";
 import type { RemoteDBStatus } from "@lib/replication/LiveSyncAbstractReplicator.ts";
-import type { IJournalStorage } from "./JournalStorageAdapter.ts";
+import {
+    JournalStorageReadStatuses,
+    type IJournalStorage,
+    type JournalStorageReadResult,
+} from "./JournalStorageAdapter.ts";
 import { parseHeaderValues } from "@lib/common/utils.ts";
 import type { LiveSyncJournalReplicatorEnv } from "@lib/replication/journal/LiveSyncJournalReplicatorEnv.ts";
 import { runWithTrackedPhysicalRequest } from "@lib/services/lib/remoteActivity.ts";
@@ -136,7 +140,7 @@ export class MinioStorageAdapter implements IJournalStorage {
         return false;
     }
 
-    async download(key: string, ignoreCache: boolean = false): Promise<Uint8Array | false> {
+    async downloadWithResult(key: string, ignoreCache: boolean = false): Promise<JournalStorageReadResult<Uint8Array>> {
         const client = this._getClient();
         const cmd = new GetObjectCommand({
             Bucket: this._settings.bucket,
@@ -148,15 +152,32 @@ export class MinioStorageAdapter implements IJournalStorage {
             return await this.runTrackedRequest(async () => {
                 const r = await client.send(cmd);
                 if (r.Body) {
-                    return new Uint8Array(await r.Body.transformToByteArray());
+                    return {
+                        status: JournalStorageReadStatuses.AVAILABLE,
+                        value: new Uint8Array(await r.Body.transformToByteArray()),
+                    };
                 }
-                return false;
+                return {
+                    status: JournalStorageReadStatuses.UNAVAILABLE,
+                    error: new Error(`The response body for ${key} was empty`),
+                };
             });
         } catch (ex) {
+            if (isMissingObjectError(ex)) {
+                return { status: JournalStorageReadStatuses.NOT_FOUND };
+            }
             Logger(`Could not download ${key}`);
             Logger(ex, LOG_LEVEL_VERBOSE);
+            return {
+                status: JournalStorageReadStatuses.UNAVAILABLE,
+                error: ex,
+            };
         }
-        return false;
+    }
+
+    async download(key: string, ignoreCache: boolean = false): Promise<Uint8Array | false> {
+        const result = await this.downloadWithResult(key, ignoreCache);
+        return result.status === JournalStorageReadStatuses.AVAILABLE ? result.value : false;
     }
 
     async listFiles(from: string, limit?: number): Promise<string[]> {
@@ -229,4 +250,11 @@ export class MinioStorageAdapter implements IJournalStorage {
             return false;
         }
     }
+}
+
+function isMissingObjectError(error: unknown): boolean {
+    if (!error || typeof error !== "object") return false;
+    const { name, Code, code } = error as { name?: string; Code?: string; code?: string };
+    const errorCode = Code ?? code ?? name;
+    return errorCode === "NoSuchKey" || errorCode === "NotFound";
 }

--- a/src/replication/journal/objectstore/MinioStorageAdapter.unit.spec.ts
+++ b/src/replication/journal/objectstore/MinioStorageAdapter.unit.spec.ts
@@ -76,6 +76,23 @@ describe("MinioStorageAdapter physical request activity", () => {
         expect(responseCount.value).toBe(1);
     });
 
+    it("distinguishes a missing object from an unavailable object store", async () => {
+        const missing = Object.assign(new Error("The specified key does not exist"), { name: "NoSuchKey" });
+        const { adapter } = createAdapter({ send: vi.fn(() => Promise.reject(missing)) });
+
+        await expect(adapter.downloadWithResult("missing.json")).resolves.toEqual({ status: "not-found" });
+    });
+
+    it("preserves an object-store failure in the detailed download result", async () => {
+        const failure = new Error("network failed");
+        const { adapter } = createAdapter({ send: vi.fn(() => Promise.reject(failure)) });
+
+        await expect(adapter.downloadWithResult("settings.json")).resolves.toEqual({
+            status: "unavailable",
+            error: failure,
+        });
+    });
+
     it("balances activity when an SDK command rejects", async () => {
         const { adapter, requestCount, responseCount } = createAdapter({
             send: vi.fn(() => Promise.reject(new Error("network failed"))),

--- a/src/replication/trystero/LiveSyncTrysteroReplicator.ts
+++ b/src/replication/trystero/LiveSyncTrysteroReplicator.ts
@@ -3,6 +3,8 @@ import {
     type RemoteDBSettings,
     type EntryLeaf,
     type TweakValues,
+    type RemotePreferredTweakResult,
+    RemotePreferredTweakStatuses,
     LOG_LEVEL_NOTICE,
     LOG_LEVEL_INFO,
     LOG_LEVEL_VERBOSE,
@@ -447,12 +449,12 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
         );
         return Promise.resolve(false);
     }
-    getRemotePreferredTweakValues(_setting: RemoteDBSettings): Promise<false | TweakValues> {
+    getRemotePreferredTweakValues(_setting: RemoteDBSettings): Promise<RemotePreferredTweakResult> {
         Logger(
             "Trying to get tweak values but P2P replication does not support to do this. This operation has been ignored",
             LOG_LEVEL_INFO
         );
-        return Promise.resolve(false);
+        return Promise.resolve({ status: RemotePreferredTweakStatuses.UNSUPPORTED });
     }
     countCompromisedChunks(): Promise<number> {
         Logger("P2P Replicator cannot count compromised chunks", LOG_LEVEL_VERBOSE);

--- a/src/replication/trystero/LiveSyncTrysteroReplicator.unit.spec.ts
+++ b/src/replication/trystero/LiveSyncTrysteroReplicator.unit.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { LiveSyncTrysteroReplicator } from "./LiveSyncTrysteroReplicator";
 import { TrysteroReplicator } from "./TrysteroReplicator";
 import { createServiceContext } from "@lib/services/base/ServiceBase";
+import type { RemoteDBSettings } from "@lib/common/types";
 
 function createDeferred() {
     let resolve!: () => void;
@@ -43,6 +44,16 @@ describe("LiveSyncTrysteroReplicator host environment", () => {
 
         expect(runFiniteReplicationActivity).toHaveBeenCalledWith(task, { label: "replication" });
         expect(translate).toHaveBeenCalledWith("P2P.NotEnabled");
+    });
+});
+
+describe("LiveSyncTrysteroReplicator remote preferred tweak values", () => {
+    it("reports that remote preferred values are unsupported", async () => {
+        const replicator = createLifecycleReplicator();
+
+        await expect(replicator.getRemotePreferredTweakValues({} as RemoteDBSettings)).resolves.toEqual({
+            status: "unsupported",
+        });
     });
 });
 

--- a/src/services/base/IService.ts
+++ b/src/services/base/IService.ts
@@ -16,6 +16,7 @@ import type {
     MISSING_OR_ERROR,
     ObsidianLiveSyncSettings,
     RemoteDBSettings,
+    RemotePreferredTweakResult,
     SettingsMigrationState,
     TweakValues,
     UXFileInfo,
@@ -359,7 +360,7 @@ export interface ISettingService {
     deleteSmallConfig(key: string): void;
 }
 export interface ITweakValueService {
-    fetchRemotePreferred(trialSetting: RemoteDBSettings): Promise<TweakValues | false>;
+    fetchRemotePreferred(trialSetting: RemoteDBSettings): Promise<RemotePreferredTweakResult>;
 
     checkAndAskResolvingMismatched(preferred: Partial<TweakValues>): Promise<[TweakValues | boolean, boolean]>;
 

--- a/src/services/base/TweakValueService.ts
+++ b/src/services/base/TweakValueService.ts
@@ -1,4 +1,4 @@
-import type { RemoteDBSettings, TweakValues } from "@lib/common/types";
+import type { RemoteDBSettings, RemotePreferredTweakResult, TweakValues } from "@lib/common/types";
 import type { ITweakValueService } from "./IService";
 import { ServiceBase, type ServiceContext } from "./ServiceBase";
 
@@ -13,7 +13,7 @@ export abstract class TweakValueService<T extends ServiceContext = ServiceContex
      * Fetch and trial the remote database settings to determine if they are preferred.
      * @param trialSetting The remote database settings to connect.
      */
-    abstract fetchRemotePreferred(trialSetting: RemoteDBSettings): Promise<TweakValues | false>;
+    abstract fetchRemotePreferred(trialSetting: RemoteDBSettings): Promise<RemotePreferredTweakResult>;
 
     /**
      * Check and ask the user to resolve any mismatched tweak values.


### PR DESCRIPTION
This change gives remote-preferred synchronisation setting reads explicit outcomes so consumers can distinguish an empty remote from a failed read.

## Summary

- Add a typed result with `available`, `not-configured`, `unavailable`, and `unsupported` states.
- Map CouchDB, Journal, and Object Storage responses to those states without treating transport, authentication, or read failures as an empty remote.
- Expose the result consistently through replicator and tweak-value service boundaries.
- Report P2P as unsupported because it has no central remote synchronisation settings.
- Record the API in the proven-in-use inventory.

## Rationale

The previous `TweakValues | false` result conflated a remote with no saved settings and a remote whose settings could not be read. That prevented setup consumers from giving safe, specific guidance and contributed to the ambiguity reported in vrtmrz/obsidian-livesync#1064.

This changes the return contract for implementations and consumers. Downstream consumers must adopt the typed result when updating to the released package version.

## Verification

```text
npm test -- src/replication/couchdb/LiveSyncReplicator.unit.spec.ts src/replication/journal/JournalSyncCore.unit.spec.ts src/replication/journal/LiveSyncJournalReplicator.unit.spec.ts src/replication/journal/objectstore/MinioStorageAdapter.unit.spec.ts src/replication/trystero/LiveSyncTrysteroReplicator.unit.spec.ts --maxWorkers=1 --no-file-parallelism
```

Result: 5 test files and 37 tests passed.
