### PR TITLE
Prepare Commonlib 0.1.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.17
+
+### Added
+
+- `storeWithLiveBaseRevision()` conditionally stores content below an exact current revision-tree leaf using PouchDB's ordinary revision check. Maintained hosts can therefore create a successor without force-writing below a stale base, while the existing `storeWithBaseRevision()` operation retains its deliberate force-write behaviour.
+
 ## 0.1.16
 
 ### Improved


### PR DESCRIPTION
This release prepares `@vrtmrz/livesync-commonlib` 0.1.17 so maintained hosts can conditionally advance a live revision without force-writing beneath an obsolete base.

## Summary

- Set the package and lockfile version to 0.1.17.
- Record `storeWithLiveBaseRevision()` in `updates.md`.
- Preserve `storeWithBaseRevision()` for callers which deliberately require force-write behaviour.
- Keep publication configured for public access on the `next` dist-tag; this pull request does not publish the package.

## Package identity

- Package: `@vrtmrz/livesync-commonlib@0.1.17`
- Reviewed release branch: `release/0.1.17`
- Reviewed release commit: `3d1e232d873ab9c8563dc85f433bf582952500ac`
- Trusted staging source: `main@8b075e89b1c3bb46e10ad2a420fd9f5fe56320ca`
- Staging workflow run: `32216341756`
- Registry: `https://registry.npmjs.org`
- Intended first dist-tag: `next`
- Packed size: 410,816 bytes
- Unpacked size: 1,770,479 bytes
- SHA-256: `62d16427321ed7b242f0d5a615b03ae215ca926be6c75601d76dd47ef74edca9`
- SHA-1: `2cf6ff4220f6841d23392941dbf39b0ef0c30d8d`
- Integrity: `sha512-5EGZOKOfoe8jUKwr7Yecyxi6SuHYtMPpWVygKTtkuC8Nf9ZayvYqd6R3VpPqtRoD/nD1KqxrbwJzUbS+qAJgHw==`

## Verification

- Clean installation with Node.js 24.18.0 and npm 11.18.0.
- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package`:
  - type checks passed;
  - 71 test files and 1,318 tests passed;
  - package boundary tests passed;
  - release-selection tests passed; and
  - the packed-package consumer build and checks passed.
- `npm publish --dry-run .package --tag next --access public --json` passed.
- The exact local package passed downstream LiveSync unit tests, type and lint checks, the production build, the existing Document History navigation E2E test, and the real-Obsidian restoration E2E test.
- The trusted workflow reproduced the same 502-file payload byte for byte. Its archive uses ordinary `0644` entry modes, while the local dry-run archive used `0600`; the workflow artefact above is the exact candidate which will be staged.

## Audit

The dependency graph is unchanged from 0.1.16. The production audit reports 18 moderate findings in the existing PouchDB and UUID dependency chain, with no high or critical findings. The full audit additionally reports one high-severity development-only path through Vitest, Vite, PostCSS, and NanoID. This release does not include automatic audit fixes or unrelated dependency changes.

## Remaining release work

- [x] Prepare and validate the exact package locally.
- [x] Validate the exact package in the downstream LiveSync consumer.
- [x] Complete GitHub CI and review.
- [x] Merge the exact release commit into `main`.
- [x] Stage the exact `main` commit to `next` through the trusted workflow.
- [ ] Validate the registry artefact in LiveSync.
- [ ] Promote the exact version to `latest` as a separate operation.
