### PR TITLE
Prepare Commonlib 0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+## 0.1.7
+
 ### Fixed
 
-- Fast Fetch now sizes each finite CouchDB changes page from a one-row status probe, counts the returned result together with `pending`, and resumes from the page's opaque `last_seq` without comparing token representations. Heartbeat-enabled feeds no longer wait for future writes after the currently available rows have been persisted ([Self-hosted LiveSync issue #1065](https://github.com/vrtmrz/obsidian-livesync/issues/1065)).
+- Fast Fetch now sizes each finite CouchDB changes page from a one-row status probe, counts the returned result together with `pending`, and resumes from the page's opaque `last_seq` without comparing token representations. Heartbeat-enabled feeds no longer wait for future writes after the currently available rows have been persisted.
 
 ## 0.1.6
 


### PR DESCRIPTION
This release preparation updates Commonlib to 0.1.7 so the bounded Fast Fetch completion fix can be published and validated as an exact stable package.

## Changes

- Bump `package.json` and `package-lock.json` from 0.1.6 to 0.1.7.
- Move the bounded Fast Fetch completion note from `Unreleased` to 0.1.7.

## Verification

- `npm ci`
- Complete package gate: 70 test files and 1,250 tests passed.
- Package-boundary, release-selection, generated-package, and clean-consumer checks passed.
- `npm publish --dry-run .package --tag next --access public` succeeded.
- Dry-run package: 500 files, 398,268 bytes.
- Integrity: `sha512-tVOg5WQT7oBaPDsoKvdgsUq17kTTMA48ys6oha7/oSgC2+hxxv6sJYXch8KdIwMApAF6O4o2EFK/8KhSC9ooHA==`

The dependency graph is unchanged. npm audit continues to report the existing PouchDB/uuid findings and a development-only nanoid advisory.
