### PR TITLE
Prepare Commonlib 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.9
+
 ### Fixed
 
 - Fast Fetch now forwards configured CouchDB custom headers to every changes-feed request, allowing reverse proxies such as Cloudflare Access to authenticate initial setup consistently with ordinary replication (PR #82). Thank you to @nimula for the contribution!


### PR DESCRIPTION
This release preparation updates Commonlib to 0.1.9 so the Fast Fetch custom-header fix can be staged and validated as an exact package.

## Changes

- Bump `package.json` and `package-lock.json` from 0.1.8 to 0.1.9.
- Record the Fast Fetch custom-header fix under the 0.1.9 release heading.
- Preserve the original contribution and credit from #82, as adapted and merged in #102.

## Impact

Fast Fetch previously assembled its own CouchDB request headers and omitted the custom headers used by ordinary replication. Version 0.1.9 packages the fix which forwards those headers to every changes-feed request, allowing reverse proxies such as Cloudflare Access to authenticate initial setup consistently.

## Verification

- `npm ci`
- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package` — 70 test files and 1,253 tests passed, together with type, package-boundary, release-selection, generated-package, and clean-consumer checks.
- `NODE_OPTIONS=--max-old-space-size=3072 npm publish --dry-run .package --tag next --access public` — succeeded.
- Dry-run package: 500 files, 398,420 bytes packed, and 1,712,018 bytes unpacked.
- Integrity: `sha512-vQIPTncZ0enXtGHhft6a2b6NIoD66UnFod8nWX12ekQgwnt6LebYeG9tp7D7wXsh0l/Xw23uP/Ju5oalcpidTA==`

The dependency graph is unchanged. npm audit continues to report 20 existing advisories: 19 moderate and one high.
