### PR TITLE
Add configurable P2P transport compatibility

### DIFF
--- a/src/API/processSetting.unit.spec.ts
+++ b/src/API/processSetting.unit.spec.ts
@@ -17,6 +17,19 @@ describe("QR Codec Round-Trip Test with Real Data", () => {
         expect(decoded.allowSleepDuringSynchronisationOnDesktop).toBe(false);
     });
 
+    it("preserves P2P transport compatibility settings in Setup URI data", () => {
+        const encoded = encodeSettingsToQRCodeData({
+            ...DEFAULT_SETTINGS,
+            P2P_maxWirePayloadBytes: 1024,
+            P2P_connectionPath: "relay",
+        });
+
+        const decoded = decodeSettingsFromQRCodeData(encoded);
+
+        expect(decoded.P2P_maxWirePayloadBytes).toBe(1024);
+        expect(decoded.P2P_connectionPath).toBe("relay");
+    });
+
     it("should preserve remoteConfigurations through encode/decode cycle", () => {
         // Dummy test data with remoteConfigurations
         // Note: In production, this would load from actual user settings containing multiple remoteConfigurations

--- a/src/common/ConnectionString.ts
+++ b/src/common/ConnectionString.ts
@@ -1,5 +1,6 @@
 import type { JWTAlgorithm } from "@lib/common/models/auth.type";
 import type { CouchDBConnection, BucketSyncSetting, P2PConnectionInfo } from "./models/setting.type";
+import { normaliseP2PConnectionPath, normaliseP2PMaxWirePayloadBytes } from "./models/setting.p2p";
 
 export type RemoteConfigurationResult =
     | { type: "couchdb"; settings: CouchDBConnection }
@@ -187,6 +188,8 @@ export class ConnectionStringParser {
             P2P_turnServers: searchParams.get("turnServers") || "",
             P2P_turnUsername: searchParams.get("turnUser") || "",
             P2P_turnCredential: searchParams.get("turnPass") || "",
+            P2P_maxWirePayloadBytes: normaliseP2PMaxWirePayloadBytes(Number(searchParams.get("maxWirePayloadBytes"))),
+            P2P_connectionPath: normaliseP2PConnectionPath(searchParams.get("connectionPath")),
         };
     }
 
@@ -200,6 +203,11 @@ export class ConnectionStringParser {
         if (settings.P2P_turnServers) searchParams.set("turnServers", settings.P2P_turnServers);
         if (settings.P2P_turnUsername) searchParams.set("turnUser", settings.P2P_turnUsername);
         if (settings.P2P_turnCredential) searchParams.set("turnPass", settings.P2P_turnCredential);
+        searchParams.set(
+            "maxWirePayloadBytes",
+            String(normaliseP2PMaxWirePayloadBytes(settings.P2P_maxWirePayloadBytes))
+        );
+        searchParams.set("connectionPath", normaliseP2PConnectionPath(settings.P2P_connectionPath));
 
         const credentials = settings.P2P_passphrase ? `:${encodeURIComponent(settings.P2P_passphrase)}@` : "";
         const host = encodeURIComponent(settings.P2P_roomID);

--- a/src/common/ConnectionString.unit.spec.ts
+++ b/src/common/ConnectionString.unit.spec.ts
@@ -125,6 +125,8 @@ describe("ConnectionStringParser P2P", () => {
                 P2P_turnServers: "turn:turn.example:3478",
                 P2P_turnUsername: "turn-user",
                 P2P_turnCredential: "turn-pass",
+                P2P_maxWirePayloadBytes: 800,
+                P2P_connectionPath: "relay",
             },
         });
 
@@ -137,6 +139,8 @@ describe("ConnectionStringParser P2P", () => {
         expect(uri).toContain("turnServers=");
         expect(uri).toContain("turnUser=turn-user");
         expect(uri).toContain("turnPass=turn-pass");
+        expect(uri).toContain("maxWirePayloadBytes=800");
+        expect(uri).toContain("connectionPath=relay");
 
         const parsed = ConnectionStringParser.parse(uri);
         if (parsed.type !== "p2p") {
@@ -153,6 +157,8 @@ describe("ConnectionStringParser P2P", () => {
         expect(parsed.settings.P2P_turnServers).toBe("turn:turn.example:3478");
         expect(parsed.settings.P2P_turnUsername).toBe("turn-user");
         expect(parsed.settings.P2P_turnCredential).toBe("turn-pass");
+        expect(parsed.settings.P2P_maxWirePayloadBytes).toBe(800);
+        expect(parsed.settings.P2P_connectionPath).toBe("relay");
     });
 
     it("should handle edge case characters in room ID and passphrase", () => {
@@ -204,7 +210,9 @@ describe("ConnectionStringParser P2P", () => {
             settings,
         });
 
-        expect(uri).toBe("sls+p2p://room-simple?relays=wss%3A%2F%2Frelay.example&appId=self-hosted-livesync");
+        expect(uri).toBe(
+            "sls+p2p://room-simple?relays=wss%3A%2F%2Frelay.example&appId=self-hosted-livesync&maxWirePayloadBytes=15360&connectionPath=automatic"
+        );
 
         const parsed = ConnectionStringParser.parse(uri);
         if (parsed.type !== "p2p") {
@@ -213,6 +221,30 @@ describe("ConnectionStringParser P2P", () => {
 
         expect(parsed.settings.P2P_roomID).toBe("room-simple");
         expect(parsed.settings.P2P_passphrase).toBe("");
+    });
+
+    it("applies compatibility defaults when parsing a legacy P2P URI", () => {
+        const parsed = ConnectionStringParser.parse(
+            "sls+p2p://room-simple?relays=wss%3A%2F%2Frelay.example&appId=self-hosted-livesync"
+        );
+        if (parsed.type !== "p2p") {
+            throw new Error("Expected p2p type");
+        }
+
+        expect(parsed.settings.P2P_maxWirePayloadBytes).toBe(15 * 1024);
+        expect(parsed.settings.P2P_connectionPath).toBe("automatic");
+    });
+
+    it("normalises unsafe P2P compatibility parameters", () => {
+        const parsed = ConnectionStringParser.parse(
+            "sls+p2p://room-simple?maxWirePayloadBytes=1&connectionPath=direct"
+        );
+        if (parsed.type !== "p2p") {
+            throw new Error("Expected p2p type");
+        }
+
+        expect(parsed.settings.P2P_maxWirePayloadBytes).toBe(15 * 1024);
+        expect(parsed.settings.P2P_connectionPath).toBe("automatic");
     });
 });
 

--- a/src/common/models/setting.const.defaults.ts
+++ b/src/common/models/setting.const.defaults.ts
@@ -1,4 +1,11 @@
-import { ChunkAlgorithms, CURRENT_SETTING_VERSION, E2EEAlgorithms, REMOTE_COUCHDB } from "./setting.const";
+import {
+    ChunkAlgorithms,
+    CURRENT_SETTING_VERSION,
+    E2EEAlgorithms,
+    P2PConnectionPaths,
+    P2PMessageSizePresets,
+    REMOTE_COUCHDB,
+} from "./setting.const";
 import { PREFERRED_BASE } from "./setting.const.preferred";
 import { AutoAccepting, type ObsidianLiveSyncSettings, type P2PSyncSetting } from "./setting.type";
 import type { CustomRegExpSourceList } from "./shared.type.util";
@@ -23,6 +30,8 @@ export const P2P_DEFAULT_SETTINGS: P2PSyncSetting = {
     P2P_turnServers: "",
     P2P_turnUsername: "",
     P2P_turnCredential: "",
+    P2P_maxWirePayloadBytes: P2PMessageSizePresets.Standard,
+    P2P_connectionPath: P2PConnectionPaths.Automatic,
     P2P_useDiagRTC: false,
 } as const;
 

--- a/src/common/models/setting.const.qr.ts
+++ b/src/common/models/setting.const.qr.ts
@@ -170,4 +170,6 @@ export const KeyIndexOfSettings: Record<keyof ObsidianLiveSyncSettings, number> 
     autoAcceptCompatibleTweak: 160,
     tweakModified: -1,
     P2P_useDiagRTC: -1, // Do not encode into the QR Code.
+    P2P_maxWirePayloadBytes: 163,
+    P2P_connectionPath: 164,
 } as const;

--- a/src/common/models/setting.const.ts
+++ b/src/common/models/setting.const.ts
@@ -13,6 +13,26 @@ export const REMOTE_MINIO = RemoteTypes.REMOTE_MINIO;
 //
 export const REMOTE_P2P = RemoteTypes.REMOTE_P2P;
 
+/** ICE route policies supported by a P2P connection profile. */
+export const P2PConnectionPaths = {
+    Automatic: "automatic",
+    Relay: "relay",
+} as const;
+export type P2PConnectionPath = (typeof P2PConnectionPaths)[keyof typeof P2PConnectionPaths];
+
+/**
+ * User-facing message-size presets for the P2P RPC transport.
+ *
+ * These values limit Commonlib wire payloads before Trystero applies its own
+ * framing. They are not file Chunk sizes or network MTUs.
+ */
+export const P2PMessageSizePresets = {
+    Standard: 15_360,
+    Reduced: 2_048,
+    Conservative: 1_024,
+    MaximumCompatibility: 800,
+} as const;
+
 export const E2EEAlgorithmNames = {
     "": "V1: Legacy",
     v2: "V2: AES-256-GCM With HKDF",

--- a/src/common/models/setting.lifecycle.unit.spec.ts
+++ b/src/common/models/setting.lifecycle.unit.spec.ts
@@ -63,6 +63,16 @@ describe("prepareSettingsForLoad", () => {
         expect(prepared.settings.allowSleepDuringSynchronisationOnDesktop).toBe(true);
     });
 
+    it("adds P2P transport compatibility defaults when stored settings predate them", () => {
+        const prepared = prepareSettingsForLoad({
+            settingVersion: CURRENT_SETTING_VERSION,
+            liveSync: true,
+        });
+
+        expect(prepared.settings.P2P_maxWirePayloadBytes).toBe(15 * 1024);
+        expect(prepared.settings.P2P_connectionPath).toBe("automatic");
+    });
+
     it("is idempotent after the current schema has been applied", () => {
         const first = prepareSettingsForLoad({
             liveSync: true,
@@ -156,9 +166,7 @@ describe("prepareSettingsForLoad", () => {
         expect(TweakValuesShouldMatchedTemplate.doNotUseFixedRevisionForChunks).toBeUndefined();
         expect(TweakValuesRecommendedTemplate.doNotUseFixedRevisionForChunks).toBeUndefined();
         expect(
-            IncompatibleChangesInSpecificPattern.filter(
-                ({ key }) => key === "doNotUseFixedRevisionForChunks"
-            )
+            IncompatibleChangesInSpecificPattern.filter(({ key }) => key === "doNotUseFixedRevisionForChunks")
         ).toEqual([]);
     });
 

--- a/src/common/models/setting.p2p.ts
+++ b/src/common/models/setting.p2p.ts
@@ -1,0 +1,56 @@
+import { P2PConnectionPaths, P2PMessageSizePresets, type P2PConnectionPath } from "./setting.const";
+
+/**
+ * Return a safe outgoing RPC wire-payload bound for Trystero.
+ *
+ * Existing profiles can omit this value. Invalid, excessively small, and
+ * excessively large values retain the established 15,360-byte behaviour.
+ */
+export function normaliseP2PMaxWirePayloadBytes(value: unknown): number {
+    if (
+        typeof value !== "number" ||
+        !Number.isSafeInteger(value) ||
+        value < P2PMessageSizePresets.MaximumCompatibility ||
+        value > P2PMessageSizePresets.Standard
+    ) {
+        return P2PMessageSizePresets.Standard;
+    }
+    return value;
+}
+
+/** Return a recognised P2P connection path, defaulting legacy values to automatic selection. */
+export function normaliseP2PConnectionPath(value: unknown): P2PConnectionPath {
+    return value === P2PConnectionPaths.Relay ? P2PConnectionPaths.Relay : P2PConnectionPaths.Automatic;
+}
+
+/** Split the stored comma-separated TURN server list without changing its entries. */
+export function splitP2PTurnServerUrls(value: string): string[] {
+    return value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Report whether a value is a minimally valid TURN or TURN-over-TLS URL.
+ *
+ * Full allocation validation remains the responsibility of WebRTC. This
+ * check only prevents relay-only mode when no TURN endpoint can be attempted.
+ */
+export function isValidP2PTurnServerUrl(value: string): boolean {
+    const candidate = value.trim();
+    if (!candidate || /\s/.test(candidate)) return false;
+    try {
+        const parsed = new URL(candidate);
+        const protocol = parsed.protocol.toLowerCase();
+        if (protocol !== "turn:" && protocol !== "turns:") return false;
+        return (parsed.hostname || parsed.pathname).length > 0;
+    } catch {
+        return false;
+    }
+}
+
+/** Report whether a stored TURN server list contains at least one usable TURN URL. */
+export function hasValidP2PTurnServerUrl(value: string): boolean {
+    return splitP2PTurnServerUrls(value).some(isValidP2PTurnServerUrl);
+}

--- a/src/common/models/setting.type.ts
+++ b/src/common/models/setting.type.ts
@@ -6,6 +6,7 @@ import type {
     MODE_PAUSED,
     MODE_SELECTIVE,
     MODE_SHINY,
+    P2PConnectionPath,
     RemoteTypes,
 } from "./setting.const";
 import type { CustomRegExpSourceList } from "./shared.type.util";
@@ -616,6 +617,18 @@ export interface P2PConnectionInfo {
      * The TURN credential (password, secret, etc...) for the P2P connection.
      */
     P2P_turnCredential: string;
+
+    /**
+     * Maximum serialised RPC wire payload sent through Trystero before
+     * Commonlib splits it. Applies to outgoing messages.
+     */
+    P2P_maxWirePayloadBytes?: number;
+
+    /**
+     * ICE route policy for this P2P profile. Relay-only mode is effective only
+     * when the profile contains at least one valid TURN URL.
+     */
+    P2P_connectionPath?: P2PConnectionPath;
 
     /**
      * Use Diagnostic Wrapper for RTCPeerConnection to collect statistics.

--- a/src/common/models/shared.definition.configNames.ts
+++ b/src/common/models/shared.definition.configNames.ts
@@ -166,6 +166,14 @@ export const configurationNames: Partial<Record<keyof ObsidianLiveSyncSettings, 
         desc: "The credential/password for the TURN servers.",
         isHidden: true,
     },
+    P2P_maxWirePayloadBytes: {
+        name: "P2P Message Size",
+        desc: "The maximum outgoing RPC wire payload before Commonlib splits it for the P2P transport.",
+    },
+    P2P_connectionPath: {
+        name: "Connection Path",
+        desc: "Select the WebRTC route automatically or require a configured TURN relay.",
+    },
     useOnlyLocalChunk: {
         name: "Use Only Local Chunks",
         desc: "If enabled, the plugin will not attempt to connect to the remote database even if the chunk was not found locally.",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -106,7 +106,17 @@ import {
     MODE_PAUSED,
     MODE_SELECTIVE,
     MODE_SHINY,
+    P2PConnectionPaths,
+    P2PMessageSizePresets,
+    type P2PConnectionPath,
 } from "./models/setting.const.ts";
+import {
+    hasValidP2PTurnServerUrl,
+    isValidP2PTurnServerUrl,
+    normaliseP2PConnectionPath,
+    normaliseP2PMaxWirePayloadBytes,
+    splitP2PTurnServerUrls,
+} from "./models/setting.p2p.ts";
 import {
     PREFERRED_BASE,
     PREFERRED_JOURNAL_SYNC,
@@ -265,8 +275,24 @@ export { type PluginSyncSettingEntry };
 export { SETTING_VERSION_INITIAL, SETTING_VERSION_SUPPORT_CASE_INSENSITIVE, CURRENT_SETTING_VERSION };
 export type { BucketSyncSetting, LocalDBSettings };
 
-export { RemoteTypes, REMOTE_COUCHDB, REMOTE_MINIO, REMOTE_P2P, type RemoteType, AutoAccepting };
-export type { P2PConnectionInfo, P2PSyncSetting };
+export {
+    RemoteTypes,
+    REMOTE_COUCHDB,
+    REMOTE_MINIO,
+    REMOTE_P2P,
+    P2PConnectionPaths,
+    P2PMessageSizePresets,
+    type RemoteType,
+    AutoAccepting,
+};
+export type { P2PConnectionInfo, P2PConnectionPath, P2PSyncSetting };
+export {
+    hasValidP2PTurnServerUrl,
+    isValidP2PTurnServerUrl,
+    normaliseP2PConnectionPath,
+    normaliseP2PMaxWirePayloadBytes,
+    splitP2PTurnServerUrls,
+};
 
 export { P2P_DEFAULT_SETTINGS };
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -24,6 +24,7 @@ import {
     type CouchDBConnection,
     type EncryptionSettings,
 } from "./types.ts";
+import { normaliseP2PConnectionPath, normaliseP2PMaxWirePayloadBytes } from "./models/setting.p2p.ts";
 import { isErrorOfMissingDoc } from "@lib/pouchdb/utils_couchdb.ts";
 import { replaceAll, replaceAllPairs } from "octagonal-wheels/string";
 export { replaceAll, replaceAllPairs };
@@ -610,6 +611,8 @@ export function pickP2PSyncSettings(setting: Partial<ObsidianLiveSyncSettings> &
         P2P_turnServers: setting.P2P_turnServers,
         P2P_turnUsername: setting.P2P_turnUsername,
         P2P_turnCredential: setting.P2P_turnCredential,
+        P2P_maxWirePayloadBytes: normaliseP2PMaxWirePayloadBytes(setting.P2P_maxWirePayloadBytes),
+        P2P_connectionPath: normaliseP2PConnectionPath(setting.P2P_connectionPath),
     };
 }
 

--- a/src/replication/trystero/LiveSyncTrysteroReplicator.ts
+++ b/src/replication/trystero/LiveSyncTrysteroReplicator.ts
@@ -29,6 +29,12 @@ import { delay } from "octagonal-wheels/promises";
 import type { AsyncActivityOptions } from "@lib/interfaces/AsyncActivityRunner";
 
 import type { Advertisement } from "./types";
+import {
+    hasValidP2PTurnServerUrl,
+    normaliseP2PConnectionPath,
+    normaliseP2PMaxWirePayloadBytes,
+} from "@lib/common/models/setting.p2p";
+import { P2PConnectionPaths } from "@lib/common/models/setting.const";
 
 export interface LiveSyncTrysteroReplicatorEnv extends LiveSyncReplicatorEnv {
     // services: IServiceHub;
@@ -49,6 +55,7 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
     private _replicator?: TrysteroReplicator;
     private _lifecycleOperation: Promise<void> = Promise.resolve();
     private _shouldBeOpen = false;
+    private _activeTransportCompatibilitySignature?: string;
 
     get openReplicationUI() {
         return this.env.openReplicationUI;
@@ -119,6 +126,31 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
         return queued;
     }
 
+    /**
+     * Capture settings which are fixed when the active P2P transport joins its room.
+     * A later open request can remain idempotent only while these effective values match.
+     */
+    private _getTransportCompatibilitySignature(): string {
+        const settings = this.env.services.setting.currentSettings();
+        const configuredPath = normaliseP2PConnectionPath(settings.P2P_connectionPath);
+        const effectivePath =
+            configuredPath === P2PConnectionPaths.Relay && hasValidP2PTurnServerUrl(settings.P2P_turnServers ?? "")
+                ? P2PConnectionPaths.Relay
+                : P2PConnectionPaths.Automatic;
+        return `${normaliseP2PMaxWirePayloadBytes(settings.P2P_maxWirePayloadBytes)}:${effectivePath}`;
+    }
+
+    /** Close and forget the transport without changing the requested lifecycle state. */
+    private async _closeTransport(): Promise<void> {
+        if (this._replicator) {
+            this._replicator.disableBroadcastChanges();
+            await this._replicator.close();
+            this._replicator = undefined;
+        }
+        this._p2pHost = undefined;
+        this._activeTransportCompatibilitySignature = undefined;
+    }
+
     async open() {
         if (!this.env.services.setting.currentSettings().P2P_Enabled) {
             Logger(this.translate("P2P.NotEnabled"), LOG_LEVEL_NOTICE);
@@ -128,9 +160,13 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
         this._shouldBeOpen = true;
         await this._enqueueLifecycleOperation(async () => {
             if (!this._shouldBeOpen) return;
+            const compatibilitySignature = this._getTransportCompatibilitySignature();
             if (this._replicator && this._p2pHost?.isServing) {
-                Logger("P2P replicator is already open.");
-                return;
+                if (this._activeTransportCompatibilitySignature === compatibilitySignature) {
+                    Logger("P2P replicator is already open.");
+                    return;
+                }
+                await this._closeTransport();
             }
             try {
                 const env = this._buildEnv();
@@ -139,11 +175,13 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
                 this._p2pHost = host;
                 this._replicator = replicator;
                 await replicator.open();
+                this._activeTransportCompatibilitySignature = compatibilitySignature;
             } catch (e) {
                 Logger(e instanceof Error ? e.message : "Error while opening P2P connection", LOG_LEVEL_NOTICE);
                 Logger(e, LOG_LEVEL_VERBOSE);
                 this._p2pHost = undefined;
                 this._replicator = undefined;
+                this._activeTransportCompatibilitySignature = undefined;
             }
         });
     }
@@ -151,12 +189,7 @@ export class LiveSyncTrysteroReplicator extends LiveSyncAbstractReplicator {
     async close() {
         this._shouldBeOpen = false;
         await this._enqueueLifecycleOperation(async () => {
-            if (this._replicator) {
-                this._replicator.disableBroadcastChanges();
-                await this._replicator.close();
-                this._replicator = undefined;
-            }
-            this._p2pHost = undefined;
+            await this._closeTransport();
         });
     }
 

--- a/src/replication/trystero/LiveSyncTrysteroReplicator.unit.spec.ts
+++ b/src/replication/trystero/LiveSyncTrysteroReplicator.unit.spec.ts
@@ -12,12 +12,12 @@ function createDeferred() {
     return { promise, resolve };
 }
 
-function createLifecycleReplicator() {
+function createLifecycleReplicator(settings: Record<string, unknown> = { P2P_Enabled: true }) {
     return new LiveSyncTrysteroReplicator({
         services: {
             context: createServiceContext(),
             setting: {
-                currentSettings: () => ({ P2P_Enabled: true }),
+                currentSettings: () => settings,
             },
             keyValueDB: {
                 openSimpleStore: () => ({}),
@@ -179,5 +179,38 @@ describe("LiveSyncTrysteroReplicator transport lifecycle", () => {
         expect(openedTransport?.server?.isServing).toBe(false);
         expect(replicator.rawReplicator).toBeUndefined();
         expect(replicator.rawHost).toBeUndefined();
+    });
+
+    it.each([
+        ["message-size bound", "P2P_maxWirePayloadBytes", 15_360, 800],
+        ["connection path", "P2P_connectionPath", "automatic", "relay"],
+    ])("replaces a serving transport when its effective %s changes", async (_label, key, initialValue, nextValue) => {
+        vi.restoreAllMocks();
+        const lifecycle: string[] = [];
+        const settings: Record<string, unknown> = {
+            P2P_Enabled: true,
+            P2P_maxWirePayloadBytes: 15_360,
+            P2P_connectionPath: "automatic",
+            P2P_turnServers: "turn:turn.example.com:3478",
+            [key]: initialValue,
+        };
+        vi.spyOn(TrysteroReplicator.prototype, "open").mockImplementation(async function () {
+            lifecycle.push("open");
+            (this.server as any)._room = {};
+        });
+        vi.spyOn(TrysteroReplicator.prototype, "close").mockImplementation(async function () {
+            lifecycle.push("close");
+            (this.server as any)._room = undefined;
+        });
+        const replicator = createLifecycleReplicator(settings);
+
+        await replicator.open();
+        const firstTransport = replicator.rawReplicator;
+        settings[key] = nextValue;
+        await replicator.open();
+
+        expect(lifecycle).toEqual(["open", "close", "open"]);
+        expect(replicator.rawReplicator).not.toBe(firstTransport);
+        expect(replicator.rawHost?.isServing).toBe(true);
     });
 });

--- a/src/replication/trystero/TrysteroReplicatorP2PServer.ts
+++ b/src/replication/trystero/TrysteroReplicatorP2PServer.ts
@@ -21,7 +21,7 @@ import { EVENT_PLATFORM_UNLOADED } from "@lib/events/coreEvents";
 import { shareRunningResult } from "octagonal-wheels/concurrency/lock_v2";
 import { Computed } from "octagonal-wheels/dataobject/Computed";
 import { RpcRoom, type JsonLike, type RpcWireMessage, type TransportAdapter } from "@lib/rpc";
-import { TRYSTERO_RPC_DEFAULTS } from "@lib/rpc/transports/TrysteroTransport";
+import { resolveTrysteroRpcOptions } from "@lib/rpc/transports/TrysteroTransport";
 import { subscribeTrysteroPeerEvents } from "@lib/rpc/transports/trysteroRoomEvents";
 import { toRpcMethodName } from "./rpcCompat";
 import { generateJoinRoomOptions } from "@lib/rpc/transports/trysteroUtils";
@@ -466,7 +466,7 @@ You can chose as follows:
         };
         this._rpcRoom?.close();
         this._rpcRoom = new RpcRoom({
-            ...TRYSTERO_RPC_DEFAULTS,
+            ...resolveTrysteroRpcOptions(this.settings),
             transport,
             canAcceptRequest: async (peerId, method) => {
                 if (method === toRpcMethodName("!reqAuth")) return true;

--- a/src/replication/trystero/TrysteroReplicatorP2PServer.unit.spec.ts
+++ b/src/replication/trystero/TrysteroReplicatorP2PServer.unit.spec.ts
@@ -1,9 +1,34 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createLiveSyncEventHub } from "@lib/hub/hub";
+
+const { rpcRoomOptions } = vi.hoisted(() => ({
+    rpcRoomOptions: [] as unknown[],
+}));
+
+vi.mock("@lib/rpc", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@lib/rpc")>();
+    return {
+        ...actual,
+        RpcRoom: class MockRpcRoom {
+            constructor(options: unknown) {
+                rpcRoomOptions.push(options);
+            }
+
+            close() {}
+
+            register() {}
+        },
+    };
+});
+
 import { P2PHost } from "./TrysteroReplicatorP2PServer";
 
-describe("P2PHost transport ownership", () => {
+describe("P2PHost transport configuration and ownership", () => {
+    beforeEach(() => {
+        rpcRoomOptions.length = 0;
+    });
+
     it("leaves the room without closing Trystero-owned peer connections directly", async () => {
         const closePeerConnection = vi.fn();
         const leave = vi.fn(async () => undefined);
@@ -25,5 +50,30 @@ describe("P2PHost transport ownership", () => {
         expect(closePeerConnection).not.toHaveBeenCalled();
         expect(host.room).toBeUndefined();
         expect(host.rpcRoom).toBeUndefined();
+    });
+
+    it("passes the configured wire-payload bound to RpcRoom", () => {
+        const host = new P2PHost({
+            events: createLiveSyncEventHub(),
+            simpleStore: {},
+            settings: {
+                P2P_Enabled: true,
+                P2P_maxWirePayloadBytes: 800,
+            },
+        } as any);
+        (host as any)._room = {
+            makeAction: vi.fn(() => ({
+                send: vi.fn(async () => undefined),
+                onMessage: null,
+            })),
+            onPeerJoin: null,
+            onPeerLeave: null,
+        };
+
+        host.onAfterJoinRoom();
+
+        expect(rpcRoomOptions.at(-1)).toMatchObject({
+            maxWirePayloadBytes: 800,
+        });
     });
 });

--- a/src/rpc/transports/TrysteroTransport.ts
+++ b/src/rpc/transports/TrysteroTransport.ts
@@ -6,6 +6,7 @@ import { RpcPouchDBProxy } from "@lib/rpc/pouchdb/RpcPouchDBProxy";
 import type { RpcRoomOptions, RpcWireMessage, TransportAdapter } from "@lib/rpc/types";
 //TODO: following imports should be moved to a separated module, to make this module as a library.
 import type { P2PConnectionInfo } from "@lib/common/models/setting.type";
+import { normaliseP2PMaxWirePayloadBytes } from "@lib/common/models/setting.p2p";
 import { ConnectionStringParser } from "@lib/common/ConnectionString";
 import { compatGlobal } from "@lib/common/coreEnvFunctions";
 import { generateJoinRoomOptions } from "./trysteroUtils";
@@ -136,6 +137,16 @@ export const TRYSTERO_RPC_DEFAULTS = {
     /** SCTP guarantees delivery; retransmission is a last-resort safety net. */
     chunkMissingRetryMs: 150,
 } as const;
+
+/** Resolve the RpcRoom defaults contributed by one P2P connection profile. */
+export function resolveTrysteroRpcOptions(
+    settings: Pick<P2PConnectionInfo, "P2P_maxWirePayloadBytes">
+): Required<Pick<RpcRoomOptions, "maxWirePayloadBytes" | "chunkMissingRetryMs">> {
+    return {
+        ...TRYSTERO_RPC_DEFAULTS,
+        maxWirePayloadBytes: normaliseP2PMaxWirePayloadBytes(settings.P2P_maxWirePayloadBytes),
+    };
+}
 
 // ---------------------------------------------------------------------------
 // Low-level: wrap an already-joined Trystero Room
@@ -303,7 +314,11 @@ export function serveTrysteroDB(
     options?: TrysteroRoomOptions
 ): TrysteroDBServerHandle {
     const roomHandle = joinTrysteroRoom(settings);
-    const rpcRoom = new RpcRoom({ ...TRYSTERO_RPC_DEFAULTS, transport: roomHandle.transport, ...options });
+    const rpcRoom = new RpcRoom({
+        ...resolveTrysteroRpcOptions(settings),
+        transport: roomHandle.transport,
+        ...options,
+    });
     exposeDB(rpcRoom, db, ns);
 
     return {
@@ -359,7 +374,11 @@ export function connectTrysteroDBClient(
     options?: TrysteroRoomOptions
 ): TrysteroDBClientHandle {
     const roomHandle = joinTrysteroRoom(settings);
-    const rpcRoom = new RpcRoom({ ...TRYSTERO_RPC_DEFAULTS, transport: roomHandle.transport, ...options });
+    const rpcRoom = new RpcRoom({
+        ...resolveTrysteroRpcOptions(settings),
+        transport: roomHandle.transport,
+        ...options,
+    });
     const proxy = new RpcPouchDBProxy(rpcRoom.session(serverPeerId), dbName, ns);
 
     return {

--- a/src/rpc/transports/TrysteroTransport.unit.spec.ts
+++ b/src/rpc/transports/TrysteroTransport.unit.spec.ts
@@ -113,6 +113,7 @@ import {
     connectTrysteroDBClient,
     joinTrysteroRoom,
     joinTrysteroRoomFromUrl,
+    resolveTrysteroRpcOptions,
     serveTrysteroDB,
     wrapTrysteroRoom,
 } from "./TrysteroTransport";
@@ -144,6 +145,20 @@ const BASE_SETTINGS: P2PConnectionInfo = {
     P2P_turnUsername: "",
     P2P_turnCredential: "",
 };
+
+describe("resolveTrysteroRpcOptions", () => {
+    it.each([
+        [undefined, 15_360],
+        [799, 15_360],
+        [800, 800],
+        [1_024, 1_024],
+        [15_360, 15_360],
+        [15_361, 15_360],
+        [1_024.5, 15_360],
+    ])("normalises the configured wire-payload bound %s to %s", (configured, expected) => {
+        expect(resolveTrysteroRpcOptions({ P2P_maxWirePayloadBytes: configured }).maxWirePayloadBytes).toBe(expected);
+    });
+});
 
 // ---------------------------------------------------------------------------
 // wrapTrysteroRoom
@@ -319,6 +334,45 @@ describe("joinTrysteroRoom", () => {
         ]);
     });
 
+    it.each(["turn:turn.example.com:3478", "turns:turn.example.com:5349"])(
+        "forces the relay ICE transport with the valid TURN URL %s",
+        (turnServer) => {
+            joinTrysteroRoom({
+                ...BASE_SETTINGS,
+                P2P_turnServers: turnServer,
+                P2P_connectionPath: "relay",
+            });
+
+            const [opts] = mockJoinRoom.mock.calls[0];
+            expect((opts as any).rtcConfig).toEqual({ iceTransportPolicy: "relay" });
+        }
+    );
+
+    it.each(["", "stun:stun.example.com:3478", "https://turn.example.com", "turn:"])(
+        "does not force the relay ICE transport without a valid TURN URL: %s",
+        (turnServer) => {
+            joinTrysteroRoom({
+                ...BASE_SETTINGS,
+                P2P_turnServers: turnServer,
+                P2P_connectionPath: "relay",
+            });
+
+            const [opts] = mockJoinRoom.mock.calls[0];
+            expect((opts as any).rtcConfig).toBeUndefined();
+        }
+    );
+
+    it("retains automatic ICE selection when a valid TURN URL is configured", () => {
+        joinTrysteroRoom({
+            ...BASE_SETTINGS,
+            P2P_turnServers: "turn:turn.example.com:3478",
+            P2P_connectionPath: "automatic",
+        });
+
+        const [opts] = mockJoinRoom.mock.calls[0];
+        expect((opts as any).rtcConfig).toBeUndefined();
+    });
+
     it("includes multiple TURN servers when given a comma-separated list", () => {
         joinTrysteroRoom({
             ...BASE_SETTINGS,
@@ -442,6 +496,19 @@ describe("serveTrysteroDB", () => {
         void server.close();
     });
 
+    it("uses the profile wire-payload bound for the server RpcRoom", async () => {
+        const server = serveTrysteroDB(
+            {
+                ...BASE_SETTINGS,
+                P2P_maxWirePayloadBytes: 800,
+            },
+            db
+        );
+
+        expect((server.rpcRoom as any).options.maxWirePayloadBytes).toBe(800);
+        await server.close();
+    });
+
     it("registers pdb.* methods on the RpcRoom", () => {
         const server = serveTrysteroDB(BASE_SETTINGS, db);
         // RpcRoom.hasMethod is not public, but we can verify via a call attempt
@@ -493,6 +560,20 @@ describe("connectTrysteroDBClient", () => {
         const client = connectTrysteroDBClient(BASE_SETTINGS, "server-peer", "my-db");
         expect(client.rpcRoom).toBeInstanceOf(RpcRoom);
         void client.close();
+    });
+
+    it("uses the profile wire-payload bound for the client RpcRoom", async () => {
+        const client = connectTrysteroDBClient(
+            {
+                ...BASE_SETTINGS,
+                P2P_maxWirePayloadBytes: 800,
+            },
+            "server-peer",
+            "my-db"
+        );
+
+        expect((client.rpcRoom as any).options.maxWirePayloadBytes).toBe(800);
+        await client.close();
     });
 
     it("close() calls room.leave()", async () => {

--- a/src/rpc/transports/trysteroUtils.ts
+++ b/src/rpc/transports/trysteroUtils.ts
@@ -1,5 +1,11 @@
 import type { BaseRoomConfig, RelayConfig } from "@trystero-p2p/nostr";
 import type { P2PConnectionInfo } from "@lib/common/models/setting.type";
+import { P2PConnectionPaths } from "@lib/common/models/setting.const";
+import {
+    hasValidP2PTurnServerUrl,
+    normaliseP2PConnectionPath,
+    splitP2PTurnServerUrls,
+} from "@lib/common/models/setting.p2p";
 import { mixedHash } from "octagonal-wheels/hash/purejs";
 import { compatGlobal } from "@lib/common/coreEnvFunctions";
 import { createDiagRTCPeerConnectionConstructor } from "./DiagRTCPeerConnections";
@@ -11,9 +17,7 @@ export function generateJoinRoomOptions(settings: P2PConnectionInfo): BaseRoomCo
         .map((e) => e.trim())
         .filter((e) => e.length > 0);
 
-    const turnServers = settings.P2P_turnServers.split(",")
-        .map((e) => e.trim())
-        .filter((e) => e.length > 0);
+    const turnServers = splitP2PTurnServerUrls(settings.P2P_turnServers);
     const relayConfig: RelayConfig = {
         manualReconnection: true,
         urls: relays,
@@ -37,6 +41,14 @@ export function generateJoinRoomOptions(settings: P2PConnectionInfo): BaseRoomCo
                 credential: settings.P2P_turnCredential,
             },
         ];
+    }
+    if (
+        normaliseP2PConnectionPath(settings.P2P_connectionPath) === P2PConnectionPaths.Relay &&
+        hasValidP2PTurnServerUrl(settings.P2P_turnServers)
+    ) {
+        options.rtcConfig = {
+            iceTransportPolicy: "relay",
+        };
     }
     return options;
 }


### PR DESCRIPTION
This change adds explicit P2P transport compatibility settings so constrained WebRTC paths can use smaller messages or a TURN-only route.

## Summary

- add a normalised outgoing RPC message-size setting with the existing 15,360-byte behaviour as its default;
- retain the message-size and connection-path choices in P2P settings, connection strings, and QR-encoded settings;
- apply the configured message bound to Commonlib's Trystero RPC server and client surfaces;
- require a syntactically valid `turn:` or `turns:` endpoint before applying `iceTransportPolicy: 'relay'`; and
- recreate a serving P2P transport when either effective compatibility value changes, while retaining idempotent concurrent opens when the values are unchanged.

## Rationale

Issue #97 traced a reproducible cross-network stall to an ICE path which silently dropped fragmented messages. A fixed 15,360-byte RPC bound left affected users with no supported way to select the demonstrated 800-byte workaround. The transport cannot reliably infer that fragmentation caused a timeout, so this change exposes a bounded explicit setting rather than adding automatic fallback.

The connection-path choice also makes a configured TURN route testable without changing the normal default: `automatic` retains ordinary ICE selection, while `relay` is effective only when the profile contains a usable TURN URL.

Thank you to @andrewschreiber for the detailed end-to-end diagnosis and reproducible workaround in #97.

## Verification

- `npm run check:types`
- `npx --no-install vitest run --maxWorkers=1 --reporter=dot` — 71 files and 1,341 tests passed
- focused Trystero, connection-string, settings-lifecycle, and RPC transport tests — 84 tests passed
- Prettier verification for the changed source and test files
