### PR TITLE
Allow CouchDB 3.2 to close bounded Fast Fetch pages

### DIFF
--- a/src/pouchdb/StreamingFetch.ts
+++ b/src/pouchdb/StreamingFetch.ts
@@ -18,9 +18,16 @@ interface AnyDecryptedDoc {
 type DBSequence = number | string;
 
 // This bounds one HTTP response without changing the smaller PouchDB write
-// batches. A finite continuous feed returns its own opaque `last_seq` marker,
-// which is the only page boundary Fast Fetch needs to persist and replay.
+// batches. Each completed page returns an opaque `last_seq` marker, which is
+// the only page boundary Fast Fetch needs to persist and replay.
 const FAST_FETCH_CHANGES_PAGE_LIMIT = 10_000;
+
+// A heartbeat keeps a continuous feed open after its finite limit on CouchDB
+// 3.2. Without a heartbeat, this timeout closes the feed after CouchDB has
+// exhausted the currently available changes and lets it emit `last_seq`.
+// Fast Fetch then reconnects from that cursor, so the short wait does not bound
+// the duration of an active page transfer.
+const FAST_FETCH_CHANGES_PAGE_TIMEOUT_MS = 1_000;
 
 /**
  * Identifies the boundary at which Fast Fetch stopped.
@@ -365,7 +372,6 @@ export async function fetchChangesForInitialSync(
         conflicts: "true",
         revs: "true",
         since: since.toString(),
-        heartbeat: "30000",
     } as const;
     const fetchHeaders = {
         Accept: "application/json",
@@ -522,6 +528,7 @@ export async function fetchChangesForInitialSync(
                 ...changesBaseParams,
                 since: pageSince.toString(),
                 limit: pageLimit.toString(),
+                timeout: FAST_FETCH_CHANGES_PAGE_TIMEOUT_MS.toString(),
             });
             const response = await fetchResponse(
                 changesURL.toString(),

--- a/src/pouchdb/StreamingFetch.unit.spec.ts
+++ b/src/pouchdb/StreamingFetch.unit.spec.ts
@@ -47,6 +47,16 @@ function failingStream(error: Error) {
     });
 }
 
+function streamWhichFailsAfterCurrentRows(lines: string[], error: Error) {
+    return new ReadableStream({
+        start(controller) {
+            const encoder = new TextEncoder();
+            controller.enqueue(encoder.encode(lines.join("\n") + "\n"));
+            setTimeout(() => controller.error(error), 10);
+        },
+    });
+}
+
 function changeLine(sequence: string | number, id: string, value?: string): string {
     return JSON.stringify({
         seq: sequence,
@@ -182,6 +192,45 @@ describe("fetchChangesForInitialSync", () => {
         const changesURL = new URL(fetchMock.mock.calls[2][0]);
         expect(changesURL.searchParams.get("feed")).toBe("continuous");
         expect(changesURL.searchParams.get("limit")).toBe("1");
+    });
+
+    it("lets CouchDB 3.2 close a bounded page after its current changes are exhausted", async () => {
+        const localDB = createLocalDatabase("streaming-fetch-couchdb-3-2-page-completion");
+        let probeCount = 0;
+        fetchMock.mockImplementation(async (input: string | URL | Request) => {
+            const url = new URL(input.toString());
+            if (url.searchParams.get("since") === "now") {
+                return new Response(JSON.stringify({ last_seq: "target-sequence" }));
+            }
+            if (url.searchParams.get("feed") === "normal") {
+                const available = probeCount++ === 0 ? 1 : 0;
+                return new Response(JSON.stringify(changesStatus(available, "page-terminator")));
+            }
+            if (url.searchParams.has("heartbeat")) {
+                // CouchDB 3.2 keeps a continuous heartbeat feed open after its
+                // finite limit is exhausted. Fail the fixture after delivering the
+                // current rows so that this server-side wait is detected promptly.
+                return new Response(
+                    streamWhichFailsAfterCurrentRows(
+                        [changeLine("row-sequence", "doc1", "one")],
+                        new Error("CouchDB 3.2 kept the bounded heartbeat feed open")
+                    )
+                );
+            }
+            return new Response(
+                textStream([
+                    changeLine("row-sequence", "doc1", "one"),
+                    JSON.stringify({ last_seq: "page-terminator", pending: 0 }),
+                ])
+            );
+        });
+
+        await fetchInitial(localDB);
+
+        await expect(localDB.get("doc1")).resolves.toMatchObject({ value: "one" });
+        const pageUrl = new URL(fetchMock.mock.calls[2][0]);
+        expect(pageUrl.searchParams.get("heartbeat")).toBeNull();
+        expect(pageUrl.searchParams.get("timeout")).toBe("1000");
     });
 
     it("continues from each opaque terminator in pages of at most 10,000 rows", async () => {

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fast Fetch now uses a one-second idle timeout for each finite CouchDB changes page instead of a heartbeat, allowing CouchDB 3.2 to return its terminator after the currently available rows have been persisted.
+
 ## 0.1.7
 
 ### Fixed


### PR DESCRIPTION
Adjust bounded Fast Fetch pages so CouchDB 3.2 can return each durable page terminator instead of waiting indefinitely.

## Summary

- Replace the heartbeat on each finite continuous changes page with a one-second server-side idle timeout.
- Continue from CouchDB's opaque `last_seq` only after the page batch and checkpoint are durable.
- Add a focused regression test for CouchDB 3.2 page-tail behaviour and record the change in the package updates.

## Rationale

CouchDB 3.2 can keep a heartbeat-enabled continuous feed waiting for later database updates after all rows requested by the finite limit have arrived. Without a heartbeat, `timeout=1000` lets CouchDB emit the feed-level terminator after the currently available rows are exhausted. This timeout does not limit an active page transfer; Fast Fetch reconnects from the returned opaque cursor and probes for remaining work.

The permanent CouchDB CI matrix is unchanged. The version-specific behaviour is covered by the focused regression test and confirmed with a LiveSync test build against CouchDB 3.2.

## Verification

- Confirmed the new regression test fails for the expected heartbeat-open behaviour before the implementation change.
- `NODE_OPTIONS=--max-old-space-size=3072 npm test -- src/pouchdb/StreamingFetch.unit.spec.ts --maxWorkers=1` (17 tests passed)
- `NODE_OPTIONS=--max-old-space-size=3072 npm run check:types`
- `NODE_OPTIONS=--max-old-space-size=3072 npm run test:package`
- A manual CouchDB 3.2 protocol check returned `last_seq` and `pending` terminators for both complete and partial finite pages using the idle timeout.
- Built a LiveSync `main.js` from LiveSync `1dfdb72f` with Commonlib `1f87bd5` and confirmed Fast Fetch completed successfully against CouchDB 3.2.
