### PR TITLE
Close finite remote database connections

### DIFF
--- a/src/replication/couchdb/LiveSyncReplicator.ts
+++ b/src/replication/couchdb/LiveSyncReplicator.ts
@@ -471,7 +471,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         remoteDB: PouchDB.Database<EntryDoc> | undefined,
         showResult: boolean,
         fromSeq?: number | string
-    ) {
+    ): Promise<boolean> {
         const trench = new Trench(
             this.env.services.keyValueDB.openSimpleStore<{
                 seq: string | number;
@@ -491,10 +491,13 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
                 );
                 return false;
             }
-            remoteDB = d.db;
+            return await this.withRemoteDatabase(d.db, async (db) => this.sendChunks(setting, db, showResult, fromSeq));
         }
         // To create salt
-        await this.checkReplicationConnectivity(setting, false, false, false, false);
+        const connectivity = await this.checkReplicationConnectivity(setting, false, false, false, false);
+        if (connectivity !== false) {
+            await this.closeRemoteDatabase(connectivity.db);
+        }
         Logger(`Bulk sending chunks to remote database...`, showResult ? LOG_LEVEL_NOTICE : LOG_LEVEL_INFO, "fetch");
         const remoteMilestone = await remoteDB.get(MILESTONE_DOCID);
         const remoteID = (remoteMilestone as { created?: number })?.created ?? 0;
@@ -772,12 +775,23 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
 
     // One-shot attempts own their temporary remote handle. Continuous replication
     // keeps its handle until the replication controller terminates it.
-    private async closeRemoteDatabase(db: PouchDB.Database<EntryDoc>) {
+    private async closeRemoteDatabase(db: Pick<PouchDB.Database<DatabaseEntry>, "close">) {
         try {
             await db.close();
         } catch (ex) {
             Logger("Failed to close remote database.", LOG_LEVEL_INFO, "sync");
             Logger(ex, LOG_LEVEL_VERBOSE, "sync");
+        }
+    }
+
+    private async withRemoteDatabase<T extends object, R>(
+        db: PouchDB.Database<T>,
+        task: (db: PouchDB.Database<T>) => Promise<R>
+    ): Promise<R> {
+        try {
+            return await task(db);
+        } finally {
+            await this.closeRemoteDatabase(db);
         }
     }
 
@@ -938,6 +952,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
                     Logger(this.translate("liveSyncReplicator.checkingLastSyncPoint"), LOG_LEVEL_NOTICE, "sync");
                 }
                 const { db, syncOption } = ret;
+                try {
                 this.syncStatus = "STARTED";
                 this.maxPullSeq = Number(`${ret.info.update_seq}`.split("-")[0]);
                 this.maxPushSeq = Number(`${(await localDB.info()).update_seq}`.split("-")[0]);
@@ -970,7 +985,8 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
                 }
                 if (syncResult == "NEED_RESURRECT") {
                     this.terminateSync();
-                    return async () => await this.openContinuousReplication(this.originalSetting, showResult, false);
+                        return async () =>
+                            await this.openContinuousReplication(this.originalSetting, showResult, false);
                 }
                 if (syncResult == "NEED_RETRY") {
                     const tempSetting: RemoteDBSettings = JSON.parse(JSON.stringify(setting));
@@ -992,6 +1008,9 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
                         );
                         return async () => await this.openContinuousReplication(tempSetting, showResult, true);
                     }
+                }
+                } finally {
+                    await this.closeRemoteDatabase(db);
                 }
             }
             return false;
@@ -1018,12 +1037,16 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         const con = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
         if (typeof con == "string") return;
         try {
+        try {
             await con.db.destroy();
             Logger(this.translate("liveSyncReplicator.remoteDbDestroyed"), LOG_LEVEL_NOTICE);
             await this.tryCreateRemoteDatabase(setting);
         } catch (ex) {
             Logger(this.translate("liveSyncReplicator.remoteDbDestroyError"), LOG_LEVEL_NOTICE);
             Logger(ex, LOG_LEVEL_NOTICE);
+        }
+        } finally {
+            await this.closeRemoteDatabase(con.db);
         }
         // Recreate salt
         clearHandlers();
@@ -1034,6 +1057,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         const con2 = await this.connectRemoteCouchDBWithSetting(setting, this.isMobile(), true);
 
         if (typeof con2 === "string") return;
+        await this.closeRemoteDatabase(con2.db);
         // Recreate salt
         clearHandlers();
         await this.ensurePBKDF2Salt(setting, true, false);
@@ -1049,7 +1073,8 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             return;
         }
 
-        if (!(await checkRemoteVersion(dbRet.db, this.migrate.bind(this), VER))) {
+        await this.withRemoteDatabase(dbRet.db, async (db) => {
+            if (!(await checkRemoteVersion(db, this.migrate.bind(this), VER))) {
             Logger(this.translate("liveSyncReplicator.remoteDbCorrupted"), LOG_LEVEL_NOTICE);
             return;
         }
@@ -1067,7 +1092,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
 
         const remoteMilestone: EntryMilestoneInfo = {
             ...defInitPoint,
-            ...(await resolveWithIgnoreKnownError(dbRet.db.get(MILESTONE_DOCID), defInitPoint)),
+                ...(await resolveWithIgnoreKnownError(db.get(MILESTONE_DOCID), defInitPoint)),
         };
         remoteMilestone.node_chunk_info = { ...defInitPoint.node_chunk_info, ...remoteMilestone.node_chunk_info };
         remoteMilestone.accepted_nodes = [this.nodeid];
@@ -1078,7 +1103,8 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         } else {
             Logger(this.translate("liveSyncReplicator.unlockRemoteDb"), LOG_LEVEL_NOTICE);
         }
-        await dbRet.db.put(remoteMilestone);
+            await db.put(remoteMilestone);
+        });
     }
     async markRemoteResolved(setting: RemoteDBSettings) {
         const uri =
@@ -1090,7 +1116,8 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             return;
         }
 
-        if (!(await checkRemoteVersion(dbRet.db, this.migrate.bind(this), VER))) {
+        await this.withRemoteDatabase(dbRet.db, async (db) => {
+            if (!(await checkRemoteVersion(db, this.migrate.bind(this), VER))) {
             Logger(this.translate("liveSyncReplicator.remoteDbCorrupted"), LOG_LEVEL_NOTICE);
             return;
         }
@@ -1107,17 +1134,18 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         // check local database hash status and remote replicate hash status
         const remoteMilestone: EntryMilestoneInfo = {
             ...defInitPoint,
-            ...(await resolveWithIgnoreKnownError(dbRet.db.get(MILESTONE_DOCID), defInitPoint)),
+                ...(await resolveWithIgnoreKnownError(db.get(MILESTONE_DOCID), defInitPoint)),
         };
         remoteMilestone.node_chunk_info = { ...defInitPoint.node_chunk_info, ...remoteMilestone.node_chunk_info };
         remoteMilestone.accepted_nodes = Array.from(new Set([...remoteMilestone.accepted_nodes, this.nodeid]));
         Logger(this.translate("liveSyncReplicator.markDeviceResolved"), LOG_LEVEL_NOTICE);
-        const result = await dbRet.db.put(remoteMilestone);
+            const result = await db.put(remoteMilestone);
         if (result.ok) {
             Logger(this.translate("liveSyncReplicator.remoteDbMarkedResolved"), LOG_LEVEL_VERBOSE);
         } else {
             Logger(this.translate("liveSyncReplicator.couldNotMarkResolveRemoteDb"), LOG_LEVEL_NOTICE);
         }
+        });
     }
 
     connectRemoteCouchDBWithSetting(
@@ -1185,14 +1213,19 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         id: string,
         db?: PouchDB.Database<T>
     ): Promise<T | false> {
+        const ownsConnection = db === undefined;
+        const connDB = db ?? (await this._ensureConnection<T>(settings));
         try {
-            const connDB = db ?? (await this._ensureConnection(settings));
             return await connDB.get(id);
         } catch (ex: unknown) {
             if (ex && (ex as { status?: number }).status == 404) {
                 return false;
             }
             throw ex;
+        } finally {
+            if (ownsConnection) {
+                await this.closeRemoteDatabase(connDB);
+            }
         }
     }
     /**
@@ -1210,8 +1243,15 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
     ): Promise<PouchDB.Core.Response> {
         // The `putRemoteDocument` function may be called to update the salt,
         // so we cannot skip the setup phase.
-        const connDB = db ?? (await this._ensureConnection(settings, true));
+        const ownsConnection = db === undefined;
+        const connDB = db ?? (await this._ensureConnection<T>(settings, true));
+        try {
         return await connDB.put(doc);
+        } finally {
+            if (ownsConnection) {
+                await this.closeRemoteDatabase(connDB);
+            }
+        }
     }
 
     async fetchRemoteChunks(missingChunks: string[], showResult: boolean): Promise<false | EntryLeaf[]> {
@@ -1224,7 +1264,8 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             );
             return false;
         }
-        const remoteChunks = await ret.db.allDocs({ keys: missingChunks, include_docs: true });
+        return await this.withRemoteDatabase(ret.db, async (db) => {
+            const remoteChunks = await db.allDocs({ keys: missingChunks, include_docs: true });
         const errorRows = remoteChunks.rows.filter((e) => "error" in e);
         if (errorRows.length > 0) {
             Logger(
@@ -1233,14 +1274,17 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
                 "fetch"
             );
             Logger(`Requested chunks: ${missingChunks.join(",")}`, LOG_LEVEL_VERBOSE);
-            Logger(`Error chunks: ${errorRows.map((e) => (e as { key?: string }).key).join(",")}`, LOG_LEVEL_VERBOSE);
+                Logger(
+                    `Error chunks: ${errorRows.map((e) => (e as { key?: string }).key).join(",")}`,
+                    LOG_LEVEL_VERBOSE
+                );
         }
 
-        const remoteChunkItems = remoteChunks.rows
+            return remoteChunks.rows
             .filter((e) => !("error" in e))
             .map((e) => (e as { doc?: EntryLeaf }).doc)
             .filter((e): e is EntryLeaf => e !== undefined);
-        return remoteChunkItems;
+        });
     }
 
     async tryConnectRemote(setting: RemoteDBSettings, showResult: boolean = true): Promise<boolean> {
@@ -1256,8 +1300,10 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             );
             return false;
         }
+        return await this.withRemoteDatabase(db.db, async () => {
         Logger(`Connected to ${db.info.db_name} successfully`, LOG_LEVEL_NOTICE);
         return true;
+        });
     }
 
     async resetRemoteTweakSettings(setting: RemoteDBSettings): Promise<void> {
@@ -1270,21 +1316,23 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             return;
         }
 
-        if (!(await checkRemoteVersion(dbRet.db, this.migrate.bind(this), VER))) {
+        await this.withRemoteDatabase(dbRet.db, async (db) => {
+            if (!(await checkRemoteVersion(db, this.migrate.bind(this), VER))) {
             Logger(this.translate("liveSyncReplicator.remoteDbCorrupted"), LOG_LEVEL_NOTICE);
             return;
         }
         // check local database hash status and remote replicate hash status
         try {
-            const remoteMilestone = (await dbRet.db.get(MILESTONE_DOCID)) as EntryMilestoneInfo;
+                const remoteMilestone = (await db.get(MILESTONE_DOCID)) as EntryMilestoneInfo;
             remoteMilestone.tweak_values = {};
-            await dbRet.db.put(remoteMilestone);
+                await db.put(remoteMilestone);
             Logger(`tweak values on the remote database have been cleared`, LOG_LEVEL_VERBOSE);
         } catch (ex) {
             // While trying unlocking and not exist on the remote, it is not normal.
             Logger(`Could not retrieve remote milestone`, LOG_LEVEL_NOTICE);
             throw ex;
         }
+        });
     }
 
     async setPreferredRemoteTweakSettings(setting: RemoteDBSettings): Promise<void> {
@@ -1297,21 +1345,23 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             return;
         }
 
-        if (!(await checkRemoteVersion(dbRet.db, this.migrate.bind(this), VER))) {
+        await this.withRemoteDatabase(dbRet.db, async (db) => {
+            if (!(await checkRemoteVersion(db, this.migrate.bind(this), VER))) {
             Logger(this.translate("liveSyncReplicator.remoteDbCorrupted"), LOG_LEVEL_NOTICE);
             return;
         }
         // check local database hash status and remote replicate hash status
         try {
-            const remoteMilestone = (await dbRet.db.get(MILESTONE_DOCID)) as EntryMilestoneInfo;
+                const remoteMilestone = (await db.get(MILESTONE_DOCID)) as EntryMilestoneInfo;
             remoteMilestone.tweak_values[DEVICE_ID_PREFERRED] = extractObject(TweakValuesTemplate, { ...setting });
-            await dbRet.db.put(remoteMilestone);
+                await db.put(remoteMilestone);
             Logger(`Preferred tweak values has been registered`, LOG_LEVEL_VERBOSE);
         } catch (ex) {
             // While trying unlocking and not exist on the remote, it is not normal.
             Logger(`Could not retrieve remote milestone`, LOG_LEVEL_NOTICE);
             throw ex;
         }
+        });
     }
 
     async getRemotePreferredTweakValues(setting: RemoteDBSettings): Promise<RemotePreferredTweakResult> {
@@ -1336,8 +1386,9 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
                 error: new Error(dbRet),
             };
         }
+        return await this.withRemoteDatabase(dbRet.db, async (db) => {
         try {
-            if (!(await checkRemoteVersion(dbRet.db, this.migrate.bind(this), VER))) {
+                if (!(await checkRemoteVersion(db, this.migrate.bind(this), VER))) {
                 const error = new Error("The remote database version is not compatible");
                 Logger(this.translate("liveSyncReplicator.remoteDbCorrupted"), LOG_LEVEL_NOTICE);
                 return {
@@ -1355,7 +1406,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         }
 
         try {
-            const remoteMilestone = (await dbRet.db.get(MILESTONE_DOCID)) as EntryMilestoneInfo;
+                const remoteMilestone = (await db.get(MILESTONE_DOCID)) as EntryMilestoneInfo;
             if (!remoteMilestone) {
                 return {
                     status: RemotePreferredTweakStatuses.NOT_CONFIGURED,
@@ -1387,6 +1438,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
                 error: ex,
             };
         }
+        });
     }
 
     async compactRemote(setting: RemoteDBSettings): Promise<boolean> {
@@ -1399,8 +1451,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             return false;
         }
 
-        const ret = await dbRet.db.compact({ interval: 1000 });
-        return ret.ok;
+        return await this.withRemoteDatabase(dbRet.db, async (db) => (await db.compact({ interval: 1000 })).ok);
     }
 
     async getRemoteStatus(setting: RemoteDBSettings): Promise<RemoteDBStatus | false> {
@@ -1412,11 +1463,13 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             Logger(this.translate("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
             return false;
         }
-        const info = await dbRet.db.info();
+        return await this.withRemoteDatabase(dbRet.db, async (db) => {
+            const info = await db.info();
         return {
             ...info,
             estimatedSize: (info as { sizes?: { file?: number } })?.sizes?.file || 0,
         };
+        });
     }
 
     async countCompromisedChunks(setting: RemoteDBSettings = this.currentSettings): Promise<number | boolean> {
@@ -1428,8 +1481,7 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             Logger(this.translate("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
             return false;
         }
-        const compromised = await countCompromisedChunks(dbRet.db);
-        return compromised;
+        return await this.withRemoteDatabase(dbRet.db, countCompromisedChunks);
     }
 
     async getConnectedDeviceList(
@@ -1443,7 +1495,8 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
             Logger(this.translate("liveSyncReplicator.couldNotConnectToURI", { uri, dbRet }), LOG_LEVEL_NOTICE);
             return false;
         }
-        const milestoneDoc = await dbRet.db.get(MILESTONE_DOCID);
+        return await this.withRemoteDatabase(dbRet.db, async (db) => {
+            const milestoneDoc = await db.get(MILESTONE_DOCID);
         if (!milestoneDoc) {
             Logger("Could not retrieve remote milestone", LOG_LEVEL_NOTICE);
             return false;
@@ -1451,5 +1504,6 @@ export class LiveSyncCouchDBReplicator extends LiveSyncAbstractReplicator {
         const nodeInfo = (milestoneDoc as EntryMilestoneInfo).node_info;
         const acceptedNodes = (milestoneDoc as EntryMilestoneInfo).accepted_nodes || [];
         return { node_info: nodeInfo, accepted_nodes: acceptedNodes };
+        });
     }
 }

--- a/src/replication/couchdb/LiveSyncReplicator.unit.spec.ts
+++ b/src/replication/couchdb/LiveSyncReplicator.unit.spec.ts
@@ -58,7 +58,7 @@ describe("LiveSyncCouchDBReplicator remote preferred tweak values", () => {
         } as unknown as ConstructorParameters<typeof LiveSyncCouchDBReplicator>[0];
         const replicator = new LiveSyncCouchDBReplicator(env);
         vi.spyOn(replicator, "connectRemoteCouchDBWithSetting").mockResolvedValue({
-            db: { get },
+            db: { get, close: vi.fn().mockResolvedValue(undefined) },
             info: { db_name: "remote" },
         } as never);
         return replicator;
@@ -173,7 +173,13 @@ describe("LiveSyncCouchDBReplicator continuous catch-up", () => {
     });
 
     it("starts another finite catch-up when the live channel retries with smaller batches", async () => {
+        const events: string[] = [];
         const runFiniteReplicationActivity = vi.fn(async <T>(task: () => Promise<T>) => await task());
+        const remoteDatabase = {
+            close: vi.fn(async () => {
+                events.push("closed");
+            }),
+        };
         const localDatabase = {
             info: vi.fn().mockResolvedValue({ update_seq: 7 }),
             sync: vi.fn(() => ({})),
@@ -195,9 +201,12 @@ describe("LiveSyncCouchDBReplicator continuous catch-up", () => {
         const catchUp = vi
             .spyOn(replicator, "openOneShotReplication")
             .mockResolvedValueOnce(true)
-            .mockResolvedValueOnce(false);
+            .mockImplementationOnce(async () => {
+                events.push("restarted");
+                return false;
+            });
         vi.spyOn(replicator, "checkReplicationConnectivity").mockResolvedValue({
-            db: {},
+            db: remoteDatabase,
             info: { update_seq: 9 },
             syncOption: {},
         } as never);
@@ -218,6 +227,40 @@ describe("LiveSyncCouchDBReplicator continuous catch-up", () => {
             false,
             "pullOnly"
         );
+        expect(events).toEqual(["closed", "restarted"]);
+    });
+
+    it("closes the live remote database when continuous replication settles", async () => {
+        const remoteDatabase = { close: vi.fn().mockResolvedValue(undefined) };
+        const localDatabase = {
+            info: vi.fn().mockResolvedValue({ update_seq: 7 }),
+            sync: vi.fn(() => ({})),
+        };
+        const replicator = Object.create(LiveSyncCouchDBReplicator.prototype) as LiveSyncCouchDBReplicator;
+        replicator.env = {
+            services: {
+                context: createServiceContext(),
+                database: { localDatabase: { localDatabase } },
+                replicator: {
+                    runFiniteReplicationActivity: vi.fn(async <T>(task: () => Promise<T>) => await task()),
+                },
+            },
+        } as unknown as LiveSyncCouchDBReplicator["env"];
+        replicator.docArrived = 0;
+        replicator.docSent = 0;
+        replicator.updateInfo = vi.fn();
+        replicator.terminateSync = vi.fn();
+        vi.spyOn(replicator, "openOneShotReplication").mockResolvedValue(true);
+        vi.spyOn(replicator, "checkReplicationConnectivity").mockResolvedValue({
+            db: remoteDatabase,
+            info: { update_seq: 9 },
+            syncOption: {},
+        } as never);
+        vi.spyOn(replicator, "processSync").mockResolvedValue("DONE");
+
+        await expect(replicator.openContinuousReplication({} as RemoteDBSettings, false, false)).resolves.toBe(true);
+
+        expect(remoteDatabase.close).toHaveBeenCalledOnce();
     });
 });
 
@@ -396,6 +439,200 @@ describe("LiveSyncCouchDBReplicator one-shot connection ownership", () => {
     });
 });
 
+describe("LiveSyncCouchDBReplicator direct document connection ownership", () => {
+    it.each([
+        ["success", { _id: "sync-params" }, undefined],
+        ["not found", false, { status: 404 }],
+        ["failure", undefined, new Error("get failed")],
+    ] as const)("closes an internally created connection after %s", async (_case, expected, error) => {
+        const remoteDatabase = {
+            get: error ? vi.fn().mockRejectedValue(error) : vi.fn().mockResolvedValue(expected),
+            close: vi.fn().mockResolvedValue(undefined),
+        };
+        const replicator = Object.create(LiveSyncCouchDBReplicator.prototype) as LiveSyncCouchDBReplicator;
+        replicator.isMobile = vi.fn().mockReturnValue(false);
+        vi.spyOn(replicator, "connectRemoteCouchDBWithSetting").mockResolvedValue({ db: remoteDatabase } as never);
+
+        const result = replicator.fetchRemoteDocument({} as RemoteDBSettings, "sync-params");
+        if (error && "status" in error && error.status === 404) {
+            await expect(result).resolves.toBe(false);
+        } else if (error) {
+            await expect(result).rejects.toBe(error);
+        } else {
+            await expect(result).resolves.toBe(expected);
+        }
+
+        expect(remoteDatabase.close).toHaveBeenCalledOnce();
+    });
+
+    it("leaves a caller-provided connection open", async () => {
+        const remoteDatabase = {
+            get: vi.fn().mockResolvedValue({ _id: "sync-params" }),
+            close: vi.fn().mockResolvedValue(undefined),
+        };
+        const replicator = Object.create(LiveSyncCouchDBReplicator.prototype) as LiveSyncCouchDBReplicator;
+
+        await replicator.fetchRemoteDocument({} as RemoteDBSettings, "sync-params", remoteDatabase as never);
+
+        expect(remoteDatabase.close).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ["success", undefined],
+        ["failure", new Error("put failed")],
+    ] as const)("closes an internally created connection after put %s", async (_case, error) => {
+        const response = { ok: true, id: "sync-params", rev: "1-test" };
+        const remoteDatabase = {
+            put: error ? vi.fn().mockRejectedValue(error) : vi.fn().mockResolvedValue(response),
+            close: vi.fn().mockResolvedValue(undefined),
+        };
+        const replicator = Object.create(LiveSyncCouchDBReplicator.prototype) as LiveSyncCouchDBReplicator;
+        replicator.isMobile = vi.fn().mockReturnValue(false);
+        vi.spyOn(replicator, "connectRemoteCouchDBWithSetting").mockResolvedValue({ db: remoteDatabase } as never);
+
+        const result = replicator.putRemoteDocument({} as RemoteDBSettings, { _id: "sync-params" } as never);
+        if (error) {
+            await expect(result).rejects.toBe(error);
+        } else {
+            await expect(result).resolves.toBe(response);
+        }
+
+        expect(remoteDatabase.close).toHaveBeenCalledOnce();
+    });
+
+    it("leaves a caller-provided connection open after put", async () => {
+        const remoteDatabase = {
+            put: vi.fn().mockResolvedValue({ ok: true, id: "sync-params", rev: "1-test" }),
+            close: vi.fn().mockResolvedValue(undefined),
+        };
+        const replicator = Object.create(LiveSyncCouchDBReplicator.prototype) as LiveSyncCouchDBReplicator;
+
+        await replicator.putRemoteDocument(
+            {} as RemoteDBSettings,
+            { _id: "sync-params" } as never,
+            remoteDatabase as never
+        );
+
+        expect(remoteDatabase.close).not.toHaveBeenCalled();
+    });
+});
+
+describe("LiveSyncCouchDBReplicator finite maintenance connection ownership", () => {
+    const setting = {
+        couchDB_URI: "https://example.invalid",
+        couchDB_DBNAME: "remote",
+    } as RemoteDBSettings;
+
+    function createReplicator(remoteDatabase: Record<string, unknown>) {
+        const replicator = Object.create(LiveSyncCouchDBReplicator.prototype) as LiveSyncCouchDBReplicator;
+        replicator.env = {
+            services: {
+                API: { isMobile: () => false },
+                context: createServiceContext(),
+                setting: { currentSettings: () => setting },
+            },
+        } as unknown as LiveSyncCouchDBReplicator["env"];
+        replicator.nodeid = "node";
+        vi.spyOn(replicator, "connectRemoteCouchDBWithSetting").mockResolvedValue({
+            db: remoteDatabase,
+            info: { db_name: "remote" },
+        } as never);
+        return replicator;
+    }
+
+    it.each([
+        ["compactRemote", (replicator: LiveSyncCouchDBReplicator) => replicator.compactRemote(setting)],
+        ["getRemoteStatus", (replicator: LiveSyncCouchDBReplicator) => replicator.getRemoteStatus(setting)],
+        [
+            "getConnectedDeviceList",
+            (replicator: LiveSyncCouchDBReplicator) => replicator.getConnectedDeviceList(setting),
+        ],
+    ] as const)("closes the connection after %s", async (_method, run) => {
+        const remoteDatabase = {
+            compact: vi.fn().mockResolvedValue({ ok: true }),
+            info: vi.fn().mockResolvedValue({ db_name: "remote" }),
+            get: vi.fn().mockResolvedValue({ node_info: {}, accepted_nodes: [] }),
+            close: vi.fn().mockResolvedValue(undefined),
+        };
+        const replicator = createReplicator(remoteDatabase);
+
+        await run(replicator);
+
+        expect(remoteDatabase.close).toHaveBeenCalledOnce();
+    });
+
+    it("closes the connection after reading preferred tweak values", async () => {
+        const remoteDatabase = {
+            get: vi.fn(async (id: string) =>
+                id === VERSIONING_DOCID
+                    ? { _id: VERSIONING_DOCID, type: "versioninfo", version: VER }
+                    : { _id: MILESTONE_DOCID, tweak_values: {} }
+            ),
+            close: vi.fn().mockResolvedValue(undefined),
+        };
+        const replicator = createReplicator(remoteDatabase);
+
+        await replicator.getRemotePreferredTweakValues(setting);
+
+        expect(remoteDatabase.close).toHaveBeenCalledOnce();
+    });
+
+    it("logs a close failure without replacing a finite operation result", async () => {
+        const closeError = new Error("close failed");
+        const remoteDatabase = {
+            compact: vi.fn().mockResolvedValue({ ok: true }),
+            close: vi.fn().mockRejectedValue(closeError),
+        };
+        const replicator = createReplicator(remoteDatabase);
+        const logger = vi.fn();
+        setGlobalLogFunction(logger);
+
+        try {
+            await expect(replicator.compactRemote(setting)).resolves.toBe(true);
+            expect(logger).toHaveBeenCalledWith("Failed to close remote database.", expect.anything(), "sync");
+            expect(logger).toHaveBeenCalledWith(closeError, expect.anything(), "sync");
+        } finally {
+            setGlobalLogFunction(defaultLogger);
+        }
+    });
+});
+
+describe("LiveSyncCouchDBReplicator chunk sending connection ownership", () => {
+    it("closes only the connection it creates when sending fails", async () => {
+        const remoteDatabase = {
+            get: vi.fn().mockRejectedValue(new Error("milestone failed")),
+            close: vi.fn().mockResolvedValue(undefined),
+        };
+        const replicator = Object.create(LiveSyncCouchDBReplicator.prototype) as LiveSyncCouchDBReplicator;
+        replicator.env = {
+            services: {
+                API: { isMobile: () => false },
+                context: createServiceContext(),
+                keyValueDB: {
+                    openSimpleStore: () => ({
+                        delete: vi.fn(),
+                        get: vi.fn(),
+                        keys: vi.fn().mockResolvedValue([]),
+                        set: vi.fn(),
+                    }),
+                },
+            },
+        } as unknown as LiveSyncCouchDBReplicator["env"];
+        vi.spyOn(replicator, "connectRemoteCouchDBWithSetting").mockResolvedValue({ db: remoteDatabase } as never);
+
+        await expect(replicator.sendChunks({} as RemoteDBSettings, undefined, false)).rejects.toThrow(
+            "milestone failed"
+        );
+        expect(remoteDatabase.close).toHaveBeenCalledOnce();
+
+        await expect(replicator.sendChunks({} as RemoteDBSettings, remoteDatabase as never, false)).rejects.toThrow(
+            "milestone failed"
+        );
+
+        expect(remoteDatabase.close).toHaveBeenCalledOnce();
+    });
+});
+
 describe("LiveSyncCouchDBReplicator remote chunk fetching", () => {
     it("preserves available chunks when another row in the same batch is missing", async () => {
         const availableChunk = {
@@ -436,5 +673,26 @@ describe("LiveSyncCouchDBReplicator remote chunk fetching", () => {
             keys: [availableChunk._id, "h:missing"],
             include_docs: true,
         });
+    });
+
+    it("closes its remote database when chunk fetching succeeds or fails", async () => {
+        const remoteDatabase = {
+            allDocs: vi.fn().mockResolvedValueOnce({ rows: [] }).mockRejectedValueOnce(new Error("chunk fetch failed")),
+            close: vi.fn().mockResolvedValue(undefined),
+        };
+        const replicator = Object.create(LiveSyncCouchDBReplicator.prototype) as LiveSyncCouchDBReplicator;
+        replicator.env = {
+            services: {
+                API: { isMobile: () => false },
+                context: createServiceContext(),
+                setting: { currentSettings: () => ({}) },
+            },
+        } as unknown as LiveSyncCouchDBReplicator["env"];
+        vi.spyOn(replicator, "connectRemoteCouchDBWithSetting").mockResolvedValue({ db: remoteDatabase } as never);
+
+        await expect(replicator.fetchRemoteChunks([], false)).resolves.toEqual([]);
+        await expect(replicator.fetchRemoteChunks([], false)).rejects.toThrow("chunk fetch failed");
+
+        expect(remoteDatabase.close).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/services/base/RemoteService.ts
+++ b/src/services/base/RemoteService.ts
@@ -294,6 +294,12 @@ export abstract class RemoteService<T extends ServiceContext = ServiceContext>
             const exMsg = ex instanceof Error ? ex : LiveSyncError.fromError(ex);
             const msg = `${exMsg.name}:${exMsg.message}`;
             this._log(ex, LOG_LEVEL_VERBOSE);
+            try {
+                await db.close();
+            } catch (closeError) {
+                this._log("Failed to close remote database after connection failure.", LOG_LEVEL_INFO);
+                this._log(closeError, LOG_LEVEL_VERBOSE);
+            }
             return msg;
         }
     }

--- a/src/services/base/RemoteService.unit.spec.ts
+++ b/src/services/base/RemoteService.unit.spec.ts
@@ -9,7 +9,10 @@ import { PouchDB } from "@lib/pouchdb/pouchdb-http";
 
 class TestRemoteService extends RemoteService {}
 
-function createService(fetchImplementation: (req: string | Request, opts?: RequestInit) => Promise<Response>) {
+function createService(
+    fetchImplementation: (req: string | Request, opts?: RequestInit) => Promise<Response>,
+    pouchDB: PouchDB.Static = PouchDB
+) {
     const requestCount = reactiveSource(0);
     const responseCount = reactiveSource(0);
     const nativeFetch = vi.fn(fetchImplementation);
@@ -29,7 +32,7 @@ function createService(fetchImplementation: (req: string | Request, opts?: Reque
         currentSettings: vi.fn(() => ({ E2EEAlgorithm: "v2" })),
     } as unknown as SettingService;
     const service = new TestRemoteService(new ServiceContext(), {
-        pouchDB: PouchDB,
+        pouchDB,
         APIService,
         appLifecycle,
         setting,
@@ -57,26 +60,48 @@ function createDatabaseInfoResponse() {
     });
 }
 
-async function connect(service: TestRemoteService) {
-    const connection = await service.connect(
+async function rawConnect(service: TestRemoteService, skipInfo = true) {
+    return await service.connect(
         "https://example.com/db",
         { username: "user", password: "password", type: "basic" },
         false,
         false,
         false,
         false,
-        true,
+        skipInfo,
         false,
         {},
         false,
         () => Promise.resolve(new Uint8Array())
     );
+}
+
+async function connect(service: TestRemoteService, skipInfo = true) {
+    const connection = await rawConnect(service, skipInfo);
     expect(typeof connection).not.toBe("string");
     if (typeof connection === "string") throw new Error(connection);
     return connection;
 }
 
 describe("RemoteService request activity", () => {
+    it.each([
+        ["closes successfully", undefined],
+        ["fails to close", new Error("close failed")],
+    ] as const)("preserves the initial info failure when cleanup %s", async (_case, closeError) => {
+        const database = {
+            info: vi.fn().mockRejectedValue(new Error("info failed")),
+            close: closeError ? vi.fn().mockRejectedValue(closeError) : vi.fn().mockResolvedValue(undefined),
+            transform: vi.fn(),
+        };
+        const FakePouchDB = vi.fn(function () {
+            return database;
+        });
+        const { service } = createService(() => Promise.reject(new Error("unused")), FakePouchDB as never);
+
+        await expect(rawConnect(service, false)).resolves.toBe("Error:info failed");
+        expect(database.close).toHaveBeenCalledOnce();
+    });
+
     it("balances the counters after a CouchDB adapter request settles", async () => {
         const { requestCount, responseCount, service } = createService(() =>
             Promise.resolve(createDatabaseInfoResponse())


### PR DESCRIPTION
## Summary
- close caller-owned remote PouchDB handles after finite replication, Security Seed refreshes, maintenance operations, and status queries
- close continuous replication handles before retry or resurrection
- close handles created by `RemoteService.connect()` when `info()` fails without replacing the original result

## Verification
- Commonlib: 1,300 unit tests, 7 boundary tests, 20 release tests, package build, and 6 managed integration tests
- Self-hosted LiveSync 1.0.13: 638 unit tests, `npm run check`, and `npm run build`
