### PR TITLE
Prepare Commonlib 0.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.6
+
+### Fixed
+
+- Fast Fetch now completes only after the captured CouchDB changes target has been persisted, and resumes transient interruptions from the last durable checkpoint. Decryption, protocol, and local write failures stop without finalising an incomplete local database ([Self-hosted LiveSync issue #1065](https://github.com/vrtmrz/obsidian-livesync/issues/1065)).
+
 ## 0.1.5
 
 ### Changed


### PR DESCRIPTION
Prepares `@vrtmrz/livesync-commonlib` 0.1.6 so the Fast Fetch persistence and completion safeguards merged in #95 can be published for downstream integration.

## Summary

- Update the source package and lockfile versions from 0.1.5 to 0.1.6.
- Record the Fast Fetch persistence and completion fix under the 0.1.6 release heading.
- Keep dependency versions and the generated package boundary unchanged.

## Release notes

### Fixed

- Fast Fetch now completes only after the captured CouchDB changes target has been persisted, and resumes transient interruptions from the last durable checkpoint. Decryption, protocol, and local write failures stop without finalising an incomplete local database ([Self-hosted LiveSync issue #1065](https://github.com/vrtmrz/obsidian-livesync/issues/1065)).

## Verification

- `npx --yes npm@11.18.0 install --package-lock-only --ignore-scripts --no-audit --no-fund` — no dependency or integrity changes
- `npx --yes npm@11.18.0 ci`
- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package` — 1,244 tests passed, with type, boundary, release-selection, and package checks successful
- `npx --yes npm@11.18.0 publish --dry-run .package --tag next --access public`
- Dry-run package: `@vrtmrz/livesync-commonlib@0.1.6`
- Dry-run integrity: `sha512-FNccs1HGkv7H01j/FxHm56dpHomz5lB/Dy5USUZcMCdrPe+Lfm+isKkhpcYW4gb6AdnyAuuqDGiJrVLHv9tPyQ==`
- Dry-run contents: 500 files, 397.7 kB packed, and 1.7 MB unpacked
