### PR TITLE
Generate TypeScript declaration mappings for public entries

### DIFF
--- a/_tools/build-package.mjs
+++ b/_tools/build-package.mjs
@@ -197,12 +197,27 @@ function createExports() {
     return exports;
 }
 
+function createTypesVersions(exports) {
+    const mappings = {};
+    for (const [exportPath, target] of Object.entries(exports)) {
+        if (exportPath === "." || exportPath === "./package.json") continue;
+        if (typeof target !== "object" || typeof target.types !== "string") {
+            throw new Error(`Public export '${exportPath}' has no declaration target.`);
+        }
+        mappings[exportPath.slice(2)] = [target.types.replace(/^\.\//u, "")];
+    }
+    // The exports map remains canonical; this mirrors it for legacy TypeScript resolvers.
+    return { "*": mappings };
+}
+
 async function writePackageManifest() {
+    const exports = createExports();
     const manifest = {
         name: sourceManifest.name,
         version: sourceManifest.version,
         description: sourceManifest.description,
         type: "module",
+        types: "./dist/index.d.ts",
         license: sourceManifest.license,
         repository: sourceManifest.repository,
         publishConfig: {
@@ -222,7 +237,8 @@ async function writePackageManifest() {
                 default: "./dist/worker/bgWorker.direct.js",
             },
         },
-        exports: createExports(),
+        exports,
+        typesVersions: createTypesVersions(exports),
         dependencies: sourceManifest.dependencies,
         peerDependencies: { svelte: sourceManifest.devDependencies.svelte },
         peerDependenciesMeta: { svelte: { optional: true } },

--- a/_tools/check-packed-package.mjs
+++ b/_tools/check-packed-package.mjs
@@ -3,7 +3,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { build } from "esbuild";
@@ -37,6 +37,25 @@ await mkdir(artefactDirectory, { recursive: true });
 const packed = JSON.parse(run("npm", ["pack", packageDirectory, "--json", "--pack-destination", artefactDirectory]))[0];
 assert.equal(packed.name, packageName);
 assert.ok(packed.size > 0, "The packed package must not be empty.");
+const generatedManifest = JSON.parse(await readFile(resolve(packageDirectory, "package.json"), "utf8"));
+assert.equal(
+    generatedManifest.types,
+    "./dist/index.d.ts",
+    "The generated package manifest must declare its root type entry for legacy TypeScript resolution."
+);
+assert.ok(
+    generatedManifest.typesVersions?.["*"],
+    "The generated package manifest must include typesVersions for legacy TypeScript resolution."
+);
+const exportedSubpaths = Object.keys(generatedManifest.exports)
+    .filter((subpath) => subpath !== "." && subpath !== "./package.json")
+    .map((subpath) => subpath.slice(2))
+    .sort();
+assert.deepEqual(
+    Object.keys(generatedManifest.typesVersions["*"]).sort(),
+    exportedSubpaths,
+    "Every public subpath must have a declaration mapping."
+);
 assert.ok(
     packed.files.every(({ path }) => !path.startsWith("src/")),
     "Source files must not be published."
@@ -388,6 +407,32 @@ assert.match(workerSource, /new Worker\(/u);
 const manifest = JSON.parse(
     await readFile(resolve(consumerDirectory, "node_modules", "@vrtmrz", "livesync-commonlib", "package.json"), "utf8")
 );
+const installedPackageDirectory = resolve(consumerDirectory, "node_modules", "@vrtmrz", "livesync-commonlib");
+const { default: ts } = await import("typescript");
+const compilerOptions = {
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+};
+const containingFile = resolve(consumerDirectory, "type-smoke.ts");
+const rootResolution = ts.resolveModuleName(packageName, containingFile, compilerOptions, ts.sys);
+assert.equal(
+    relative(installedPackageDirectory, rootResolution.resolvedModule?.resolvedFileName ?? "")
+        .split("\\")
+        .join("/"),
+    manifest.types.replace(/^\.\//u, ""),
+    "Node10 resolution selected an unexpected root declaration."
+);
+for (const [subpath, targets] of Object.entries(manifest.typesVersions["*"])) {
+    assert.equal(targets.length, 1, `Expected one declaration target for '${subpath}'.`);
+    const resolution = ts.resolveModuleName(`${packageName}/${subpath}`, containingFile, compilerOptions, ts.sys);
+    const resolved = resolution.resolvedModule?.resolvedFileName;
+    assert.ok(resolved, `Node10 resolution could not resolve '${packageName}/${subpath}'.`);
+    assert.equal(
+        relative(installedPackageDirectory, resolved).split("\\").join("/"),
+        targets[0],
+        `Node10 resolution selected an unexpected declaration for '${packageName}/${subpath}'.`
+    );
+}
 assert.equal(manifest.name, packageName);
 assert.notEqual(manifest.private, true, "The generated package must be publishable.");
 assert.deepEqual(

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "idb": "^8.0.3",
         "markdown-it": "^14.2.0",
         "minimatch": "^10.2.5",
-        "octagonal-wheels": "^0.1.51",
+        "octagonal-wheels": "^0.1.53",
         "pouchdb-adapter-http": "^9.0.0",
         "pouchdb-adapter-idb": "^9.0.0",
         "pouchdb-adapter-indexeddb": "^9.0.0",
@@ -2860,9 +2860,9 @@
       }
     },
     "node_modules/octagonal-wheels": {
-      "version": "0.1.51",
-      "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.51.tgz",
-      "integrity": "sha512-KTlfqKPjobHJg/t3A539srnFf+VHr1aXkHSmsNDDpiI5UFC7FamZ95dWpJfGE2EI/HULR5hveQDgkazmz8SAcg==",
+      "version": "0.1.53",
+      "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.53.tgz",
+      "integrity": "sha512-4NJsb96Sk6rJXhrTyjAY5GRIoWMFJsFp56b5ba9fV8/87ys2HCjMo0hior4F8k4ma72pLTJT7i6DvuihHxSsMA==",
       "license": "MIT",
       "dependencies": {
         "idb": "^8.0.3"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "idb": "^8.0.3",
     "markdown-it": "^14.2.0",
     "minimatch": "^10.2.5",
-    "octagonal-wheels": "^0.1.51",
+    "octagonal-wheels": "^0.1.53",
     "pouchdb-adapter-http": "^9.0.0",
     "pouchdb-adapter-idb": "^9.0.0",
     "pouchdb-adapter-indexeddb": "^9.0.0",


### PR DESCRIPTION
Generate root and subpath declaration fallbacks from Commonlib's existing public export inventory so Node10-style TypeScript resolution can resolve supported declarations without relying on `exports` conditions.

## Summary

- declare the root `./dist/index.d.ts` entry through the generated manifest's top-level `types` field;
- derive `typesVersions` from the same `createExports()` result used for focused and compatibility entries;
- extend packed-consumer verification to resolve the root and every public subpath with TypeScript's `Node10` module resolution; and
- require `octagonal-wheels` 0.1.53, whose generated manifest provides the corresponding root and subpath declaration mappings.

## Rationale

TypeScript's `Node10` resolution does not use the declaration conditions in the package `exports` map. The package root therefore requires a top-level `types` entry, while public subpaths require `typesVersions`.

The generated `exports` map remains authoritative. The compatibility mappings mirror it and cannot introduce an additional public entry independently.

## Verification

- confirmed that the packed-package check failed first for the missing `typesVersions` field;
- confirmed separately that root resolution failed without the top-level `types` field;
- ran the complete Commonlib package gate and managed integration suite with `octagonal-wheels` 0.1.53;
- resolved the generated root and all 115 public subpaths from the installed Commonlib tarball with TypeScript's `Node10` module resolution;
- confirmed that repeated package generation produces an identical manifest;
- installed the exact Commonlib tarball in Self-hosted LiveSync at `39732904858ed1889a5a8bde6a6c6f27b2fdcb02`, then passed its type check, 638 unit tests, plug-in, CLI, WebApp, and WebPeer builds, and CLI end-to-end test; and
- ran the official Obsidian Community ESLint configuration against that exact consumer installation; the targeted `error`-typed union and intersection findings were absent.

## Release order

`octagonal-wheels` 0.1.53 was published through trusted staged publishing, validated from the exact registry artefact in Commonlib and Self-hosted LiveSync, and promoted to `latest`. Commonlib now records 0.1.53 as its minimum compatible `octagonal-wheels` version.
