### PR TITLE
Prepare Commonlib 0.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.14
+
+### Fixed
+
+- Commonlib now closes the temporary CouchDB connections it creates for finite remote operations, including one-shot replication, Security Seed refreshes, chunk transfer, maintenance operations, and status queries. Continuous replication closes its previous connection before a retry or restart, while caller-provided connections remain under caller ownership. Connection set-up failures also close the partially initialised handle without masking the original connection error (PR #112). Thank you to @apple-ouyang for the contribution!
+
 ## 0.1.13
 
 ### Fixed


### PR DESCRIPTION
This release preparation updates Commonlib to 0.1.14 so finite CouchDB operations release their temporary connections promptly instead of retaining obsolete remote handles.

## Changes

- Bump `package.json` and `package-lock.json` from 0.1.13 to 0.1.14.
- Include the connection-ownership fix merged in PR #112 for finite replication, Security Seed refreshes, chunk transfer, maintenance operations, status queries, continuous replication retries, and connection set-up failures.
- Include the formatting and repeated one-shot Security Seed regression coverage from PR #114.
- Record the release and thank @apple-ouyang for the contribution.

## Impact

Commonlib closes only the temporary remote database connections it creates. Caller-provided connections remain under caller ownership, and continuous replication retains its active connection until that controller settles.

This release does not change public entry points, settings, stored data, or synchronisation protocols.

## Verification

- `npm ci` succeeded.
- TypeScript type checking succeeded.
- 71 unit-test files and 1,301 tests passed with one worker.
- Seven package-boundary tests and the release-selection test suite passed.
- The package boundary remains at the zero-import migration baseline.
- The generated `@vrtmrz/livesync-commonlib@0.1.14` package passed its packed-package checks with 109 explicit compatibility exports.
- Generated package integrity: `sha512-TpEr/OjSwHBnjS5TaYtCLwjKyOEXQzmgCp/1MsgWML+IYOJAzn2z77WMBD4eBwIr5E9zG4iUCdDEr4f9SUmGTw==`.
- Package CI run `31788490926` repeated package verification and managed integration against release head `5327268f7a1451a58b8a891d276ede3b7bcb96fc`; Package verification, Integration tests, and Complete package gate all succeeded.
- Production audit reports 18 existing moderate advisories and no high or critical advisories. The dependency graph is unchanged from 0.1.13.
