### PR TITLE
Make Fast Fetch completion persistence-safe

### DIFF
--- a/src/pouchdb/StreamingFetch.integration.spec.ts
+++ b/src/pouchdb/StreamingFetch.integration.spec.ts
@@ -46,6 +46,7 @@ describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
             // safe to ignore
         }
         remoteDB = new PouchDB(remoteDbUrlWithAuth, { adapter: "http" });
+        await remoteDB.info();
     });
 
     afterEach(async () => {
@@ -61,14 +62,16 @@ describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
         }
     });
 
-    it("should fetch all documents from a populated remote database", async () => {
-        // 1. Put some documents in the remote database
-        const docs = [
-            { _id: "doc1", type: "plain", data: "hello 1" },
-            { _id: "doc2", type: "plain", data: "hello 2" },
-            { _id: "doc3", type: "plain", data: "hello 3" },
-        ];
+    it("should fetch and checkpoint all documents across a batch boundary", async () => {
+        // 1. Put enough documents in the remote database to cross the 100-document batch boundary.
+        const docs = Array.from({ length: 101 }, (_, index) => ({
+            _id: `doc-${index.toString().padStart(3, "0")}`,
+            type: "plain",
+            data: `hello ${index}`,
+        }));
         await remoteDB.bulkDocs(docs);
+        const targetSequence = (await remoteDB.changes({ since: "now", limit: 0 })).last_seq;
+        const checkpoints: Array<string | number> = [];
 
         // 2. Perform streaming fetch
         await fetchChangesForInitialSync(
@@ -77,13 +80,15 @@ describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
             authHeader,
             (doc) => Promise.resolve(doc as any),
             "0",
-            () => {}
+            () => {},
+            (sequence) => checkpoints.push(sequence)
         );
 
         // 3. Verify documents in local database
         const localDocs = await localDB.allDocs({ include_docs: true });
-        expect(localDocs.rows.length).toBe(3);
-        expect(localDocs.rows.map((r) => r.id).sort()).toEqual(["doc1", "doc2", "doc3"]);
+        expect(localDocs.rows.length).toBe(docs.length);
+        expect(localDocs.rows.map((row) => row.id).sort()).toEqual(docs.map((doc) => doc._id));
+        expect(checkpoints.at(-1)?.toString()).toBe(targetSequence.toString());
     });
 
     it("should handle empty database gracefully", async () => {
@@ -100,8 +105,7 @@ describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
         await remoteDB.bulkDocs(docs);
 
         // Get the latest sequence
-        const info: any = await remoteDB.info();
-        const latestSeq = info.update_seq;
+        const latestSeq = (await remoteDB.changes({ since: "now", limit: 0 })).last_seq;
 
         // 2. Perform streaming fetch with "since" set to the latest sequence
         await fetchChangesForInitialSync(

--- a/src/pouchdb/StreamingFetch.ts
+++ b/src/pouchdb/StreamingFetch.ts
@@ -3,93 +3,255 @@ import { LOG_LEVEL_VERBOSE, Logger } from "octagonal-wheels/common/logger";
 import type { EntryDoc } from "@lib/common/models/db.definition";
 import type { AnyEntry, EntryLeaf } from "@lib/common/models/db.type";
 
-// Type definition for each line from the CouchDB _changes API (feed=continuous).
 interface CouchChangeLine {
     seq: number | string;
     id: string;
     changes: Array<{ rev: string }>;
-    doc?: EntryDoc; // include_docs=true includes the full document body.
+    doc?: EntryDoc;
     deleted?: boolean;
 }
 
-// interface AnyDoc {
-//     _id: string;
-// }
 interface AnyDecryptedDoc {
     _id: string;
 }
 
 type DBSequence = number | string;
 
-function generatePouchDBWriteStream(
+/**
+ * Identifies the boundary at which Fast Fetch stopped.
+ *
+ * - `transport`: the request or response stream was interrupted. Only failures
+ *   explicitly created at this boundary may be retried.
+ * - `authentication`: CouchDB rejected the supplied credentials.
+ * - `protocol`: CouchDB returned an unsuccessful or structurally invalid
+ *   response, or an unexpected exception escaped the processing pipeline.
+ * - `decryption`: a remote document could not be decrypted or did not produce a
+ *   serialisable PouchDB document.
+ * - `storage`: a local batch or its durable checkpoint could not be written.
+ *
+ * This remains a string-literal union because the values are discriminants, not
+ * data to enumerate, persist, or map to user-interface labels. The constructor
+ * and consumers therefore receive typo checking without a runtime constants
+ * object becoming part of the package API.
+ */
+export type StreamingFetchFailureStage = "transport" | "authentication" | "protocol" | "decryption" | "storage";
+
+/**
+ * A classified Fast Fetch failure. Retryability is explicit rather than inferred
+ * from the stage so that future exceptions can be narrowed without broadening all
+ * failures at that boundary.
+ */
+export class StreamingFetchFailure extends Error {
+    override readonly name = "StreamingFetchFailure";
+
+    constructor(
+        readonly stage: StreamingFetchFailureStage,
+        message: string,
+        readonly retryable: boolean,
+        options?: { status?: number; cause?: unknown }
+    ) {
+        super(message, options?.cause === undefined ? undefined : { cause: options.cause });
+        this.status = options?.status;
+    }
+
+    readonly status?: number;
+}
+
+export function isRetryableStreamingFetchFailure(error: unknown): error is StreamingFetchFailure {
+    // Do not accept arbitrary errors which happen to contain `retryable: true`.
+    // Only the streaming boundary is allowed to opt a failure into automatic retry.
+    return error instanceof StreamingFetchFailure && error.retryable;
+}
+
+function errorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) return error.message;
+    return String(error);
+}
+
+function asStreamingFetchFailure(error: unknown): StreamingFetchFailure {
+    if (error instanceof StreamingFetchFailure) return error;
+    // An unclassified processing exception has no proven recovery behaviour.
+    // Fail closed instead of turning programmer defects into a retry loop.
+    return new StreamingFetchFailure(
+        "protocol",
+        `Fast Fetch encountered an unexpected processing failure: ${errorMessage(error)}`,
+        false,
+        { cause: error }
+    );
+}
+
+function transportFailure(operation: string, error: unknown): StreamingFetchFailure {
+    return new StreamingFetchFailure("transport", `Fast Fetch could not ${operation}: ${errorMessage(error)}`, true, {
+        cause: error,
+    });
+}
+
+function responseFailure(response: Response, operation: string): StreamingFetchFailure {
+    const status = response.status;
+    if (status === 401 || status === 403) {
+        return new StreamingFetchFailure(
+            "authentication",
+            `Fast Fetch could not ${operation}: CouchDB returned HTTP ${status}.`,
+            false,
+            { status }
+        );
+    }
+    const retryable = status === 408 || status === 429 || status >= 500;
+    return new StreamingFetchFailure(
+        retryable ? "transport" : "protocol",
+        `Fast Fetch could not ${operation}: CouchDB returned HTTP ${status}.`,
+        retryable,
+        { status }
+    );
+}
+
+function ensureResponseOK(response: Response, operation: string): void {
+    if (!response.ok) throw responseFailure(response, operation);
+}
+
+async function fetchResponse(url: string, init: RequestInit, operation: string): Promise<Response> {
+    let response: Response;
+    try {
+        response = await _fetch(url, init);
+    } catch (error) {
+        throw transportFailure(operation, error);
+    }
+    ensureResponseOK(response, operation);
+    return response;
+}
+
+async function readResponseText(response: Response, operation: string): Promise<string> {
+    try {
+        return await response.text();
+    } catch (error) {
+        throw transportFailure(operation, error);
+    }
+}
+
+async function saveCheckpoint(
+    onCheckpoint: ((sequence: DBSequence) => void | Promise<void>) | undefined,
+    sequence: DBSequence
+): Promise<void> {
+    try {
+        await onCheckpoint?.(sequence);
+    } catch (error) {
+        throw new StreamingFetchFailure(
+            "storage",
+            `Fast Fetch could not save its checkpoint: ${errorMessage(error)}`,
+            false,
+            { cause: error }
+        );
+    }
+}
+
+function generatePouchDBBatchWriter(
     downloadToDB: PouchDB.Database,
     decryptFunction: (doc: EntryDoc) => Promise<AnyEntry | EntryLeaf>,
     onCheckpoint?: (sequence: DBSequence) => void | Promise<void>
 ) {
+    // The buffered documents and batchLastSequence form one persistence unit.
+    // A checkpoint may describe this unit only after every document has been
+    // accepted by PouchDB, preserving a contiguous durable prefix of the feed.
     let batchBuffer: AnyDecryptedDoc[] = [];
     let currentBatchSizeBytes = 0;
     let batchLastSequence: DBSequence | undefined;
 
     const BATCH_ITEM_LIMIT = 100;
-    const BATCH_SIZE_LIMIT = 2 * 1024 * 1024; // 2MB
+    const BATCH_SIZE_LIMIT = 2 * 1024 * 1024;
 
-    // Flush the current batch to PouchDB and clear the buffer.
-    let flushPromise: Promise<unknown> | null = null; // To track ongoing flush operations and prevent concurrent flushes.
-    const flushToDB = async () => {
+    const flush = async () => {
         if (batchBuffer.length === 0) return;
-        if (flushPromise) {
-            // If a flush is already in progress, wait for it to complete before starting a new one.
-            await flushPromise;
-        }
+
+        const documents = batchBuffer;
+        const checkpoint = batchLastSequence;
+        let results: Array<PouchDB.Core.Response | PouchDB.Core.Error>;
         try {
-            flushPromise = downloadToDB.bulkDocs(batchBuffer, { new_edits: false });
-            await flushPromise;
-            if (batchLastSequence !== undefined) {
-                await onCheckpoint?.(batchLastSequence);
-            }
+            results = await downloadToDB.bulkDocs(documents, { new_edits: false });
         } catch (error) {
-            Logger("Error bulk writing to PouchDB:", LOG_LEVEL_VERBOSE);
-            Logger(error, LOG_LEVEL_VERBOSE);
-            throw error; // Propagate the error to be handled by the caller.
-        } finally {
-            // Clear the batch buffer and reset the size counter regardless of success or failure to avoid blocking the stream.
+            throw new StreamingFetchFailure(
+                "storage",
+                `Fast Fetch could not write a batch to the local database: ${errorMessage(error)}`,
+                false,
+                { cause: error }
+            );
+        }
+
+        // With new_edits:false, PouchDB may omit successful results and return an
+        // empty array. Inspect every returned item for an error instead of expecting
+        // one success result per input document.
+        const failedResult = results.find(
+            (result): result is PouchDB.Core.Error => "error" in result && Boolean(result.error)
+        );
+        if (failedResult) {
+            const detail = failedResult.message || failedResult.name || "the local database rejected a document";
+            throw new StreamingFetchFailure(
+                "storage",
+                `Fast Fetch could not write a batch to the local database: ${detail}`,
+                false,
+                { cause: failedResult }
+            );
+        }
+
+        if (checkpoint !== undefined) {
+            await saveCheckpoint(onCheckpoint, checkpoint);
+        }
+        // Clear the unit only after both persistence operations succeed. If saving
+        // the checkpoint fails, a later invocation safely replays the already-written
+        // revisions because new_edits:false is idempotent for those revisions.
+        batchBuffer = [];
+        currentBatchSizeBytes = 0;
+        batchLastSequence = undefined;
+    };
+
+    return {
+        async write(doc: EntryDoc, sequence: DBSequence) {
+            let decryptedDoc: AnyEntry | EntryLeaf;
+            try {
+                decryptedDoc = await decryptFunction(doc);
+            } catch (error) {
+                throw new StreamingFetchFailure(
+                    "decryption",
+                    `Fast Fetch could not decrypt a document: ${errorMessage(error)}`,
+                    false,
+                    { cause: error }
+                );
+            }
+
+            let serialisedDoc: string;
+            try {
+                const serialised = JSON.stringify(decryptedDoc);
+                if (serialised === undefined) throw new Error("the decrypted value is not a document");
+                serialisedDoc = serialised;
+            } catch (error) {
+                throw new StreamingFetchFailure(
+                    "decryption",
+                    `Fast Fetch produced an invalid decrypted document: ${errorMessage(error)}`,
+                    false,
+                    { cause: error }
+                );
+            }
+            batchBuffer.push(decryptedDoc);
+            currentBatchSizeBytes += serialisedDoc.length;
+            batchLastSequence = sequence;
+
+            if (batchBuffer.length >= BATCH_ITEM_LIMIT || currentBatchSizeBytes >= BATCH_SIZE_LIMIT) {
+                await flush();
+            }
+        },
+        async flushThrough(sequence: DBSequence) {
+            // A changes row may legitimately have no included document. Earlier
+            // buffered rows must still become durable before its sequence can be
+            // recorded, otherwise the checkpoint would jump over unwritten content.
+            await flush();
+            await saveCheckpoint(onCheckpoint, sequence);
+        },
+        flush,
+        abort() {
             batchBuffer = [];
             currentBatchSizeBytes = 0;
             batchLastSequence = undefined;
-            flushPromise = null;
-        }
+        },
     };
-    return new WritableStream<{ doc: EntryDoc; seq: DBSequence }>({
-        async write(chunk) {
-            try {
-                // 1. Decrypt the document
-                const decryptedDoc = await decryptFunction(chunk.doc);
-
-                // 2. Buffer the decrypted document
-                batchBuffer.push(decryptedDoc);
-                currentBatchSizeBytes += JSON.stringify(decryptedDoc).length;
-                batchLastSequence = chunk.seq;
-
-                // 3. Flush the batch if limits are exceeded
-                if (batchBuffer.length >= BATCH_ITEM_LIMIT || currentBatchSizeBytes >= BATCH_SIZE_LIMIT) {
-                    await flushToDB();
-                }
-            } catch (error) {
-                Logger("Error processing document stream:", LOG_LEVEL_VERBOSE);
-                throw error;
-            }
-        },
-        async close() {
-            // Flush any remaining documents when the stream is closed
-            await flushToDB();
-        },
-        abort(reason) {
-            // Cleanup when the stream is forcibly terminated due to an error or other reasons
-            Logger(`Stream aborted: ${reason}`, LOG_LEVEL_VERBOSE);
-            batchBuffer = [];
-            currentBatchSizeBytes = 0;
-        },
-    });
 }
 
 function setParamsToURL(url: URL, params: Record<string, string>) {
@@ -100,32 +262,62 @@ function setParamsToURL(url: URL, params: Record<string, string>) {
 }
 
 export type FetchChangesForInitialSyncProgress = {
-    totalFetched: number; // Total number of changes fetched from CouchDB (including those without doc bodies).
-    totalValidFetched: number; // Total number of changes with valid doc bodies fetched and processed.
-    targetSeq: number | string; // The target sequence ID that we aim to reach for initial sync completion.
-    docsToFetch: number; // Total number of documents that need to be fetched based on the pending count from CouchDB.
-    totalBytes: number; // Total bytes fetched so far.
+    totalFetched: number;
+    totalValidFetched: number;
+    targetSeq: number | string;
+    docsToFetch: number;
+    totalBytes: number;
 };
 
 type DatabaseSyncStatus = {
-    update_seq?: DBSequence;
     last_seq?: DBSequence;
     pending?: number;
 };
 
-function reachedTargetSequence(seq: DBSequence | undefined, targetSeq: DBSequence | undefined): boolean {
-    if (seq === undefined || targetSeq === undefined) return false;
-    const seqStr = seq.toString();
-    const targetSeqStr = targetSeq.toString();
-    if (seqStr === targetSeqStr) return true;
+function isTargetSequence(sequence: DBSequence | undefined, targetSequence: DBSequence | undefined): boolean {
+    if (sequence === undefined || targetSequence === undefined) return false;
+    return sequence.toString() === targetSequence.toString();
+}
 
-    // CouchDB sequence IDs are typically formatted as "seq_num-opaque_hash" (e.g. "5-g1AAA...") or just integers (e.g. 5).
-    const seqNum = parseInt(seqStr.split("-")[0], 10);
-    const targetSeqNum = parseInt(targetSeqStr.split("-")[0], 10);
-    if (!isNaN(seqNum) && !isNaN(targetSeqNum)) {
-        return seqNum >= targetSeqNum;
+function parseStatusSource(source: string): DatabaseSyncStatus {
+    const trimmed = source.trim();
+    if (!trimmed) {
+        throw new StreamingFetchFailure("protocol", "Fast Fetch received no changes status from CouchDB.", false);
     }
-    return false;
+
+    const candidates = [trimmed, ...trimmed.split("\n").reverse().filter(Boolean)];
+    for (const candidate of candidates) {
+        try {
+            const parsed = JSON.parse(candidate) as unknown;
+            if (parsed && typeof parsed === "object") return parsed as DatabaseSyncStatus;
+        } catch {
+            // Try the final non-blank line when a proxy has returned an NDJSON response.
+        }
+    }
+    throw new StreamingFetchFailure("protocol", "Fast Fetch received an invalid changes status from CouchDB.", false);
+}
+
+function parseChangeLine(line: string): CouchChangeLine {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(line);
+    } catch (error) {
+        throw new StreamingFetchFailure("protocol", "Fast Fetch received a malformed changes-feed row.", false, {
+            cause: error,
+        });
+    }
+    if (!parsed || typeof parsed !== "object" || !("seq" in parsed)) {
+        throw new StreamingFetchFailure(
+            "protocol",
+            "Fast Fetch received a changes-feed row without a sequence.",
+            false
+        );
+    }
+    const change = parsed as Partial<CouchChangeLine>;
+    if (change.seq === undefined || (change.doc !== undefined && (!change.doc || typeof change.doc !== "object"))) {
+        throw new StreamingFetchFailure("protocol", "Fast Fetch received an invalid changes-feed row.", false);
+    }
+    return change as CouchChangeLine;
 }
 
 /**
@@ -146,6 +338,7 @@ export async function fetchChangesForInitialSync(
 ): Promise<void> {
     let totalFetched = 0;
     let totalValidFetched = 0;
+    let totalBytes = 0;
     const changesBaseParams = {
         feed: "continuous",
         include_docs: "true",
@@ -160,107 +353,95 @@ export async function fetchChangesForInitialSync(
         Authorization: authHeader,
     };
 
-    // 1. Fetch database info to get the actual final sequence ID (targetSeq)
-    let targetSeq: DBSequence | undefined = undefined;
-    try {
-        const dbInfoRes = await _fetch(remoteDbUrl, {
-            headers: fetchHeaders,
-        });
-        if (dbInfoRes.ok) {
-            const dbInfo = await dbInfoRes.json();
-            targetSeq = dbInfo.update_seq;
-        }
-    } catch (e) {
-        Logger("Failed to fetch database info for target sequence:", LOG_LEVEL_VERBOSE);
-        Logger(e, LOG_LEVEL_VERBOSE);
-    }
-
-    // 2. Fetch changes status with limit=1 and feed=normal to get the pending count without blocking
-    const fetchURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
+    // Capture the completion boundary from _changes itself. CouchDB treats sequence
+    // tokens as opaque, and a clustered database may encode update_seq from database
+    // information differently from a row at the same logical changes position.
+    const targetURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
         ...changesBaseParams,
         feed: "normal",
-        limit: "1",
+        since: "now",
+        limit: "0",
     });
-
-    const infoRes = await _fetch(fetchURL.toString(), {
-        headers: fetchHeaders,
-    });
-    const infoSource = await infoRes.text();
-    const infoSourceTrimmed = infoSource.trim();
-    if (!infoSourceTrimmed) {
-        throw new Error("Failed to fetch changes from CouchDB. No data received.");
+    const targetResponse = await fetchResponse(
+        targetURL.toString(),
+        { headers: fetchHeaders },
+        "capture the changes target"
+    );
+    const targetStatus = parseStatusSource(await readResponseText(targetResponse, "read the changes target"));
+    const finalTargetSeq = targetStatus.last_seq;
+    if (finalTargetSeq === undefined) {
+        throw new StreamingFetchFailure(
+            "protocol",
+            "Fast Fetch could not obtain an authoritative changes target from CouchDB.",
+            false
+        );
     }
-
-    let info: DatabaseSyncStatus;
-    if (infoSourceTrimmed.startsWith("{") && infoSourceTrimmed.endsWith("}")) {
-        try {
-            info = JSON.parse(infoSourceTrimmed) as DatabaseSyncStatus;
-        } catch {
-            const infoLines = infoSourceTrimmed.split("\n").filter((line) => line.trim() !== "");
-            const lastLine = infoLines[infoLines.length - 1];
-            info = JSON.parse(lastLine) as DatabaseSyncStatus;
-        }
-    } else {
-        const infoLines = infoSourceTrimmed.split("\n").filter((line) => line.trim() !== "");
-        const lastLine = infoLines[infoLines.length - 1];
-        info = JSON.parse(lastLine) as DatabaseSyncStatus;
-    }
-    const pendingDocs = info.pending || 0;
-    const docsToFetch = pendingDocs + 1; // +1 to include the change we just fetched for getting the target sequence.
-
-    // If targetSeq was not fetched successfully from the database info, fallback to the info response
-    if (targetSeq === undefined) {
-        targetSeq = info.last_seq || info.update_seq || (info as { seq?: string | number }).seq;
-    }
-
-    const finalTargetSeq = targetSeq ?? "";
-
-    if (reachedTargetSequence(since, finalTargetSeq)) {
+    if (isTargetSequence(since, finalTargetSeq)) {
         Logger("Already at the target sequence. Initial data synchronisation is complete.");
         return;
     }
 
-    Logger(
-        `Starting initial synchronisation. Current sequence: ${since}, Target sequence: ${finalTargetSeq}, Total documents to fetch: ${docsToFetch}.`
-    );
-    const controller = new AbortController();
-    const url = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
+    const fetchURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
         ...changesBaseParams,
+        feed: "normal",
+        limit: "0",
     });
-    const response = await _fetch(url.toString(), {
-        method: "GET",
-        headers: fetchHeaders,
-        signal: controller.signal,
-    });
+    const infoResponse = await fetchResponse(fetchURL.toString(), { headers: fetchHeaders }, "read changes status");
+    const info = parseStatusSource(await readResponseText(infoResponse, "read changes status"));
+    if (typeof info.pending !== "number" || info.pending < 0) {
+        throw new StreamingFetchFailure(
+            "protocol",
+            "Fast Fetch received changes status without a valid pending count.",
+            false
+        );
+    }
+    // `pending` is useful for progress, but it is not a completion boundary. A
+    // filtered or clustered feed can make document counts diverge from sequence
+    // movement, so only the captured target token can complete a non-empty fetch.
+    const pendingDocs = info.pending;
+    const docsToFetch = pendingDocs;
+    if (pendingDocs === 0) {
+        // This status request is made after the target was captured. No changes after
+        // the durable `since` position therefore proves that the captured target also
+        // represents durable empty work, including for a newly created database.
+        await saveCheckpoint(onCheckpoint, finalTargetSeq);
+        Logger("No changes remain before the captured Fast Fetch target.");
+        return;
+    }
 
+    Logger(
+        `Starting initial synchronisation. Current sequence: ${since}, Target sequence: ${finalTargetSeq}, Estimated documents to fetch: ${docsToFetch}.`
+    );
+
+    const controller = new AbortController();
+    const changesURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), changesBaseParams);
+    const response = await fetchResponse(
+        changesURL.toString(),
+        {
+            method: "GET",
+            headers: fetchHeaders,
+            signal: controller.signal,
+        },
+        "open the changes feed"
+    );
     if (!response.body) {
-        throw new Error("ReadableStream is not supported by this browser.");
+        throw new StreamingFetchFailure("protocol", "Fast Fetch could not read the CouchDB response stream.", false);
     }
 
     const sizeCaptureStream = new TransformStream({
-        transform(chunk, controller) {
-            const chunkSize = chunk.length || chunk.byteLength || 0;
-            totalBytes += chunkSize;
-            controller.enqueue(chunk);
+        transform(chunk, streamController) {
+            totalBytes += chunk.byteLength;
+            streamController.enqueue(chunk);
         },
     });
-    // Convert the byte stream into a text stream.
     const reader = response.body.pipeThrough(sizeCaptureStream).pipeThrough(new TextDecoderStream()).getReader();
-    const writeDocStream = generatePouchDBWriteStream(downloadToDB, decryptFunction, onCheckpoint);
-    const writer = writeDocStream.getWriter();
+    const batchWriter = generatePouchDBBatchWriter(downloadToDB, decryptFunction, onCheckpoint);
     let buffer = "";
     let lastProgress = 0;
     let lastReportTime = Date.now();
-    let totalBytes = 0;
-    let abortedAfterTargetReached = false;
+
     const reportProgress = () => {
-        if (totalFetched - lastProgress < 25) {
-            // Report progress for every 25 changes fetched to avoid excessive updates.
-            // However, if it's been more than 2 seconds since the last report, we should report progress regardless to keep the UI responsive.
-            if (Date.now() - lastReportTime < 2000) {
-                return;
-            }
-        }
+        if (totalFetched - lastProgress < 25 && Date.now() - lastReportTime < 2000) return;
         lastProgress = totalFetched;
         lastReportTime = Date.now();
         onProgress?.({
@@ -271,91 +452,86 @@ export async function fetchChangesForInitialSync(
             totalBytes,
         });
     };
+
+    const processLine = async (line: string): Promise<boolean> => {
+        const parsed = parseChangeLine(line);
+        totalFetched++;
+        if (parsed.doc) {
+            await batchWriter.write(parsed.doc, parsed.seq);
+            totalValidFetched++;
+        } else {
+            await batchWriter.flushThrough(parsed.seq);
+        }
+        reportProgress();
+        if (!isTargetSequence(parsed.seq, finalTargetSeq)) return false;
+
+        // `write` may still hold the target row in memory. Completion is reported only
+        // after the target and every preceding row have crossed the persistence and
+        // checkpoint boundary.
+        await batchWriter.flush();
+        Logger("The captured Fast Fetch target is durable in the local database.");
+        controller.abort();
+        reportProgress();
+        return true;
+    };
+
     try {
         while (true) {
-            // Read a chunk from the network.
             reportProgress();
-            const { value, done } = await reader.read();
-            if (value) {
-                totalBytes += value.length;
-            }
-            if (done) {
-                // When the stream ends, process the final line left in the buffer.
-                if (buffer.trim()) {
-                    try {
-                        totalFetched++;
-                        const parsed = JSON.parse(buffer) as CouchChangeLine;
-                        if (parsed.doc) {
-                            await writer.write({ doc: parsed.doc, seq: parsed.seq });
-                            totalValidFetched++;
-                        } else {
-                            await onCheckpoint?.(parsed.seq);
-                        }
-                        reportProgress();
-                    } catch (e) {
-                        Logger(`Failed to parse the final line: ${buffer}. Skipping it.`);
-                        Logger(e, LOG_LEVEL_VERBOSE);
-                    }
-                }
-                await writer.close();
-                break; // Exit the loop.
+            let readResult: ReadableStreamReadResult<string>;
+            try {
+                readResult = await reader.read();
+            } catch (error) {
+                throw transportFailure("read the changes feed", error);
             }
 
-            buffer += value;
+            if (readResult.done) {
+                if (buffer.trim() && (await processLine(buffer))) return;
+                await batchWriter.flush();
+                throw new StreamingFetchFailure(
+                    "transport",
+                    "The CouchDB changes feed ended before Fast Fetch reached its captured target.",
+                    true
+                );
+            }
+
+            buffer += readResult.value;
             const lines = buffer.split("\n");
-
-            // The final line is often incomplete, so carry it over to the next buffer.
             buffer = lines.pop() || "";
-
             for (const line of lines) {
-                if (!line.trim()) continue; // Skip empty lines (for example, CouchDB heartbeats).
-
-                try {
-                    const parsed = JSON.parse(line) as CouchChangeLine;
-                    // Add to the batch only when a document body exists.
-                    totalFetched++;
-                    if (parsed.doc) {
-                        await writer.write({ doc: parsed.doc, seq: parsed.seq });
-                        totalValidFetched++;
-                    } else {
-                        await onCheckpoint?.(parsed.seq);
-                    }
-                    reportProgress();
-                    if (totalFetched >= docsToFetch || reachedTargetSequence(parsed.seq, finalTargetSeq)) {
-                        Logger(
-                            `All documents fetched. Stopping the stream and writing remaining documents to PouchDB...`
-                        );
-
-                        // Write any remaining documents to PouchDB before exiting.
-                        await writer.close(); // Close the writer to ensure all documents are flushed to PouchDB.
-                        // Abort the fetch request to stop receiving more data.
-                        abortedAfterTargetReached = true;
-                        controller.abort();
-                        reportProgress();
-                        return; // Exit the function gracefully.
-                    }
-                } catch (e) {
-                    Logger(`JSON parsing failed. Skipping line: ${line}`, LOG_LEVEL_VERBOSE);
-                    Logger(e, LOG_LEVEL_VERBOSE);
-                }
+                if (!line.trim()) continue;
+                if (await processLine(line)) return;
             }
-            // backpressure is automatically handled by awaiting the writer.write() calls, which will pause reading from the network until the current document is processed and written to PouchDB.
-            // This ensures that we do not read too much data into memory at once, and we can handle large datasets without running into memory issues.
         }
-        Logger("Initial data synchronisation via stream has completed.");
-        reportProgress();
     } catch (error) {
-        if (abortedAfterTargetReached && error instanceof DOMException && error.name === "AbortError") {
-            Logger(
-                "Stream has been aborted as the target sequence has been reached. Finalising the synchronising process..."
-            );
-            return; // Exit gracefully without treating this as an error.
+        const failure = asStreamingFetchFailure(error);
+        if (failure.stage !== "storage") {
+            // Preserve useful work before a later protocol, transport, or decryption
+            // failure. A storage failure is not flushed again here because the failed
+            // batch may already be partly applied; the retained older checkpoint makes
+            // replay explicit and idempotent on the next invocation.
+            try {
+                await batchWriter.flush();
+            } catch (flushError) {
+                batchWriter.abort();
+                throw asStreamingFetchFailure(flushError);
+            }
         }
-        Logger("An error occurred during synchronisation:", LOG_LEVEL_VERBOSE);
-        Logger(error, LOG_LEVEL_VERBOSE);
-        throw error;
+        batchWriter.abort();
+        Logger(`Fast Fetch failed during ${failure.stage}.`, LOG_LEVEL_VERBOSE);
+        Logger(failure, LOG_LEVEL_VERBOSE);
+        throw failure;
     } finally {
-        // Always release the lock.
+        // Releasing a reader lock does not cancel its underlying continuous HTTP
+        // response. Abort the transport on every exit, then cancel the decoded
+        // stream as a fallback for stream implementations which do not observe the
+        // request signal directly.
+        controller.abort();
+        try {
+            await reader.cancel();
+        } catch {
+            // The stream may already be closed or errored at this point.
+        }
         reader.releaseLock();
     }
 }

--- a/src/pouchdb/StreamingFetch.unit.spec.ts
+++ b/src/pouchdb/StreamingFetch.unit.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import PouchDB from "pouchdb-core";
 import MemoryAdapter from "pouchdb-adapter-memory";
 import { fetchChangesForInitialSync } from "./StreamingFetch";
@@ -11,12 +11,30 @@ vi.mock("@lib/common/coreEnvFunctions", () => ({
     _fetch: fetchMock,
 }));
 
+const remoteDbUrl = "https://example.com/db";
+const localDatabases: PouchDB.Database[] = [];
+
+function createLocalDatabase(name: string): PouchDB.Database {
+    const database = new PouchDB(name, { adapter: "memory" });
+    localDatabases.push(database);
+    return database;
+}
+
 function textStream(lines: string[]) {
     return new ReadableStream({
         start(controller) {
             const encoder = new TextEncoder();
             controller.enqueue(encoder.encode(lines.join("\n") + "\n"));
             controller.close();
+        },
+    });
+}
+
+function openTextStream(lines: string[]) {
+    return new ReadableStream({
+        start(controller) {
+            const encoder = new TextEncoder();
+            controller.enqueue(encoder.encode(lines.join("\n") + "\n"));
         },
     });
 }
@@ -29,73 +47,177 @@ function failingStream(error: Error) {
     });
 }
 
-describe("fetchChangesForInitialSync", () => {
-    it("reports the last persisted sequence for resumable fast fetch", async () => {
-        const localDB = new PouchDB("streaming-fetch-checkpoint", {
-            adapter: "memory",
-        });
-        const checkpointSequences: Array<string | number> = [];
-
-        fetchMock
-            .mockResolvedValueOnce(new Response(JSON.stringify({ update_seq: 2 })))
-            .mockResolvedValueOnce(new Response(JSON.stringify({ pending: 1, last_seq: 1 })))
-            .mockResolvedValueOnce(
-                new Response(
-                    textStream([
-                        JSON.stringify({
-                            seq: 1,
-                            id: "doc1",
-                            changes: [{ rev: "1-a" }],
-                            doc: { _id: "doc1", _rev: "1-a", value: "one" },
-                        }),
-                        JSON.stringify({
-                            seq: 2,
-                            id: "doc2",
-                            changes: [{ rev: "1-b" }],
-                            doc: { _id: "doc2", _rev: "1-b", value: "two" },
-                        }),
-                    ])
-                )
-            );
-
-        await fetchChangesForInitialSync(
-            localDB,
-            "https://example.com/db",
-            "Basic test",
-            (doc) => Promise.resolve(doc as any),
-            "0",
-            undefined,
-            (sequence) => {
-                checkpointSequences.push(sequence);
-            }
-        );
-
-        expect(checkpointSequences[checkpointSequences.length - 1]).toBe(2);
-        await expect(localDB.get("doc2")).resolves.toMatchObject({ value: "two" });
-
-        await localDB.destroy();
+function changeLine(sequence: string | number, id: string, value?: string): string {
+    return JSON.stringify({
+        seq: sequence,
+        id,
+        changes: [{ rev: `1-${id}` }],
+        ...(value === undefined ? {} : { doc: { _id: id, _rev: `1-${id}`, value } }),
     });
+}
 
-    it("does not treat an external AbortError as successful completion", async () => {
-        const localDB = new PouchDB("streaming-fetch-external-abort", {
-            adapter: "memory",
-        });
+function queueChangesFeed(target: string | number, pending: number, body: string[] | ReadableStream<Uint8Array>): void {
+    fetchMock
+        .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: target })))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ pending, last_seq: "since" })))
+        .mockResolvedValueOnce(new Response(Array.isArray(body) ? textStream(body) : body));
+}
 
-        fetchMock
-            .mockResolvedValueOnce(new Response(JSON.stringify({ update_seq: 2 })))
-            .mockResolvedValueOnce(new Response(JSON.stringify({ pending: 1, last_seq: 1 })))
-            .mockResolvedValueOnce(new Response(failingStream(new DOMException("network changed", "AbortError"))));
+function fetchInitial(
+    localDatabase: PouchDB.Database,
+    decrypt = (doc: any) => Promise.resolve(doc),
+    onCheckpoint?: (sequence: string | number) => void
+): Promise<void> {
+    return fetchChangesForInitialSync(localDatabase, remoteDbUrl, "Basic test", decrypt, "0", undefined, onCheckpoint);
+}
+
+beforeEach(() => {
+    fetchMock.mockReset();
+});
+
+afterEach(async () => {
+    await Promise.all(localDatabases.splice(0).map((database) => database.destroy()));
+});
+
+describe("fetchChangesForInitialSync", () => {
+    it("does not checkpoint a batch when PouchDB reports an individual write failure", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-bulk-result-failure");
+        const checkpointSequences: Array<string | number> = [];
+        vi.spyOn(localDB, "bulkDocs").mockResolvedValueOnce([
+            {
+                id: "doc1",
+                error: true,
+                name: "forbidden",
+                status: 403,
+                message: "write rejected",
+            },
+        ] as any);
+        queueChangesFeed(1, 1, [changeLine(1, "doc1", "one")]);
 
         await expect(
-            fetchChangesForInitialSync(
-                localDB,
-                "https://example.com/db",
-                "Basic test",
-                (doc) => Promise.resolve(doc as any),
-                "0"
-            )
-        ).rejects.toMatchObject({ name: "AbortError" });
+            fetchInitial(localDB, undefined, (sequence) => checkpointSequences.push(sequence))
+        ).rejects.toMatchObject({
+            stage: "storage",
+            retryable: false,
+            message: expect.stringContaining("write rejected"),
+        });
+        expect(checkpointSequences).toEqual([]);
+    });
 
-        await localDB.destroy();
+    it("reports a decryption failure instead of skipping the affected row", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-decryption-failure");
+        const checkpointSequences: Array<string | number> = [];
+        queueChangesFeed(1, 1, [changeLine(1, "doc1", "one")]);
+
+        await expect(
+            fetchInitial(
+                localDB,
+                () => Promise.reject(new Error("cannot decrypt doc1")),
+                (sequence) => checkpointSequences.push(sequence)
+            )
+        ).rejects.toMatchObject({
+            stage: "decryption",
+            retryable: false,
+            message: expect.stringContaining("cannot decrypt doc1"),
+        });
+        expect(checkpointSequences).toEqual([]);
+    });
+
+    it("aborts the continuous request when document processing fails terminally", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-terminal-abort");
+        queueChangesFeed(1, 1, openTextStream([changeLine(1, "doc1", "one")]));
+
+        await expect(
+            fetchInitial(localDB, () => Promise.reject(new Error("cannot decrypt doc1")))
+        ).rejects.toMatchObject({
+            stage: "decryption",
+            retryable: false,
+        });
+
+        const request = fetchMock.mock.calls[2][1] as RequestInit;
+        expect(request.signal?.aborted).toBe(true);
+    });
+
+    it("uses the captured target rather than the estimate and checkpoints the persisted target", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-target-completion");
+        const checkpointSequences: Array<string | number> = [];
+        queueChangesFeed(2, 1, [changeLine(1, "doc1", "one"), changeLine(2, "doc2", "two")]);
+
+        await fetchInitial(localDB, undefined, (sequence) => checkpointSequences.push(sequence));
+
+        await expect(localDB.get("doc2")).resolves.toMatchObject({ value: "two" });
+        expect(checkpointSequences.at(-1)).toBe(2);
+    });
+
+    it("flushes preceding documents before checkpointing a row without a document", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-docless-checkpoint");
+        const checkpointSequences: Array<string | number> = [];
+        queueChangesFeed(2, 2, [changeLine(1, "doc1", "one"), changeLine(2, "doc2")]);
+
+        await fetchInitial(localDB, undefined, (sequence) => checkpointSequences.push(sequence));
+
+        expect(checkpointSequences).toEqual([1, 2]);
+        await expect(localDB.get("doc1")).resolves.toMatchObject({ value: "one" });
+    });
+
+    it("classifies an authentication response as terminal", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-authentication-failure");
+        fetchMock.mockResolvedValueOnce(new Response("unauthorised", { status: 401 }));
+
+        await expect(fetchInitial(localDB)).rejects.toMatchObject({
+            stage: "authentication",
+            retryable: false,
+            status: 401,
+        });
+    });
+
+    it("requires an authoritative target sequence from the changes-feed snapshot", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-missing-target");
+        fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ db_name: "db" })));
+
+        await expect(fetchInitial(localDB)).rejects.toMatchObject({
+            stage: "protocol",
+            retryable: false,
+            message: expect.stringContaining("authoritative changes target"),
+        });
+    });
+
+    it("does not treat a missing pending count as proof of completion", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-missing-pending");
+        fetchMock
+            .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: "0-target" })))
+            .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: "0-since" })));
+
+        await expect(fetchInitial(localDB)).rejects.toMatchObject({
+            stage: "protocol",
+            retryable: false,
+            message: expect.stringContaining("pending count"),
+        });
+    });
+
+    it("checkpoints a captured target without opening a stream when no changes are pending", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-no-pending-changes");
+        const checkpointSequences: Array<string | number> = [];
+        fetchMock
+            .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: "0-target" })))
+            .mockResolvedValueOnce(new Response(JSON.stringify({ pending: 0, last_seq: "0-since" })));
+
+        await fetchInitial(localDB, undefined, (sequence) => checkpointSequences.push(sequence));
+
+        expect(checkpointSequences).toEqual(["0-target"]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(new URL(fetchMock.mock.calls[0][0]).searchParams.get("since")).toBe("now");
+        expect(new URL(fetchMock.mock.calls[0][0]).searchParams.get("limit")).toBe("0");
+    });
+
+    it("classifies an external AbortError as a retryable transport failure", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-external-abort");
+        queueChangesFeed(2, 2, failingStream(new DOMException("network changed", "AbortError")));
+
+        await expect(fetchInitial(localDB)).rejects.toMatchObject({
+            name: "StreamingFetchFailure",
+            stage: "transport",
+            retryable: true,
+        });
     });
 });

--- a/src/serviceModules/Rebuilder.ts
+++ b/src/serviceModules/Rebuilder.ts
@@ -20,7 +20,7 @@ import type { LiveSyncEventHub } from "@lib/hub/hub";
 import { EVENT_DATABASE_REBUILT } from "@lib/events/coreEvents";
 import { ServiceModuleBase } from "@lib/serviceModules/ServiceModuleBase";
 import type { ControlService } from "@lib/services/base/ControlService";
-import { fetchChangesForInitialSync } from "@lib/pouchdb/StreamingFetch";
+import { fetchChangesForInitialSync, isRetryableStreamingFetchFailure } from "@lib/pouchdb/StreamingFetch";
 import { getConfiguredFunctionsForEncryption } from "@lib/pouchdb/encryption";
 import { AuthorizationHeaderGenerator, generateCredentialObject } from "@lib/replication/httplib";
 import { sizeToHumanReadable } from "octagonal-wheels/number";
@@ -468,7 +468,12 @@ Are you sure you wish to proceed?`;
                 );
                 break;
             } catch (ex) {
-                if (attempt >= FAST_FETCH_RETRY_DELAYS.length) throw ex;
+                // StreamingFetch owns failure classification. Retrying only its
+                // explicitly transient transport failures prevents deterministic
+                // authentication, protocol, decryption, or storage failures from
+                // consuming the retry budget. Each retry resumes from the latest
+                // contiguous checkpoint persisted by the previous attempt.
+                if (!isRetryableStreamingFetchFailure(ex) || attempt >= FAST_FETCH_RETRY_DELAYS.length) throw ex;
                 checkpoint = this.getFastFetchCheckpoint(remote);
                 since = checkpoint?.sequence ?? since;
                 this._log(

--- a/src/serviceModules/Rebuilder.unit.spec.ts
+++ b/src/serviceModules/Rebuilder.unit.spec.ts
@@ -9,6 +9,8 @@ const fetchChangesForInitialSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@lib/pouchdb/StreamingFetch", () => ({
     fetchChangesForInitialSync: fetchChangesForInitialSyncMock,
+    isRetryableStreamingFetchFailure: (error: unknown) =>
+        Boolean((error as { retryable?: boolean } | undefined)?.retryable),
 }));
 
 vi.mock("octagonal-wheels/promises", async (importOriginal) => {
@@ -202,7 +204,10 @@ describe("ServiceRebuilder fast fetch retry", () => {
         fetchChangesForInitialSyncMock
             .mockImplementationOnce(async (...args: any[]) => {
                 await args[6]("10-g1");
-                throw new Error("network changed");
+                throw Object.assign(new Error("network changed"), {
+                    stage: "transport",
+                    retryable: true,
+                });
             })
             .mockResolvedValueOnce(undefined);
 
@@ -214,6 +219,23 @@ describe("ServiceRebuilder fast fetch retry", () => {
         expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
             label: "fast-fetch",
         });
+    });
+
+    it("does not retry a terminal fast fetch failure or finalise the local database", async () => {
+        fetchChangesForInitialSyncMock.mockReset().mockRejectedValue(
+            Object.assign(new Error("cannot decrypt remote document"), {
+                stage: "decryption",
+                retryable: false,
+            })
+        );
+        const { rebuilder, services } = createRebuilder();
+
+        await expect(rebuilder.$fetchLocalDBFast(true)).rejects.toThrow("cannot decrypt remote document");
+
+        expect(fetchChangesForInitialSyncMock).toHaveBeenCalledOnce();
+        expect(services.replication.markResolved).not.toHaveBeenCalled();
+        expect(services.vault.scanVault).not.toHaveBeenCalled();
+        expect(services.setting.deleteSmallConfig).not.toHaveBeenCalledWith("fast-fetch-checkpoint");
     });
 
     it("keeps reflection resumption and checkpoint removal inside a successful fast-fetch activity", async () => {


### PR DESCRIPTION
Makes Fast Fetch report success only after the captured CouchDB changes target has been durably persisted, preventing an incomplete local database from being finalised.

## Summary

- Capture an authoritative target from the CouchDB changes feed and treat sequence tokens as opaque.
- Decrypt and validate each document, inspect every batch-write result, and advance only a contiguous durable checkpoint.
- Classify Fast Fetch failures and retry only explicitly transient transport failures from the latest durable checkpoint.
- Abort the request and cancel the decoded stream on every completion and failure path.
- Add focused unit and real CouchDB integration coverage for persistence, checkpointing, retry, and stream-lifecycle behaviour.

## Rationale

Fast Fetch previously handled parsing, decryption, persistence, and completion inside a broad error boundary. A deterministic document failure or an individual failed batch result could consequently be misreported or allow processing to continue without a trustworthy checkpoint. Progress estimates could also influence completion even though CouchDB's sequence token is the authoritative boundary.

This change supplies the Commonlib behaviour required by the corresponding LiveSync Fast Setup work prompted by [vrtmrz/obsidian-livesync#1065](https://github.com/vrtmrz/obsidian-livesync/issues/1065). It does not claim that every reported symptom has been confirmed against the reporter's environment.

## Impact

A Fast Fetch with an unreadable document or failed local write now stops without finalising the database. Durably completed work remains reusable through the last contiguous checkpoint, while transient connection failures can resume automatically. Ordinary PouchDB replication is unchanged.

## Verification

- `npm run check:types`
- `npm run test:unit` — 70 files, 1,244 tests
- Managed CouchDB and MinIO integration tests — 2 files, 4 tests
- `npm run test:package`
- Installed the exact packed artefact into LiveSync and passed its 133 focused Fast Setup tests
- Passed the downstream production build, iOS 15 compatibility check, and real Obsidian Fast Setup E2E workflow
