### PR TITLE
Prepare Commonlib 0.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
+## 0.1.12
+
 ### Fixed
 
-- Fast Fetch now writes deletion tombstones to the local database without attempting to decrypt them. A tombstone has no encrypted payload, and decryption previously aborted the whole fetch at the first deleted document. New devices could not complete their initial sync on vaults that contain old deletions ([Self-hosted LiveSync issue #1099](https://github.com/vrtmrz/obsidian-livesync/issues/1099)).
+- Fast Fetch now writes deletion tombstones to the local database without attempting to decrypt them. A tombstone has no encrypted payload, and decryption previously aborted the whole fetch at the first deleted document. New devices could not complete their initial sync on vaults that contain old deletions ([Self-hosted LiveSync issue #1099](https://github.com/vrtmrz/obsidian-livesync/issues/1099); PR #108). Thank you to @KennethLloyd for the contribution!
+- Offline scans now validate each Metadata document against its actual database ID before pairing it with storage. An inconsistent entry is left unchanged and cannot trigger reflection, deletion, or last-seen updates; a separate, consistent entry for the same logical path continues normally. Maintained hosts can inspect the mismatch by actual ID and explicitly repair one unambiguous entry at a time.
 
 ## 0.1.11
 


### PR DESCRIPTION
This release preparation updates Commonlib to 0.1.12 so Fast Fetch tombstones and inconsistent Metadata identities can be handled safely in an exact staged package.

## Changes

- Bump `package.json` and `package-lock.json` from 0.1.11 to 0.1.12.
- Record the Fast Fetch tombstone fix from PR #108. Thank you to @KennethLloyd for the contribution.
- Record the Metadata identity validation, inspection, and explicit one-entry repair from PR #109.

## Impact

Fast Fetch now writes deletion tombstones to the local database without attempting to decrypt their absent payload. Old deletions therefore no longer abort an initial fetch, while the deletion remains represented locally.

Offline scans now validate each decoded Metadata document against its actual database ID before target filtering or pair construction. An inconsistent entry remains unchanged and cannot trigger reflection, deletion, expired-history cleanup, or last-seen persistence. A separate, consistent entry for the same logical path continues normally.

Maintained hosts can inspect an inconsistent entry by its actual ID and explicitly repair one unambiguous entry at a time. This release does not infer how a mismatch arose, perform batch repair, rename Vault storage, choose between case variants, coordinate devices, or alter Fast Setup and CLI completion policy.

## Verification

- `npm ci` with npm 11.18.0 succeeded.
- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package` — 71 test files and 1,283 tests passed, together with seven boundary tests, 20 release-selection tests, type checks, package-boundary checks, 117 generated compatibility exports, and clean-consumer checks.
- `npm run check:package` — succeeded.
- `npm publish --dry-run .package --tag next --access public` — succeeded.
- Dry-run package: 500 files, 404,246 bytes packed, and 1,737,880 bytes unpacked.
- Integrity: `sha512-7EQy1lsxQPGL5aBxx0aliBszZqF3XKzf+sHcEcS94oZF2MoFugoyxwqoxB/SuZ9gRbGAZDQYiD5R8Y+i6FRivA==`
- The Metadata identity implementation package passed focused downstream Self-hosted LiveSync tests, its type check, and its production build.

The dependency graph is unchanged. Production audit reports 18 existing moderate advisories. The full development audit reports 19 moderate advisories and one high advisory; the high advisory is confined to the Vitest development dependency chain.
