### PR TITLE
Fix Fast Fetch completion with bounded changes pages

### DIFF
--- a/src/pouchdb/StreamingFetch.integration.spec.ts
+++ b/src/pouchdb/StreamingFetch.integration.spec.ts
@@ -33,18 +33,55 @@ const remoteDbUrlWithAuth = urlObj.toString();
 const remoteDbUrl = new URL(remoteDbName, hostname).toString();
 const authHeader = "Basic " + Buffer.from(`${username}:${password}`).toString("base64");
 
+async function recreateTwoShardRemoteDatabase(): Promise<void> {
+    const deleteResponse = await fetch(remoteDbUrl, {
+        method: "DELETE",
+        headers: { Authorization: authHeader },
+    });
+    if (!deleteResponse.ok && deleteResponse.status !== 404) {
+        throw new Error(`Could not delete the integration database: HTTP ${deleteResponse.status}.`);
+    }
+
+    const createUrl = new URL(remoteDbUrl);
+    createUrl.searchParams.set("n", "1");
+    createUrl.searchParams.set("q", "2");
+    const createResponse = await fetch(createUrl, {
+        method: "PUT",
+        headers: { Authorization: authHeader },
+    });
+    if (!createResponse.ok) {
+        throw new Error(`Could not create the integration database: HTTP ${createResponse.status}.`);
+    }
+
+    const infoResponse = await fetch(remoteDbUrl, { headers: { Authorization: authHeader } });
+    if (!infoResponse.ok) {
+        throw new Error(`Could not inspect the integration database: HTTP ${infoResponse.status}.`);
+    }
+    const info = (await infoResponse.json()) as { cluster?: { n?: number; q?: number } };
+    expect(info.cluster).toMatchObject({ n: 1, q: 2 });
+}
+
+async function expectCheckpointHasNoPendingChanges(checkpoint: string | number | undefined): Promise<void> {
+    expect(checkpoint).toBeDefined();
+    const resumeUrl = new URL(`${remoteDbUrl}/_changes`);
+    resumeUrl.searchParams.set("since", checkpoint!.toString());
+    resumeUrl.searchParams.set("feed", "normal");
+    resumeUrl.searchParams.set("limit", "1");
+    resumeUrl.searchParams.set("include_docs", "false");
+    const resumeResponse = await fetch(resumeUrl, { headers: { Authorization: authHeader } });
+    expect(resumeResponse.ok).toBe(true);
+    const resumeStatus = (await resumeResponse.json()) as { results?: unknown[]; pending?: number };
+    expect(resumeStatus.results).toEqual([]);
+    expect(resumeStatus.pending).toBe(0);
+}
+
 describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
     let localDB: PouchDB.Database;
     let remoteDB: PouchDB.Database;
 
     beforeEach(async () => {
         localDB = new PouchDB("local_test_db_" + Date.now(), { adapter: "memory" });
-        remoteDB = new PouchDB(remoteDbUrlWithAuth, { adapter: "http" });
-        try {
-            await remoteDB.destroy();
-        } catch {
-            // safe to ignore
-        }
+        await recreateTwoShardRemoteDatabase();
         remoteDB = new PouchDB(remoteDbUrlWithAuth, { adapter: "http" });
         await remoteDB.info();
     });
@@ -62,7 +99,7 @@ describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
         }
     });
 
-    it("should fetch and checkpoint all documents across a batch boundary", async () => {
+    it("should fetch and checkpoint all documents across a batch boundary on two shards", async () => {
         // 1. Put enough documents in the remote database to cross the 100-document batch boundary.
         const docs = Array.from({ length: 101 }, (_, index) => ({
             _id: `doc-${index.toString().padStart(3, "0")}`,
@@ -70,7 +107,6 @@ describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
             data: `hello ${index}`,
         }));
         await remoteDB.bulkDocs(docs);
-        const targetSequence = (await remoteDB.changes({ since: "now", limit: 0 })).last_seq;
         const checkpoints: Array<string | number> = [];
 
         // 2. Perform streaming fetch
@@ -88,7 +124,61 @@ describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
         const localDocs = await localDB.allDocs({ include_docs: true });
         expect(localDocs.rows.length).toBe(docs.length);
         expect(localDocs.rows.map((row) => row.id).sort()).toEqual(docs.map((doc) => doc._id));
-        expect(checkpoints.at(-1)?.toString()).toBe(targetSequence.toString());
+        await expectCheckpointHasNoPendingChanges(checkpoints.at(-1));
+    });
+
+    it("should complete when a feed-level target differs from the final two-shard row sequence", async () => {
+        await remoteDB.put({ _id: "single-shard-change", type: "plain", data: "hello" });
+        const remoteChanges = await remoteDB.changes({ since: "0" });
+        const targetUrl = new URL(`${remoteDbUrl}/_changes`);
+        targetUrl.searchParams.set("feed", "normal");
+        targetUrl.searchParams.set("since", "now");
+        targetUrl.searchParams.set("limit", "1");
+        targetUrl.searchParams.set("include_docs", "false");
+        const targetResponse = await fetch(targetUrl, { headers: { Authorization: authHeader } });
+        expect(targetResponse.ok).toBe(true);
+        const targetSequence = ((await targetResponse.json()) as { last_seq: string | number }).last_seq;
+        const finalRowSequence = remoteChanges.results.at(-1)?.seq;
+        expect(finalRowSequence).toBeDefined();
+        expect(finalRowSequence?.toString()).not.toBe(targetSequence.toString());
+        const checkpoints: Array<string | number> = [];
+
+        await fetchChangesForInitialSync(
+            localDB,
+            remoteDbUrl,
+            authHeader,
+            (doc) => Promise.resolve(doc as any),
+            "0",
+            () => {},
+            (sequence) => checkpoints.push(sequence)
+        );
+
+        await expect(localDB.get("single-shard-change")).resolves.toMatchObject({ data: "hello" });
+        await expectCheckpointHasNoPendingChanges(checkpoints.at(-1));
+    });
+
+    it("should count a deletion tombstone as one bounded changes row", async () => {
+        await remoteDB.put({ _id: "retained-document", type: "plain", data: "keep" });
+        const deletedDocument = await remoteDB.put({ _id: "deleted-document", type: "plain", data: "remove" });
+        await remoteDB.remove("deleted-document", deletedDocument.rev);
+        const checkpoints: Array<string | number> = [];
+        const progress: Array<{ totalFetched: number; docsToFetch: number }> = [];
+
+        await fetchChangesForInitialSync(
+            localDB,
+            remoteDbUrl,
+            authHeader,
+            (doc) => Promise.resolve(doc as any),
+            "0",
+            (current) => progress.push(current),
+            (sequence) => checkpoints.push(sequence)
+        );
+
+        await expect(localDB.get("retained-document")).resolves.toMatchObject({ data: "keep" });
+        const deletedRows = await localDB.allDocs({ keys: ["deleted-document"] });
+        expect(deletedRows.rows[0]).toMatchObject({ value: { deleted: true } });
+        expect(progress.at(-1)).toMatchObject({ totalFetched: 2, docsToFetch: 2 });
+        await expectCheckpointHasNoPendingChanges(checkpoints.at(-1));
     });
 
     it("should handle empty database gracefully", async () => {
@@ -105,7 +195,7 @@ describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
         await remoteDB.bulkDocs(docs);
 
         // Get the latest sequence
-        const latestSeq = (await remoteDB.changes({ since: "now", limit: 0 })).last_seq;
+        const latestSeq = (await remoteDB.changes({ since: "now", limit: 1 })).last_seq;
 
         // 2. Perform streaming fetch with "since" set to the latest sequence
         await fetchChangesForInitialSync(

--- a/src/pouchdb/StreamingFetch.ts
+++ b/src/pouchdb/StreamingFetch.ts
@@ -17,6 +17,11 @@ interface AnyDecryptedDoc {
 
 type DBSequence = number | string;
 
+// This bounds one HTTP response without changing the smaller PouchDB write
+// batches. A finite continuous feed returns its own opaque `last_seq` marker,
+// which is the only page boundary Fast Fetch needs to persist and replay.
+const FAST_FETCH_CHANGES_PAGE_LIMIT = 10_000;
+
 /**
  * Identifies the boundary at which Fast Fetch stopped.
  *
@@ -272,12 +277,12 @@ export type FetchChangesForInitialSyncProgress = {
 type DatabaseSyncStatus = {
     last_seq?: DBSequence;
     pending?: number;
+    results?: unknown[];
 };
 
-function isTargetSequence(sequence: DBSequence | undefined, targetSequence: DBSequence | undefined): boolean {
-    if (sequence === undefined || targetSequence === undefined) return false;
-    return sequence.toString() === targetSequence.toString();
-}
+type ParsedChangesFeedLine =
+    | { type: "change"; change: CouchChangeLine }
+    | { type: "terminator"; lastSequence: DBSequence };
 
 function parseStatusSource(source: string): DatabaseSyncStatus {
     const trimmed = source.trim();
@@ -297,7 +302,7 @@ function parseStatusSource(source: string): DatabaseSyncStatus {
     throw new StreamingFetchFailure("protocol", "Fast Fetch received an invalid changes status from CouchDB.", false);
 }
 
-function parseChangeLine(line: string): CouchChangeLine {
+function parseChangesFeedLine(line: string): ParsedChangesFeedLine {
     let parsed: unknown;
     try {
         parsed = JSON.parse(line);
@@ -306,7 +311,21 @@ function parseChangeLine(line: string): CouchChangeLine {
             cause: error,
         });
     }
-    if (!parsed || typeof parsed !== "object" || !("seq" in parsed)) {
+    if (!parsed || typeof parsed !== "object") {
+        throw new StreamingFetchFailure("protocol", "Fast Fetch received an invalid changes-feed line.", false);
+    }
+    if (!("seq" in parsed) && "last_seq" in parsed) {
+        const lastSequence = (parsed as DatabaseSyncStatus).last_seq;
+        if (lastSequence === undefined) {
+            throw new StreamingFetchFailure(
+                "protocol",
+                "Fast Fetch received a changes-feed terminator without a sequence.",
+                false
+            );
+        }
+        return { type: "terminator", lastSequence };
+    }
+    if (!("seq" in parsed)) {
         throw new StreamingFetchFailure(
             "protocol",
             "Fast Fetch received a changes-feed row without a sequence.",
@@ -317,7 +336,7 @@ function parseChangeLine(line: string): CouchChangeLine {
     if (change.seq === undefined || (change.doc !== undefined && (!change.doc || typeof change.doc !== "object"))) {
         throw new StreamingFetchFailure("protocol", "Fast Fetch received an invalid changes-feed row.", false);
     }
-    return change as CouchChangeLine;
+    return { type: "change", change: change as CouchChangeLine };
 }
 
 /**
@@ -353,14 +372,17 @@ export async function fetchChangesForInitialSync(
         Authorization: authHeader,
     };
 
-    // Capture the completion boundary from _changes itself. CouchDB treats sequence
-    // tokens as opaque, and a clustered database may encode update_seq from database
-    // information differently from a row at the same logical changes position.
+    // Capture a progress target from _changes itself. This is deliberately only a
+    // progress hint: a clustered row `seq` and a feed-level `last_seq` can represent
+    // related positions using different opaque values. Completion is established
+    // by per-page probes and finite page terminators below, never by comparing this
+    // target with another token.
     const targetURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
         ...changesBaseParams,
         feed: "normal",
         since: "now",
-        limit: "0",
+        limit: "1",
+        include_docs: "false",
     });
     const targetResponse = await fetchResponse(
         targetURL.toString(),
@@ -368,140 +390,242 @@ export async function fetchChangesForInitialSync(
         "capture the changes target"
     );
     const targetStatus = parseStatusSource(await readResponseText(targetResponse, "read the changes target"));
-    const finalTargetSeq = targetStatus.last_seq;
-    if (finalTargetSeq === undefined) {
+    const progressTargetSeq = targetStatus.last_seq;
+    if (progressTargetSeq === undefined) {
         throw new StreamingFetchFailure(
             "protocol",
-            "Fast Fetch could not obtain an authoritative changes target from CouchDB.",
+            "Fast Fetch could not obtain a changes progress target from CouchDB.",
             false
         );
     }
-    if (isTargetSequence(since, finalTargetSeq)) {
-        Logger("Already at the target sequence. Initial data synchronisation is complete.");
-        return;
-    }
 
-    const fetchURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
-        ...changesBaseParams,
-        feed: "normal",
-        limit: "0",
-    });
-    const infoResponse = await fetchResponse(fetchURL.toString(), { headers: fetchHeaders }, "read changes status");
-    const info = parseStatusSource(await readResponseText(infoResponse, "read changes status"));
-    if (typeof info.pending !== "number" || info.pending < 0) {
-        throw new StreamingFetchFailure(
-            "protocol",
-            "Fast Fetch received changes status without a valid pending count.",
-            false
-        );
-    }
-    // `pending` is useful for progress, but it is not a completion boundary. A
-    // filtered or clustered feed can make document counts diverge from sequence
-    // movement, so only the captured target token can complete a non-empty fetch.
-    const pendingDocs = info.pending;
-    const docsToFetch = pendingDocs;
-    if (pendingDocs === 0) {
-        // This status request is made after the target was captured. No changes after
-        // the durable `since` position therefore proves that the captured target also
-        // represents durable empty work, including for a newly created database.
-        await saveCheckpoint(onCheckpoint, finalTargetSeq);
-        Logger("No changes remain before the captured Fast Fetch target.");
-        return;
-    }
-
-    Logger(
-        `Starting initial synchronisation. Current sequence: ${since}, Target sequence: ${finalTargetSeq}, Estimated documents to fetch: ${docsToFetch}.`
-    );
-
-    const controller = new AbortController();
-    const changesURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), changesBaseParams);
-    const response = await fetchResponse(
-        changesURL.toString(),
-        {
-            method: "GET",
-            headers: fetchHeaders,
-            signal: controller.signal,
-        },
-        "open the changes feed"
-    );
-    if (!response.body) {
-        throw new StreamingFetchFailure("protocol", "Fast Fetch could not read the CouchDB response stream.", false);
-    }
-
-    const sizeCaptureStream = new TransformStream({
-        transform(chunk, streamController) {
-            totalBytes += chunk.byteLength;
-            streamController.enqueue(chunk);
-        },
-    });
-    const reader = response.body.pipeThrough(sizeCaptureStream).pipeThrough(new TextDecoderStream()).getReader();
     const batchWriter = generatePouchDBBatchWriter(downloadToDB, decryptFunction, onCheckpoint);
-    let buffer = "";
+    let docsToFetch = 0;
     let lastProgress = 0;
     let lastReportTime = Date.now();
 
-    const reportProgress = () => {
-        if (totalFetched - lastProgress < 25 && Date.now() - lastReportTime < 2000) return;
+    const reportProgress = (force = false) => {
+        if (!force && totalFetched - lastProgress < 25 && Date.now() - lastReportTime < 2000) return;
         lastProgress = totalFetched;
         lastReportTime = Date.now();
         onProgress?.({
             totalFetched,
             totalValidFetched,
-            targetSeq: finalTargetSeq,
+            targetSeq: progressTargetSeq,
             docsToFetch,
             totalBytes,
         });
     };
 
-    const processLine = async (line: string): Promise<boolean> => {
-        const parsed = parseChangeLine(line);
-        totalFetched++;
-        if (parsed.doc) {
-            await batchWriter.write(parsed.doc, parsed.seq);
-            totalValidFetched++;
-        } else {
-            await batchWriter.flushThrough(parsed.seq);
+    const readAvailableChanges = async (pageSince: DBSequence): Promise<number> => {
+        // The normal probe and continuous page intentionally start from the same
+        // opaque cursor and use the same style and filter selection. A GET does not
+        // consume changes on the server; include_docs=false only removes the bodies.
+        //
+        // Use limit=1 rather than limit=0. CouchDB's API documentation describes
+        // zero as equivalent to one, but supported CouchDB releases have also been
+        // observed to return zero rows and keep the full count in `pending`. One
+        // explicit result makes `results.length + pending` portable across both
+        // behaviours and ensures that a final returned row is not mistaken for no
+        // work when `pending` itself is zero.
+        const statusURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
+            ...changesBaseParams,
+            feed: "normal",
+            since: pageSince.toString(),
+            limit: "1",
+            include_docs: "false",
+        });
+        const response = await fetchResponse(
+            statusURL.toString(),
+            { method: "GET", headers: fetchHeaders },
+            "read changes status"
+        );
+        const status = parseStatusSource(await readResponseText(response, "read changes status"));
+        if (!Array.isArray(status.results)) {
+            throw new StreamingFetchFailure(
+                "protocol",
+                "Fast Fetch received changes status without a valid results list.",
+                false
+            );
         }
-        reportProgress();
-        if (!isTargetSequence(parsed.seq, finalTargetSeq)) return false;
-
-        // `write` may still hold the target row in memory. Completion is reported only
-        // after the target and every preceding row have crossed the persistence and
-        // checkpoint boundary.
-        await batchWriter.flush();
-        Logger("The captured Fast Fetch target is durable in the local database.");
-        controller.abort();
-        reportProgress();
-        return true;
+        const pending = status.pending;
+        if (typeof pending !== "number" || !Number.isSafeInteger(pending) || pending < 0) {
+            throw new StreamingFetchFailure(
+                "protocol",
+                "Fast Fetch received changes status without a valid pending count.",
+                false
+            );
+        }
+        const available = status.results.length + pending;
+        if (!Number.isSafeInteger(available)) {
+            throw new StreamingFetchFailure(
+                "protocol",
+                "Fast Fetch received a changes count outside the supported range.",
+                false
+            );
+        }
+        return available;
     };
 
-    try {
-        while (true) {
-            reportProgress();
-            let readResult: ReadableStreamReadResult<string>;
-            try {
-                readResult = await reader.read();
-            } catch (error) {
-                throw transportFailure("read the changes feed", error);
+    const fetchPage = async (pageSince: DBSequence, pageLimit: number): Promise<DBSequence> => {
+        const controller = new AbortController();
+        let reader: ReadableStreamDefaultReader<string> | undefined;
+        let buffer = "";
+        let fetchedRows = 0;
+
+        const processLine = async (line: string): Promise<DBSequence | undefined> => {
+            const parsed = parseChangesFeedLine(line);
+            if (parsed.type === "terminator") {
+                if (fetchedRows === 0) {
+                    throw new StreamingFetchFailure(
+                        "transport",
+                        "Fast Fetch received no rows after its status probe reported available changes.",
+                        true
+                    );
+                }
+                // The status probe and this stream are separate requests, not a locked
+                // snapshot. A valid page may therefore be shorter than the estimate.
+                // Make its documents durable, persist its opaque terminator verbatim,
+                // and let the next normal probe establish whether more work remains.
+                await batchWriter.flush();
+                await saveCheckpoint(onCheckpoint, parsed.lastSequence);
+                reportProgress(true);
+                return parsed.lastSequence;
             }
 
-            if (readResult.done) {
-                if (buffer.trim() && (await processLine(buffer))) return;
-                await batchWriter.flush();
+            if (fetchedRows >= pageLimit) {
                 throw new StreamingFetchFailure(
-                    "transport",
-                    "The CouchDB changes feed ended before Fast Fetch reached its captured target.",
-                    true
+                    "protocol",
+                    `Fast Fetch received more than its ${pageLimit}-row page limit.`,
+                    false
+                );
+            }
+            const change = parsed.change;
+            // CouchDB's limit counts outer result rows. Tombstones and rows without
+            // an included document each consume one slot; multiple leaf revisions in
+            // the inner `changes` array do not. Count the row before deciding whether
+            // it requires a local document write.
+            fetchedRows++;
+            totalFetched++;
+            if (change.doc) {
+                await batchWriter.write(change.doc, change.seq);
+                totalValidFetched++;
+            } else {
+                await batchWriter.flushThrough(change.seq);
+            }
+            reportProgress();
+            return undefined;
+        };
+
+        try {
+            const changesURL = setParamsToURL(new URL(`${remoteDbUrl}/_changes`), {
+                ...changesBaseParams,
+                since: pageSince.toString(),
+                limit: pageLimit.toString(),
+            });
+            const response = await fetchResponse(
+                changesURL.toString(),
+                {
+                    method: "GET",
+                    headers: fetchHeaders,
+                    signal: controller.signal,
+                },
+                "open the changes feed"
+            );
+            if (!response.body) {
+                throw new StreamingFetchFailure(
+                    "protocol",
+                    "Fast Fetch could not read the CouchDB response stream.",
+                    false
                 );
             }
 
-            buffer += readResult.value;
-            const lines = buffer.split("\n");
-            buffer = lines.pop() || "";
-            for (const line of lines) {
-                if (!line.trim()) continue;
-                if (await processLine(line)) return;
+            const decoder = new TextDecoder();
+            const byteCountingDecoderStream = new TransformStream<Uint8Array, string>({
+                transform(chunk, streamController) {
+                    totalBytes += chunk.byteLength;
+                    const decoded = decoder.decode(chunk, { stream: true });
+                    if (decoded) streamController.enqueue(decoded);
+                },
+                flush(streamController) {
+                    const decoded = decoder.decode();
+                    if (decoded) streamController.enqueue(decoded);
+                },
+            });
+            reader = response.body.pipeThrough(byteCountingDecoderStream).getReader();
+
+            while (true) {
+                reportProgress();
+                let readResult: ReadableStreamReadResult<string>;
+                try {
+                    readResult = await reader.read();
+                } catch (error) {
+                    throw transportFailure("read the changes feed", error);
+                }
+
+                if (readResult.done) {
+                    if (buffer.trim()) {
+                        const lastSequence = await processLine(buffer);
+                        if (lastSequence !== undefined) return lastSequence;
+                    }
+                    await batchWriter.flush();
+                    throw new StreamingFetchFailure(
+                        "transport",
+                        "The bounded CouchDB changes feed ended without a last_seq terminator.",
+                        true
+                    );
+                }
+
+                buffer += readResult.value;
+                const lines = buffer.split("\n");
+                buffer = lines.pop() || "";
+                for (const line of lines) {
+                    if (!line.trim()) continue;
+                    const lastSequence = await processLine(line);
+                    if (lastSequence !== undefined) return lastSequence;
+                }
             }
+        } finally {
+            controller.abort();
+            if (reader) {
+                try {
+                    await reader.cancel();
+                } catch {
+                    // The stream may already be closed or errored at this point.
+                }
+                reader.releaseLock();
+            }
+        }
+    };
+
+    try {
+        let pageSince: DBSequence = since;
+        let started = false;
+        while (true) {
+            const available = await readAvailableChanges(pageSince);
+            // A later probe may observe writes which arrived after the initial
+            // progress target. Keep the denominator useful without treating it as a
+            // completion contract.
+            docsToFetch = Math.max(docsToFetch, totalFetched + available);
+            if (available === 0) break;
+
+            if (!started) {
+                started = true;
+                Logger(
+                    `Starting initial synchronisation. Current sequence: ${since}, Target sequence: ${progressTargetSeq}, Documents to fetch: ${docsToFetch}.`
+                );
+            }
+            const pageLimit = Math.min(FAST_FETCH_CHANGES_PAGE_LIMIT, available);
+            const pageTerminator = await fetchPage(pageSince, pageLimit);
+            // Treat last_seq as an opaque cursor: store and replay the exact value.
+            // Do not compare it with a row token, target token, or later probe token.
+            pageSince = pageTerminator;
+        }
+        if (started) {
+            Logger("Fast Fetch is caught up and durable in the local database.");
+            reportProgress(true);
+        } else {
+            Logger("No changes remain for Fast Fetch.");
         }
     } catch (error) {
         const failure = asStreamingFetchFailure(error);
@@ -521,17 +645,5 @@ export async function fetchChangesForInitialSync(
         Logger(`Fast Fetch failed during ${failure.stage}.`, LOG_LEVEL_VERBOSE);
         Logger(failure, LOG_LEVEL_VERBOSE);
         throw failure;
-    } finally {
-        // Releasing a reader lock does not cancel its underlying continuous HTTP
-        // response. Abort the transport on every exit, then cancel the decoded
-        // stream as a fallback for stream implementations which do not observe the
-        // request signal directly.
-        controller.abort();
-        try {
-            await reader.cancel();
-        } catch {
-            // The stream may already be closed or errored at this point.
-        }
-        reader.releaseLock();
     }
 }

--- a/src/pouchdb/StreamingFetch.unit.spec.ts
+++ b/src/pouchdb/StreamingFetch.unit.spec.ts
@@ -56,11 +56,30 @@ function changeLine(sequence: string | number, id: string, value?: string): stri
     });
 }
 
-function queueChangesFeed(target: string | number, pending: number, body: string[] | ReadableStream<Uint8Array>): void {
+function changesStatus(available: number, lastSequence: string | number) {
+    const results = available > 0 ? [JSON.parse(changeLine(`${lastSequence}-probe-row`, "probe-document"))] : [];
+    return {
+        results,
+        pending: available - results.length,
+        last_seq: lastSequence,
+    };
+}
+
+function queueChangesFeed(
+    target: string | number,
+    available: number,
+    body: string[] | ReadableStream<Uint8Array>,
+    pageTerminator: string | number = target
+): void {
     fetchMock
         .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: target })))
-        .mockResolvedValueOnce(new Response(JSON.stringify({ pending, last_seq: "since" })))
-        .mockResolvedValueOnce(new Response(Array.isArray(body) ? textStream(body) : body));
+        .mockResolvedValueOnce(new Response(JSON.stringify(changesStatus(available, "probe-sequence"))))
+        .mockResolvedValueOnce(
+            new Response(
+                Array.isArray(body) ? textStream([...body, JSON.stringify({ last_seq: pageTerminator })]) : body
+            )
+        )
+        .mockResolvedValueOnce(new Response(JSON.stringify(changesStatus(0, pageTerminator))));
 }
 
 function fetchInitial(
@@ -138,15 +157,116 @@ describe("fetchChangesForInitialSync", () => {
         expect(request.signal?.aborted).toBe(true);
     });
 
-    it("uses the captured target rather than the estimate and checkpoints the persisted target", async () => {
+    it("checkpoints a finite page only after all requested rows are persisted", async () => {
         const localDB = createLocalDatabase("streaming-fetch-target-completion");
         const checkpointSequences: Array<string | number> = [];
-        queueChangesFeed(2, 1, [changeLine(1, "doc1", "one"), changeLine(2, "doc2", "two")]);
+        queueChangesFeed(2, 2, [changeLine(1, "doc1", "one"), changeLine(2, "doc2", "two")]);
 
         await fetchInitial(localDB, undefined, (sequence) => checkpointSequences.push(sequence));
 
         await expect(localDB.get("doc2")).resolves.toMatchObject({ value: "two" });
         expect(checkpointSequences.at(-1)).toBe(2);
+    });
+
+    it("uses the bounded feed terminator when the last row sequence differs from last_seq", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-bounded-feed-terminator");
+        const checkpointSequences: Array<string | number> = [];
+        const targetSequence = "2-target-token";
+        const rowSequence = "2-row-token";
+        queueChangesFeed(targetSequence, 1, [changeLine(rowSequence, "doc1", "one")]);
+
+        await fetchInitial(localDB, undefined, (sequence) => checkpointSequences.push(sequence));
+
+        await expect(localDB.get("doc1")).resolves.toMatchObject({ value: "one" });
+        expect(checkpointSequences.at(-1)).toBe(targetSequence);
+        const changesURL = new URL(fetchMock.mock.calls[2][0]);
+        expect(changesURL.searchParams.get("feed")).toBe("continuous");
+        expect(changesURL.searchParams.get("limit")).toBe("1");
+    });
+
+    it("continues from each opaque terminator in pages of at most 10,000 rows", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-multiple-bounded-pages");
+        const firstPageTerminator = "10000-first-page";
+        const targetSequence = "10001-target";
+        const firstPage = Array.from({ length: 10_000 }, (_, index) => changeLine(index + 1, `doc-${index + 1}`));
+        fetchMock
+            .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: targetSequence })))
+            .mockResolvedValueOnce(new Response(JSON.stringify(changesStatus(10_001, "first-probe"))))
+            .mockResolvedValueOnce(
+                new Response(textStream([...firstPage, JSON.stringify({ last_seq: firstPageTerminator })]))
+            )
+            .mockResolvedValueOnce(new Response(JSON.stringify(changesStatus(1, "second-probe"))))
+            .mockResolvedValueOnce(
+                new Response(
+                    textStream([changeLine("10001-row", "doc-10001"), JSON.stringify({ last_seq: targetSequence })])
+                )
+            )
+            .mockResolvedValueOnce(new Response(JSON.stringify(changesStatus(0, targetSequence))));
+
+        await fetchInitial(localDB);
+
+        const firstPageUrl = new URL(fetchMock.mock.calls[2][0]);
+        const secondProbeUrl = new URL(fetchMock.mock.calls[3][0]);
+        const secondPageUrl = new URL(fetchMock.mock.calls[4][0]);
+        expect(firstPageUrl.searchParams.get("since")).toBe("0");
+        expect(firstPageUrl.searchParams.get("limit")).toBe("10000");
+        expect(secondProbeUrl.searchParams.get("feed")).toBe("normal");
+        expect(secondProbeUrl.searchParams.get("since")).toBe(firstPageTerminator);
+        expect(secondProbeUrl.searchParams.get("limit")).toBe("1");
+        expect(secondPageUrl.searchParams.get("since")).toBe(firstPageTerminator);
+        expect(secondPageUrl.searchParams.get("limit")).toBe("1");
+    });
+
+    it("re-probes after a valid page which is shorter than the previous estimate", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-short-page");
+        fetchMock
+            .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: "progress-target" })))
+            .mockResolvedValueOnce(new Response(JSON.stringify(changesStatus(2, "first-probe"))))
+            .mockResolvedValueOnce(
+                new Response(
+                    textStream([
+                        changeLine("first-row", "doc1", "one"),
+                        JSON.stringify({ last_seq: "first-terminator" }),
+                    ])
+                )
+            )
+            .mockResolvedValueOnce(new Response(JSON.stringify(changesStatus(1, "second-probe"))))
+            .mockResolvedValueOnce(
+                new Response(
+                    textStream([
+                        changeLine("second-row", "doc2", "two"),
+                        JSON.stringify({ last_seq: "second-terminator" }),
+                    ])
+                )
+            )
+            .mockResolvedValueOnce(new Response(JSON.stringify(changesStatus(0, "second-terminator"))));
+
+        await fetchInitial(localDB);
+
+        await expect(localDB.get("doc1")).resolves.toMatchObject({ value: "one" });
+        await expect(localDB.get("doc2")).resolves.toMatchObject({ value: "two" });
+        expect(new URL(fetchMock.mock.calls[2][0]).searchParams.get("limit")).toBe("2");
+        expect(new URL(fetchMock.mock.calls[3][0]).searchParams.get("since")).toBe("first-terminator");
+        expect(new URL(fetchMock.mock.calls[4][0]).searchParams.get("limit")).toBe("1");
+    });
+
+    it("fails retryably when a positive probe is followed by a zero-row page", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-zero-row-page");
+        const checkpointSequences: Array<string | number> = [];
+        fetchMock
+            .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: "progress-target" })))
+            .mockResolvedValueOnce(new Response(JSON.stringify(changesStatus(1, "probe-sequence"))))
+            .mockResolvedValueOnce(new Response(textStream([JSON.stringify({ last_seq: "empty-page-terminator" })])));
+
+        await expect(
+            fetchInitial(localDB, undefined, (sequence) => checkpointSequences.push(sequence))
+        ).rejects.toMatchObject({
+            stage: "transport",
+            retryable: true,
+            message: expect.stringContaining("status probe reported available changes"),
+        });
+        expect(checkpointSequences).toEqual([]);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
     });
 
     it("flushes preceding documents before checkpointing a row without a document", async () => {
@@ -156,7 +276,7 @@ describe("fetchChangesForInitialSync", () => {
 
         await fetchInitial(localDB, undefined, (sequence) => checkpointSequences.push(sequence));
 
-        expect(checkpointSequences).toEqual([1, 2]);
+        expect(checkpointSequences).toEqual([1, 2, 2]);
         await expect(localDB.get("doc1")).resolves.toMatchObject({ value: "one" });
     });
 
@@ -171,14 +291,14 @@ describe("fetchChangesForInitialSync", () => {
         });
     });
 
-    it("requires an authoritative target sequence from the changes-feed snapshot", async () => {
+    it("requires a changes-feed sequence for progress reporting", async () => {
         const localDB = createLocalDatabase("streaming-fetch-missing-target");
         fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ db_name: "db" })));
 
         await expect(fetchInitial(localDB)).rejects.toMatchObject({
             stage: "protocol",
             retryable: false,
-            message: expect.stringContaining("authoritative changes target"),
+            message: expect.stringContaining("changes progress target"),
         });
     });
 
@@ -186,7 +306,7 @@ describe("fetchChangesForInitialSync", () => {
         const localDB = createLocalDatabase("streaming-fetch-missing-pending");
         fetchMock
             .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: "0-target" })))
-            .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: "0-since" })));
+            .mockResolvedValueOnce(new Response(JSON.stringify({ results: [], last_seq: "0-since" })));
 
         await expect(fetchInitial(localDB)).rejects.toMatchObject({
             stage: "protocol",
@@ -195,19 +315,77 @@ describe("fetchChangesForInitialSync", () => {
         });
     });
 
-    it("checkpoints a captured target without opening a stream when no changes are pending", async () => {
-        const localDB = createLocalDatabase("streaming-fetch-no-pending-changes");
-        const checkpointSequences: Array<string | number> = [];
+    it("does not treat a missing results list as proof of completion", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-missing-results");
         fetchMock
             .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: "0-target" })))
             .mockResolvedValueOnce(new Response(JSON.stringify({ pending: 0, last_seq: "0-since" })));
 
+        await expect(fetchInitial(localDB)).rejects.toMatchObject({
+            stage: "protocol",
+            retryable: false,
+            message: expect.stringContaining("results list"),
+        });
+    });
+
+    it("does not open a stream when the probe has no results or pending changes", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-no-pending-changes");
+        const checkpointSequences: Array<string | number> = [];
+        fetchMock
+            .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: "0-target" })))
+            .mockResolvedValueOnce(new Response(JSON.stringify(changesStatus(0, "0-since"))));
+
         await fetchInitial(localDB, undefined, (sequence) => checkpointSequences.push(sequence));
 
-        expect(checkpointSequences).toEqual(["0-target"]);
+        expect(checkpointSequences).toEqual([]);
         expect(fetchMock).toHaveBeenCalledTimes(2);
         expect(new URL(fetchMock.mock.calls[0][0]).searchParams.get("since")).toBe("now");
-        expect(new URL(fetchMock.mock.calls[0][0]).searchParams.get("limit")).toBe("0");
+        expect(new URL(fetchMock.mock.calls[0][0]).searchParams.get("limit")).toBe("1");
+        expect(new URL(fetchMock.mock.calls[0][0]).searchParams.get("include_docs")).toBe("false");
+    });
+
+    it("counts the normal-feed result row as available work when pending is zero", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-result-plus-pending");
+        const checkpointSequences: Array<string | number> = [];
+        fetchMock
+            .mockResolvedValueOnce(new Response(JSON.stringify({ last_seq: "progress-target" })))
+            .mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        results: [JSON.parse(changeLine("row-sequence", "doc1"))],
+                        pending: 0,
+                        last_seq: "probe-sequence",
+                    })
+                )
+            )
+            .mockResolvedValueOnce(
+                new Response(
+                    textStream([
+                        changeLine("row-sequence", "doc1", "one"),
+                        JSON.stringify({ last_seq: "page-terminator" }),
+                    ])
+                )
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ results: [], pending: 0, last_seq: "page-terminator" }))
+            );
+
+        await fetchInitial(localDB, undefined, (sequence) => checkpointSequences.push(sequence));
+
+        await expect(localDB.get("doc1")).resolves.toMatchObject({ value: "one" });
+        expect(checkpointSequences.at(-1)).toBe("page-terminator");
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+        const firstProbeUrl = new URL(fetchMock.mock.calls[1][0]);
+        expect(firstProbeUrl.searchParams.get("feed")).toBe("normal");
+        expect(firstProbeUrl.searchParams.get("since")).toBe("0");
+        expect(firstProbeUrl.searchParams.get("limit")).toBe("1");
+        expect(firstProbeUrl.searchParams.get("include_docs")).toBe("false");
+        const pageUrl = new URL(fetchMock.mock.calls[2][0]);
+        expect(pageUrl.searchParams.get("feed")).toBe("continuous");
+        expect(pageUrl.searchParams.get("since")).toBe("0");
+        expect(pageUrl.searchParams.get("limit")).toBe("1");
+        const finalProbeUrl = new URL(fetchMock.mock.calls[3][0]);
+        expect(finalProbeUrl.searchParams.get("since")).toBe("page-terminator");
     });
 
     it("classifies an external AbortError as a retryable transport failure", async () => {

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fast Fetch now sizes each finite CouchDB changes page from a one-row status probe, counts the returned result together with `pending`, and resumes from the page's opaque `last_seq` without comparing token representations. Heartbeat-enabled feeds no longer wait for future writes after the currently available rows have been persisted ([Self-hosted LiveSync issue #1065](https://github.com/vrtmrz/obsidian-livesync/issues/1065)).
+
 ## 0.1.6
 
 ### Fixed


### PR DESCRIPTION
This fix prevents Fast Fetch from waiting indefinitely after the currently available CouchDB changes have been persisted by using bounded pages and opaque continuation cursors.

## Problem

Fast Fetch previously captured a target token from one `_changes` request and waited for a streamed row token to match it. CouchDB sequence tokens are opaque, and tokens from separate feed contexts need not use the same representation. When the available rows ended without exact token equality, the heartbeat-enabled stream could remain open waiting for future writes even though the local database was caught up.

## Changes

- Probe the available changes from the current cursor with `limit=1`.
- Fetch changes in finite pages of at most 10,000 rows.
- Persist each page's exact `last_seq` value as the next opaque cursor.
- Repeat until a subsequent probe reports no available rows.
- Count tombstones and document-less changes consistently with CouchDB's row limit.
- Reject incomplete pages which end without a `last_seq` terminator.

## Verification

- Focused StreamingFetch tests: 16 passed.
- Full Commonlib suite: 70 files and 1,250 tests passed.
- CouchDB 3.5 clustered integration tests: 2 files and 6 tests passed.
- Type, package-boundary, release, and packed-artefact checks passed.
- The exact packed artefact passed LiveSync type-checking, 87 test files and 627 tests, and the production build.

Related: [Self-hosted LiveSync issue #1065](https://github.com/vrtmrz/obsidian-livesync/issues/1065).
