### PR TITLE
Prepare Commonlib 0.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.10
+
+### Fixed
+
+- Fast Fetch now falls back to Standard Fetch when the internal Request API is enabled, avoiding a buffered transport which cannot provide the progressive response reading or request cancellation Fast Fetch requires. Standard Fetch also discards obsolete Fast Fetch checkpoints after resetting the local database ([Self-hosted LiveSync issue #1020](https://github.com/vrtmrz/obsidian-livesync/issues/1020)).
+
 ## 0.1.9
 
 ### Fixed


### PR DESCRIPTION
This release preparation updates Commonlib to 0.1.10 so the internal Request API fallback can be staged and validated as an exact package.

## Changes

- Bump `package.json` and `package-lock.json` from 0.1.9 to 0.1.10.
- Record the Fast Fetch fallback and checkpoint invalidation under the 0.1.10 release heading.

## Impact

Fast Fetch requires progressive response reading and request cancellation, while Obsidian's internal `requestUrl` API exposes a completed response. Version 0.1.10 falls back to Standard Fetch for that transport. Standard Fetch also discards obsolete Fast Fetch checkpoints after resetting the local database.

## Verification

- `npx --yes npm@11.18.0 ci`
- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package` — 70 test files and 1,254 tests passed, together with type, package-boundary, release-selection, generated-package, and clean-consumer checks.
- `npx --yes npm@11.18.0 publish --dry-run .package --tag next --access public` — succeeded.
- Dry-run package: 500 files, 398,493 bytes packed, and 1,712,330 bytes unpacked.
- Integrity: `sha512-8eks01IwlHazTyS/ybo44BXKjUwT/1Fg417BmQPwFdYVb5Jy888hXjtKgCp5oXLubcMsLUpydJh6NDXZckTvHA==`
- The implementation package passed downstream LiveSync checks, 630 unit tests across 88 files, and the production build.

The dependency graph is unchanged. npm audit continues to report 20 existing advisories: 19 moderate and one high.
