### PR TITLE
Prepare Commonlib 0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/src/pouchdb/StreamingFetch.integration.spec.ts
+++ b/src/pouchdb/StreamingFetch.integration.spec.ts
@@ -127,36 +127,6 @@ describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
         await expectCheckpointHasNoPendingChanges(checkpoints.at(-1));
     });
 
-    it("should complete when a feed-level target differs from the final two-shard row sequence", async () => {
-        await remoteDB.put({ _id: "single-shard-change", type: "plain", data: "hello" });
-        const remoteChanges = await remoteDB.changes({ since: "0" });
-        const targetUrl = new URL(`${remoteDbUrl}/_changes`);
-        targetUrl.searchParams.set("feed", "normal");
-        targetUrl.searchParams.set("since", "now");
-        targetUrl.searchParams.set("limit", "1");
-        targetUrl.searchParams.set("include_docs", "false");
-        const targetResponse = await fetch(targetUrl, { headers: { Authorization: authHeader } });
-        expect(targetResponse.ok).toBe(true);
-        const targetSequence = ((await targetResponse.json()) as { last_seq: string | number }).last_seq;
-        const finalRowSequence = remoteChanges.results.at(-1)?.seq;
-        expect(finalRowSequence).toBeDefined();
-        expect(finalRowSequence?.toString()).not.toBe(targetSequence.toString());
-        const checkpoints: Array<string | number> = [];
-
-        await fetchChangesForInitialSync(
-            localDB,
-            remoteDbUrl,
-            authHeader,
-            (doc) => Promise.resolve(doc as any),
-            "0",
-            () => {},
-            (sequence) => checkpoints.push(sequence)
-        );
-
-        await expect(localDB.get("single-shard-change")).resolves.toMatchObject({ data: "hello" });
-        await expectCheckpointHasNoPendingChanges(checkpoints.at(-1));
-    });
-
     it("should count a deletion tombstone as one bounded changes row", async () => {
         await remoteDB.put({ _id: "retained-document", type: "plain", data: "keep" });
         const deletedDocument = await remoteDB.put({ _id: "deleted-document", type: "plain", data: "remove" });

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.8
+
 ### Fixed
 
 - Fast Fetch now uses a one-second idle timeout for each finite CouchDB changes page instead of a heartbeat, allowing CouchDB 3.2 to return its terminator after the currently available rows have been persisted.


### PR DESCRIPTION
This release preparation updates Commonlib to 0.1.8 for the CouchDB 3.2 Fast Fetch fix and removes an invalid opaque-token assertion which made integration CI non-deterministic.

## Changes

- Bump `package.json` and `package-lock.json` from 0.1.7 to 0.1.8.
- Move the CouchDB 3.2 Fast Fetch page-completion note from `Unreleased` to 0.1.8.
- Remove an integration assertion which required sequence tokens from separate `_changes` requests to differ. They may legitimately match or differ; the differing-token path remains covered by a deterministic unit test, while integration tests continue to replay the final checkpoint to CouchDB.

## Verification

- `npm ci`
- Managed integration suite on the updated release HEAD: two test files and five tests passed.
- Complete package gate: 70 test files and 1,251 tests passed.
- Package-boundary, release-selection, generated-package, and clean-consumer checks passed.
- `npm publish --dry-run .package --tag next --access public` succeeded.
- Dry-run package: 500 files, 398,280 bytes.
- Integrity: `sha512-L8gwl7WHBjRNuv6V4iA1iIBIQnJERYs9vHuK4Pzs5aA8dCK967n1rSZF3UAeIbvKgbK1mgaFt8+BnH7qkp3COQ==`
- A LiveSync `main.js` built with the merged Commonlib source commit `1f87bd5` completed Fast Fetch successfully against CouchDB 3.2.

The dependency graph and generated package are unchanged by the test correction. npm audit continues to report the existing PouchDB and uuid findings, and development-only nanoid and PostCSS advisories.
