### PR TITLE
Prepare Commonlib 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.5
+
+### Changed
+
+- Remote-preferred synchronisation setting reads now report explicit available, not-configured, unavailable, or unsupported outcomes, so clients can distinguish a remote without saved synchronisation settings from one whose settings could not be read.
+
 ## 0.1.4
 
 ### Added


### PR DESCRIPTION
Prepares `@vrtmrz/livesync-commonlib` 0.1.5 so the explicit remote-preferred setting result contract merged in #93 can be published for downstream integration.

## Summary

- Update the source package and lockfile versions from 0.1.4 to 0.1.5.
- Record the result-contract change under the 0.1.5 release heading.
- Keep dependency versions and the generated package boundary unchanged.

## Release notes

### Changed

- Remote-preferred synchronisation setting reads now report explicit available, not-configured, unavailable, or unsupported outcomes, so clients can distinguish a remote without saved synchronisation settings from one whose settings could not be read.

## Verification

- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package` — 1,235 tests passed, with type, boundary, release-selection, and package checks successful
- `npx --yes npm@11.18.0 publish --dry-run .package --tag next --access public`
- Dry-run package: `@vrtmrz/livesync-commonlib@0.1.5`
- Dry-run integrity: `sha512-sMNY91zXScMKZDxWlEIFFbw97+sYJ3pPkwQgiS4ZGrSHAmOqBTPHmIBwV/uVOyyE+oOvdoadpDY2Dn8stx8srg==`
- Dry-run contents: 500 files, 396.3 kB packed, and 1.7 MB unpacked
