### PR TITLE
Prepare Commonlib 0.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.1.13
+
+### Fixed
+
+- Generated packages now declare root and subpath TypeScript mappings derived from the same public export inventory. TypeScript's `Node10` module resolution therefore finds the intended declarations instead of treating valid Commonlib imports as unresolved `error` types in downstream tooling.
+- `octagonal-wheels` 0.1.53 is now the minimum dependency, bringing equivalent declaration mappings to its public entries.
+
 ## 0.1.12
 
 ### Fixed


### PR DESCRIPTION
This release preparation updates Commonlib to 0.1.13 so TypeScript's Node10 module resolution can resolve declarations for the package root and every supported subpath.

## Changes

- Bump `package.json` and `package-lock.json` from 0.1.12 to 0.1.13.
- Record the root `types` entry and generated `typesVersions` mappings introduced in PR #111. Both are derived from the existing public export inventory, so the `exports` map remains authoritative.
- Require `octagonal-wheels` 0.1.53, whose generated package provides the corresponding root and subpath declaration mappings.

## Impact

TypeScript's `Node10` module resolution does not use declaration conditions from a package's `exports` map. The generated manifest now mirrors that map through a top-level `types` entry and `typesVersions`, preventing supported Commonlib imports from degrading to unresolved `error` types in downstream analysis.

This release does not introduce a public entry or change synchronisation, storage, or protocol behaviour.

## Verification

- `npm ci` with npm 11.18.0 succeeded.
- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package` succeeded: 71 test files and 1,283 tests passed, together with seven boundary tests, 20 release-selection tests, type checks, package-boundary checks, 109 generated compatibility exports, and clean-consumer checks.
- The exact generated release package resolved its root declaration and all 115 public subpaths with TypeScript's `Node10` module resolution.
- `npm publish --dry-run .package --tag next --access public` succeeded: 500 files, 405,588 bytes packed, and 1,751,037 bytes unpacked.
- Dry-run integrity: `sha512-uqFiccRbTQTY8M7RzI68SMjfms65w0MsgrqIKwoTLJkrqnXPdxoJHR4eV6Q4vq7OLWvBMjQOeGy+3mLXfXSrFA==`.
- The exact implementation package from PR #111 passed the Self-hosted LiveSync type check, 638 unit tests, plug-in, CLI, WebApp, and WebPeer builds, and CLI end-to-end test at downstream commit `39732904858ed1889a5a8bde6a6c6f27b2fdcb02`. The official Obsidian Community ESLint configuration no longer reported the targeted `error`-typed union or intersection findings.
- Package CI run `31712668655` repeated package verification and managed integration against release head `1ae3855cbd99a882470ed6cf50c11e72bbeb1087`; Package verification, Integration tests, and Complete package gate all succeeded.
- Downstream CI run `31713088266` packed that exact release head, installed `@vrtmrz/livesync-commonlib@0.1.13` into Self-hosted LiveSync commit `39732904858ed1889a5a8bde6a6c6f27b2fdcb02`, and passed the downstream type and unit checks, plug-in, CLI, WebApp, and WebPeer builds, and CLI end-to-end test.
- Production audit reports 18 existing moderate advisories. The full development audit reports 19 moderate advisories and one high advisory; the high advisory is confined to the Vitest development dependency chain.
