### PR TITLE
Fall back from Fast Fetch when using the internal API

### DIFF
--- a/src/serviceModules/Rebuilder.ts
+++ b/src/serviceModules/Rebuilder.ts
@@ -341,6 +341,7 @@ Are you sure you wish to proceed?`;
         await this.suspendReflectingDatabase(!autoResume);
         await this.control.applySettings();
         await this.resetLocalDatabase();
+        this.clearFastFetchCheckpoint();
         await delay(1000);
         await this.database.openDatabase({
             databaseEvents: this.databaseEvents,
@@ -377,6 +378,14 @@ Are you sure you wish to proceed?`;
         if (settings.remoteType !== REMOTE_COUCHDB) {
             this._log(
                 "Fast database fetch is available only for CouchDB remote. Falling back to standard fetch.",
+                LOG_LEVEL_NOTICE
+            );
+            await this.fetchLocal(false, true, autoResume);
+            return;
+        }
+        if (settings.useRequestAPI) {
+            this._log(
+                "Fast database fetch is unavailable while 'Use Internal API' is enabled. Falling back to Standard Fetch.",
                 LOG_LEVEL_NOTICE
             );
             await this.fetchLocal(false, true, autoResume);

--- a/src/serviceModules/Rebuilder.unit.spec.ts
+++ b/src/serviceModules/Rebuilder.unit.spec.ts
@@ -32,6 +32,7 @@ function createRebuilder() {
         couchDB_USER: "user",
         couchDB_PASSWORD: "pass",
         couchDB_CustomHeaders: "",
+        useRequestAPI: false,
         useJWT: false,
         passphrase: "",
         E2EEAlgorithm: "",
@@ -365,6 +366,30 @@ describe("ServiceRebuilder bounded remote activity", () => {
 
         await rebuilder.$fetchLocalDBFast(false);
 
+        expect(runBoundedRemoteActivity).toHaveBeenCalledTimes(1);
+        expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
+            label: "rebuild-fetch",
+        });
+    });
+
+    it("uses Standard Fetch when the internal Request API is enabled", async () => {
+        fetchChangesForInitialSyncMock.mockReset().mockResolvedValue(undefined);
+        const { rebuilder, services, settings, runBoundedRemoteActivity } = createRebuilder();
+        settings.useRequestAPI = true;
+        settings.additionalSuffixOfDatabaseName = "app";
+        services.setting.setSmallConfig(
+            "fast-fetch-checkpoint",
+            JSON.stringify({ remote: "https://example.com/db", sequence: "10-g1" })
+        );
+
+        await rebuilder.$fetchLocalDBFast(false);
+
+        expect(fetchChangesForInitialSyncMock).not.toHaveBeenCalled();
+        expect(services.replication.replicateAllFromRemote).toHaveBeenCalledTimes(2);
+        expect(services.setting.deleteSmallConfig).toHaveBeenCalledWith("fast-fetch-checkpoint");
+        expect(services.database.resetDatabase.mock.invocationCallOrder[0]).toBeLessThan(
+            services.setting.deleteSmallConfig.mock.invocationCallOrder[0]
+        );
         expect(runBoundedRemoteActivity).toHaveBeenCalledTimes(1);
         expect(runBoundedRemoteActivity).toHaveBeenCalledWith(expect.any(Function), {
             label: "rebuild-fetch",


### PR DESCRIPTION
This fix routes Fast Fetch to Standard Fetch when the internal Request API is enabled, avoiding a streaming path which the buffered transport cannot support.

## Summary

- Detect `useRequestAPI` before entering the Fast Fetch remote activity.
- Reuse the existing Standard Fetch path, and clear any retained Fast Fetch checkpoint after its local database reset.
- Add regression coverage for the fallback, streaming exclusion, and checkpoint invalidation order.

## Rationale

Fast Fetch requires a progressively readable response body and request cancellation. Obsidian's internal `requestUrl` API exposes only a completed response and does not accept the Fetch API's `AbortSignal`, so adapting it would not preserve the transport contract Fast Fetch relies on.

This decision is based on the selected transport. Custom headers remain eligible for Fast Fetch when the ordinary Fetch API can send them successfully.

## Verification

- Added the regression test before the production change and confirmed that it failed because Streaming Fetch was still invoked.
- `NODE_OPTIONS=--max-old-space-size=3072 npx vitest run src/serviceModules/Rebuilder.unit.spec.ts --maxWorkers=1` — 19 tests passed.
- `NODE_OPTIONS=--max-old-space-size=3072 npm run check:types` — passed.
- `NODE_OPTIONS=--max-old-space-size=3072 npm test -- --maxWorkers=1` — 1,254 tests passed across 70 files.
- `NODE_OPTIONS=--max-old-space-size=3072 npm run test:package` — passed.
- The packed Commonlib artefact passed downstream LiveSync checks, 630 unit tests across 88 files, and the production build.
