### PR TITLE
Avoid redundant path obfuscation hash stretching

### DIFF
--- a/src/string_and_binary/path.ts
+++ b/src/string_and_binary/path.ts
@@ -82,12 +82,8 @@ export function expandDocumentIDPrefix(id: DocumentID): [string, FilePathWithPre
 const _hashString = memorizeFuncWithLRUCache(async (key: string) => {
     const buff = writeString(key);
     const webcrypto = await getWebCrypto();
-    let digest = await webcrypto.subtle.digest("SHA-256", buff);
-    const len = key.length;
-    for (let i = 0; i < len; i++) {
-        // Stretching
-        digest = await webcrypto.subtle.digest("SHA-256", buff);
-    }
+    // Derive the obfuscated document ID from this input.
+    const digest = await webcrypto.subtle.digest("SHA-256", buff);
     return uint8ArrayToHexString(new Uint8Array(digest));
 });
 

--- a/src/string_and_binary/path.unit.spec.ts
+++ b/src/string_and_binary/path.unit.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const minimatchStats = vi.hoisted(() => ({ constructions: 0 }));
+const webCryptoStats = vi.hoisted(() => ({ digests: 0 }));
 
 vi.mock("minimatch", async (importOriginal) => {
     const actual = await importOriginal<typeof import("minimatch")>();
@@ -15,6 +16,24 @@ vi.mock("minimatch", async (importOriginal) => {
     return {
         ...actual,
         Minimatch: CountingMinimatch,
+    };
+});
+
+vi.mock("@lib/mods.ts", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@lib/mods.ts")>();
+    const webcrypto = await actual.getWebCrypto();
+    const countedWebCrypto = {
+        subtle: {
+            digest: (algorithm: AlgorithmIdentifier, data: BufferSource) => {
+                webCryptoStats.digests++;
+                return webcrypto.subtle.digest(algorithm, data);
+            },
+        },
+    } as Crypto;
+
+    return {
+        ...actual,
+        getWebCrypto: async () => countedWebCrypto,
     };
 });
 
@@ -34,6 +53,28 @@ describe("path2id_base path case", () => {
         const lowerCasePath = await path2id_base("calculus.md" as FilePath, false, false);
 
         expect(upperCasePath).not.toBe(lowerCasePath);
+    });
+});
+
+describe("path2id_base path obfuscation", () => {
+    it("performs one digest for each uncached hash input", async () => {
+        webCryptoStats.digests = 0;
+        const passphrase = "digest-count-regression-secret";
+
+        await path2id_base("First.md" as FilePath, passphrase, false);
+        expect(webCryptoStats.digests).toBe(2);
+
+        await path2id_base("Second.md" as FilePath, passphrase, false);
+        expect(webCryptoStats.digests).toBe(3);
+    });
+
+    it.each([
+        ["資料/概要.md", true, "f:d17ef57666777963bdb6875c83e16b39fee9ca7f7c3593f1b50af691c7bc2fa8"],
+        ["_private/Calculus.md", false, "f:2a18fa03d734284a8ace4d3c0a7b65558209b8f092ae36be1fdfc3626bc99268"],
+    ])("keeps the established document ID for %s", async (path, caseInsensitive, expected) => {
+        await expect(
+            path2id_base(path as FilePath, "path-obfuscation-regression-secret", caseInsensitive)
+        ).resolves.toBe(expected);
     });
 });
 


### PR DESCRIPTION
Remove ineffective path-obfuscation hash stretching so full Metadata identity scans retain the same document IDs without delaying plug-in start-up.

## Summary

- Replace repeated SHA-256 calls over the same unchanged input with one digest.
- Preserve the existing two-stage passphrase and path derivation, prefixes, case handling, and cache behaviour.
- Add focused coverage for digest count and established document-ID vectors.

## Rationale

Metadata identity validation now derives the expected document ID for every normal-file Metadata entry before Offline Scanner mutation. This exposed a legacy loop in path obfuscation which repeated SHA-256 according to the input length.

Every iteration hashed the original buffer again rather than chaining the previous digest. It therefore produced the same document ID as one digest while adding substantial work. On the local benchmark used for this change, collecting 4,000 consistent Metadata entries with path obfuscation fell from about 13.8 seconds to about 0.29 seconds. Absolute timing is host-dependent.

The path-obfuscation output and stored document IDs remain unchanged.

## Verification

- Confirmed the regression test failed before the implementation change: the first uncached path required 105 digest calls instead of 2.
- Focused path tests: 7 passed.
- Commonlib unit suite: 71 files and 1,304 tests passed with one worker.
- Commonlib type, package-boundary, release-selection, packed-package, and clean-consumer checks passed.
- The exact packed Commonlib artefact passed Self-hosted LiveSync type checks, application checks, Community Review lint, 91 unit-test files and 639 tests, production build, and iOS 15 compatibility inspection.
