### PR TITLE
Prepare Commonlib 0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.11
+
+### Fixed
+
+- Full offline scans now distinguish completed, deliberately skipped, and failed storage/database pairs. Failed database-to-storage reflections no longer record the database mtime as local last-seen evidence, preventing a later `NEWER_WINS` scan from misclassifying a still-missing file as an offline deletion. Actual failures propagate to maintained hosts, while conflict and size-policy skips remain non-fatal ([Self-hosted LiveSync issue #1065](https://github.com/vrtmrz/obsidian-livesync/issues/1065)).
+
 ## 0.1.10
 
 ### Fixed


### PR DESCRIPTION
This release preparation updates Commonlib to 0.1.11 so offline-scan failure propagation can be staged and validated as an exact package.

## Changes

- Bump `package.json` and `package-lock.json` from 0.1.10 to 0.1.11.
- Record the completed, deliberately skipped, and failed offline-scan result contract under the 0.1.11 release heading.

## Impact

A failed database-to-storage reflection no longer records the database mtime as evidence that the file existed locally. A later `NEWER_WINS` scan therefore retries the reflection instead of misclassifying the still-missing file as an offline local deletion.

Actual failures propagate through the full-scan result to maintained hosts, while conflict, size-limit, and policy skips remain non-fatal. This is expected to address the deletion path observed in [Self-hosted LiveSync #1065](https://github.com/vrtmrz/obsidian-livesync/issues/1065), but it does not diagnose the original reason that some local writes fail.

## Verification

- `npx --yes npm@11.18.0 ci`
- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package` — 70 test files and 1,266 tests passed, together with seven boundary tests, 20 release-selection tests, type checks, package-boundary checks, 109 generated compatibility exports, and clean-consumer checks.
- `npx --yes npm@11.18.0 publish --dry-run .package --tag next --access public` — succeeded.
- Dry-run package: 500 files, 399,470 bytes packed, and 1,716,779 bytes unpacked.
- Integrity: `sha512-ViDLJvsTfbXbkYQVDmb224ZtaZiAtMcn2u9iaAwNLmLzHqY1UbyflsTzFTv+eBptN8T4p1FM0Lggi95F11bqFQ==`
- The implementation package passed Self-hosted LiveSync 1.0.11 root and application type checks, the production plug-in build, 149 focused Fast Setup, daemon, and WebApp tests, and all six CLI mirror E2E cases.

The dependency graph is unchanged. npm audit continues to report 20 existing advisories: 19 moderate and one high.
