### PR TITLE
Prepare Commonlib 0.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.15
+
+### Fixed
+
+- Start-up offline scans are now faster when Path Obfuscation is enabled.
+
 ## 0.1.14
 
 ### Fixed


### PR DESCRIPTION
This release preparation updates Commonlib to 0.1.15 so start-up offline scans avoid redundant path-obfuscation hashing and complete faster.

## Changes

- Bump `package.json` and `package-lock.json` from 0.1.14 to 0.1.15.
- Include the path-obfuscation performance fix merged in PR #116.
- Record the faster start-up offline scan in `updates.md`.

## Impact

Start-up offline scans complete faster when Path Obfuscation is enabled, particularly in large vaults. The redundant work repeatedly hashed the same unchanged input, so removing it does not change generated document IDs.

This release does not change public entry points, settings, stored data, or synchronisation protocols.

## Verification

- `npm ci` succeeded.
- TypeScript type checking succeeded.
- 71 unit-test files and 1,304 tests passed with one worker.
- Seven package-boundary tests and the release-selection test suite passed.
- The package boundary remains at the zero-import migration baseline.
- The generated `@vrtmrz/livesync-commonlib@0.1.15` package passed its packed-package checks with 109 explicit compatibility exports.
- Generated package integrity: `sha512-46dR7FYOLrpbwPfRS6gLHKzEoTYCqM2bi1vHYYkUR0SUQpKRdFaURIXRkwPxg4AOwqxjmQeRWS5QwCtd0/u7+Q==`.
- The packed implementation change passed Self-hosted LiveSync type and application checks, Community Review lint, 91 unit-test files and 639 tests, the production build, and iOS 15 compatibility inspection.
- Production audit reports 18 existing moderate advisories and no high or critical advisories. The dependency graph is unchanged from 0.1.14.
