### PR TITLE
Prepare Commonlib 0.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+## 0.1.16
+
 ### Improved
 
-- One-shot CouchDB connectivity checks now use a flat, owned connection whose `close()` cancels its abort-capable requests before closing PouchDB. If the complete preflight remains unsettled for 60 seconds on the web-compatible fetch path, an internal safety fuse ends the attempt, releases its shared operation, and closes the temporary connection before a later trigger can try again. This is not a limit on replication duration. The explicitly selected native Request API retains its existing behaviour because that adapter cannot currently honour transport cancellation.
+- CouchDB connection handling is now more robust through the flat `OwnedCouchDBConnection` contract. Its idempotent `close()` cancels abort-capable requests before closing PouchDB. If the complete one-shot preflight remains unsettled for 60 seconds on the web-compatible fetch path, an internal safety fuse ends the attempt, releases its shared operation, and closes the temporary connection before a later trigger can try again. This is not a limit on replication duration. The explicitly selected native Request API retains its existing behaviour because that adapter cannot currently honour transport cancellation.
 
 ## 0.1.15
 


### PR DESCRIPTION
This release preparation updates Commonlib to 0.1.16 so remote CouchDB connections have explicit ownership and abort-capable one-shot preflights can release stalled shared attempts deterministically.

## Changes

- Bump `package.json` and `package-lock.json` from 0.1.15 to 0.1.16.
- Include the flat `OwnedCouchDBConnection` lifecycle merged in PR #118.
- Give the web-compatible one-shot connectivity preflight a last-resort 60-second safety fuse.
- Record the connection-lifecycle improvement in `updates.md`.

## Impact

Maintained consumers receive an additive, flat connection result with an idempotent `close()` operation. Closing an owned connection cancels its abort-capable requests before closing PouchDB. If a complete one-shot connectivity preflight remains unsettled on the web-compatible fetch path, the safety fuse closes its temporary connection and releases the shared attempt so a later trigger can try again.

The deadline is not a limit on replication duration. The explicitly selected native Request API retains its existing behaviour because that adapter cannot currently honour transport cancellation.

This release improves connection-lifecycle robustness, but does not claim to identify the exact environmental cause reported in Self-hosted LiveSync issue #1116. It does not change CouchDB documents, replication checkpoints, encryption, settings, or synchronisation protocols.

## Verification

- `npm ci` succeeded.
- TypeScript type checking succeeded.
- 71 unit-test files and 1,314 tests passed with one worker.
- Seven package-boundary tests and 20 release-selection tests passed.
- The package boundary remains at the zero-import migration baseline.
- The generated `@vrtmrz/livesync-commonlib@0.1.16` package passed its packed-package and clean-consumer checks with 109 explicit compatibility exports.
- The npm dry run selected public access on the `next` dist-tag and reported 502 files.
- Generated package integrity: `sha512-X2vdn/kOHeHftstn7M1KlJkkzBbeAgWwRN9IwKGopHlqaxIb5NX/A257gLlZr0lulOLqeN+a2zZKJ8hSHAlvpQ==`.
- Production audit reports 18 existing moderate advisories and no high or critical advisories. The dependency graph is unchanged from 0.1.15.

Validation of the exact registry artefact in Self-hosted LiveSync and a real Obsidian instance remains a later release gate after this stable release commit is merged and staged on `next`. The `latest` dist-tag will remain unchanged until that validation passes.
