### PR TITLE
fix: do not decrypt deletion tombstones during fast fetch

### DIFF
--- a/src/pouchdb/StreamingFetch.integration.spec.ts
+++ b/src/pouchdb/StreamingFetch.integration.spec.ts
@@ -151,6 +151,39 @@ describe("StreamingFetch - fetchChangesForInitialSync integration", () => {
         await expectCheckpointHasNoPendingChanges(checkpoints.at(-1));
     });
 
+    it("should tolerate a tombstone whose id is an obfuscated entry", async () => {
+        await remoteDB.put({ _id: "f:retained-file", type: "file", path: "notes/keep.md", data: "keep" });
+        const deletedFile = await remoteDB.put({ _id: "f:deleted-file", type: "file", path: "notes/remove.md", data: "remove" });
+        await remoteDB.remove("f:deleted-file", deletedFile.rev);
+        const checkpoints: Array<string | number> = [];
+
+        // Mimic the E2EE decryption contract: obfuscated entries (f: ids) must
+        // carry a path to decrypt. A tombstone has no path, so a real
+        // implementation throws for it. The fetch must still complete and
+        // record the deletion instead of aborting at the tombstone.
+        const decryptFunction = (doc: any) => {
+            if (doc._id.startsWith("f:") && doc.path === undefined) {
+                return Promise.reject(new Error("Entry has been obfuscated!"));
+            }
+            return Promise.resolve(doc);
+        };
+
+        await fetchChangesForInitialSync(
+            localDB,
+            remoteDbUrl,
+            authHeader,
+            decryptFunction,
+            "0",
+            () => {},
+            (sequence) => checkpoints.push(sequence)
+        );
+
+        await expect(localDB.get("f:retained-file")).resolves.toMatchObject({ path: "notes/keep.md" });
+        const deletedRows = await localDB.allDocs({ keys: ["f:deleted-file"] });
+        expect(deletedRows.rows[0]).toMatchObject({ value: { deleted: true } });
+        await expectCheckpointHasNoPendingChanges(checkpoints.at(-1));
+    });
+
     it("should handle empty database gracefully", async () => {
         // Perform streaming fetch on empty database
         await fetchChangesForInitialSync(localDB, remoteDbUrl, authHeader, (doc) => Promise.resolve(doc as any), "0");

--- a/src/pouchdb/StreamingFetch.ts
+++ b/src/pouchdb/StreamingFetch.ts
@@ -218,15 +218,25 @@ function generatePouchDBBatchWriter(
     return {
         async write(doc: EntryDoc, sequence: DBSequence) {
             let decryptedDoc: AnyEntry | EntryLeaf;
-            try {
-                decryptedDoc = await decryptFunction(doc);
-            } catch (error) {
-                throw new StreamingFetchFailure(
-                    "decryption",
-                    `Fast Fetch could not decrypt a document: ${errorMessage(error)}`,
-                    false,
-                    { cause: error }
-                );
+            if (doc._deleted) {
+                // A deletion tombstone carries no encrypted payload to decrypt.
+                // Pass it through unchanged so the local database records the
+                // deletion. Some decryption implementations require a path on
+                // obfuscated entries (f: ids) and throw for tombstones, which
+                // would otherwise abort the whole fetch at the first deleted
+                // document in the feed.
+                decryptedDoc = doc as unknown as AnyEntry;
+            } else {
+                try {
+                    decryptedDoc = await decryptFunction(doc);
+                } catch (error) {
+                    throw new StreamingFetchFailure(
+                        "decryption",
+                        `Fast Fetch could not decrypt a document: ${errorMessage(error)}`,
+                        false,
+                        { cause: error }
+                    );
+                }
             }
 
             let serialisedDoc: string;

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fast Fetch now writes deletion tombstones to the local database without attempting to decrypt them. A tombstone has no encrypted payload, and decryption previously aborted the whole fetch at the first deleted document. New devices could not complete their initial sync on vaults that contain old deletions ([Self-hosted LiveSync issue #1099](https://github.com/vrtmrz/obsidian-livesync/issues/1099)).
+
 ## 0.1.11
 
 ### Fixed


### PR DESCRIPTION
## Summary

Fast Fetch stops during the first synchronisation when the vault contains a deleted file.

The deletion arrives as a tombstone. A tombstone has no path. A tombstone has no content to decrypt. The decryption step fails on the tombstone. The fetch aborts. The device cannot finish its initial synchronisation. Every retry stops at the same sequence.

This change makes Fast Fetch write tombstones to the local database without decryption. The fetch continues past deleted files. The deletion is still recorded locally.

Fixes [vrtmrz/obsidian-livesync#1099](https://github.com/vrtmrz/obsidian-livesync/issues/1099).

## Changes

- `src/pouchdb/StreamingFetch.ts`: tombstones skip the decryption step.
- `src/pouchdb/StreamingFetch.integration.spec.ts`: new regression test with an `f:` tombstone and a decryption function that rejects path-less entries.
- `updates.md`: note for the unreleased changes.

## Verification

- `npm run check:types` passes.
- `npm test` passes: 1,266 tests in 70 files.
- Integration tests pass against CouchDB 3.5: 6 tests in 2 files.
- The new regression test fails without this change and passes with it.

I cannot run the full E2E suite on this machine. Please run CI tests.