### PR TITLE
Normalise generated package file modes

### DIFF
--- a/_tools/build-package.mjs
+++ b/_tools/build-package.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { cp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, relative, resolve, sep } from "node:path";
 
 import { build } from "esbuild";
@@ -275,6 +275,31 @@ async function copyStaticFiles() {
     }
 }
 
+async function normalisePackagePermissions() {
+    const manifest = JSON.parse(await readFile(resolve(packageDirectory, "package.json"), "utf8"));
+    const executablePaths = new Set(
+        (typeof manifest.bin === "string" ? [manifest.bin] : Object.values(manifest.bin ?? {})).map((path) =>
+            path.replace(/^\.\//u, "")
+        )
+    );
+
+    const visit = async (directory) => {
+        await chmod(directory, 0o755);
+        for (const entry of await readdir(directory, { withFileTypes: true })) {
+            const path = resolve(directory, entry.name);
+            if (entry.isDirectory()) {
+                await visit(path);
+                continue;
+            }
+            if (!entry.isFile()) continue;
+            const packagePath = relative(packageDirectory, path).split(sep).join("/");
+            await chmod(path, executablePaths.has(packagePath) ? 0o755 : 0o644);
+        }
+    };
+
+    await visit(packageDirectory);
+}
+
 async function validateOutput() {
     const manifest = JSON.parse(await readFile(resolve(packageDirectory, "package.json"), "utf8"));
     const missingTargets = [];
@@ -323,6 +348,7 @@ await bundleInlineWorker();
 await copyStaticFiles();
 await rewriteModuleSpecifiers();
 await writePackageManifest();
+await normalisePackagePermissions();
 await validateOutput();
 
 console.log(

--- a/_tools/check-packed-package.mjs
+++ b/_tools/check-packed-package.mjs
@@ -15,6 +15,14 @@ const consumerDirectory = resolve(root, ".package-consumer");
 const packageName = "@vrtmrz/livesync-commonlib";
 const inventory = JSON.parse(await readFile(resolve(root, "docs/migration/downstream-imports.json"), "utf8"));
 
+function formatFileMode(mode) {
+    return typeof mode === "number" ? mode.toString(8).padStart(4, "0") : String(mode);
+}
+
+function normalisePackagePath(path) {
+    return path.replace(/^\.\//u, "");
+}
+
 function run(command, args, options = {}) {
     return execFileSync(command, args, {
         cwd: options.cwd ?? root,
@@ -38,6 +46,20 @@ const packed = JSON.parse(run("npm", ["pack", packageDirectory, "--json", "--pac
 assert.equal(packed.name, packageName);
 assert.ok(packed.size > 0, "The packed package must not be empty.");
 const generatedManifest = JSON.parse(await readFile(resolve(packageDirectory, "package.json"), "utf8"));
+const declaredBinTargets = new Set(
+    (typeof generatedManifest.bin === "string"
+        ? [generatedManifest.bin]
+        : Object.values(generatedManifest.bin ?? {})
+    ).map(normalisePackagePath)
+);
+for (const file of packed.files) {
+    const expectedMode = declaredBinTargets.has(normalisePackagePath(file.path)) ? 0o755 : 0o644;
+    assert.equal(
+        file.mode,
+        expectedMode,
+        `Packed file '${file.path}' has mode ${formatFileMode(file.mode)}; expected ${formatFileMode(expectedMode)}.`
+    );
+}
 assert.equal(
     generatedManifest.types,
     "./dist/index.d.ts",

--- a/_tools/run-package-test.mjs
+++ b/_tools/run-package-test.mjs
@@ -2,17 +2,17 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = resolve(new URL("..", import.meta.url).pathname);
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const root = fileURLToPath(new URL("..", import.meta.url));
 
 // A restrictive caller umask previously changed npm tar headers even though
 // every generated package file had identical contents. Keep that environment
 // in the regular package gate so the builder must produce canonical modes.
 process.umask(0o077);
 
-for (const script of ["build:package", "check:package"]) {
-    execFileSync(npmCommand, ["run", script], {
+for (const script of ["build-package.mjs", "check-packed-package.mjs"]) {
+    execFileSync(process.execPath, [resolve(root, "_tools", script)], {
         cwd: root,
         env: process.env,
         stdio: "inherit",

--- a/_tools/run-package-test.mjs
+++ b/_tools/run-package-test.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const root = resolve(new URL("..", import.meta.url).pathname);
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+
+// A restrictive caller umask previously changed npm tar headers even though
+// every generated package file had identical contents. Keep that environment
+// in the regular package gate so the builder must produce canonical modes.
+process.umask(0o077);
+
+for (const script of ["build:package", "check:package"]) {
+    execFileSync(npmCommand, ["run", script], {
+        cwd: root,
+        env: process.env,
+        stdio: "inherit",
+    });
+}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,6 +13,8 @@ npm run verify:package
 
 The gate type-checks Commonlib, runs its complete unit suite, verifies the source boundary, builds the distributable package, installs its exact tarball into a clean consumer, and bundles representative browser and Node entry points. The source `package.json` remains private to prevent publishing the repository root. Only the generated `.package` directory is publishable, and its manifest defaults to public publication on the `next` dist-tag.
 
+The package builder normalises generated directories to `0755`, ordinary files to `0644`, and declared `bin` targets to `0755` before validation. `test:package` uses a restrictive umask and verifies the packed modes, so local and hosted builds do not differ only because their caller environments use different umasks.
+
 ### Lockfile reproducibility
 
 Regenerate `package-lock.json` with the reviewed npm CLI version pinned by the `Use the reviewed npm CLI` step in `.github/workflows/publish-npm.yml`. Do this after adding, removing, or updating a dependency, even when an older local npm reports that the lockfile is already up to date. npm minor versions can differ in how they record transitive optional peer dependencies; a lockfile accepted by an older client can otherwise fail the hosted `npm ci` before any tests run.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:contracts": "vitest run src/services/base/ServiceContext.unit.spec.ts src/platform/storage.contract.unit.test.ts src/platform/standardIo.unit.spec.ts",
     "test:integration": "node _tools/run-integration-tests.mjs",
     "test:integration:managed": "node _tools/run-integration-tests.mjs --manage-services",
-    "test:package": "npm run build:package && npm run check:package",
+    "test:package": "node _tools/run-package-test.mjs",
     "test:release": "node --test _tools/validate-release-selection.test.mjs",
     "update:downstream-import-inventory": "node _tools/update-downstream-import-inventory.mjs",
     "verify:package": "npm run check:types && npm test && npm run test:boundary && npm run test:release && npm run check:boundary && npm run test:package"


### PR DESCRIPTION
This maintenance change makes Commonlib package artefacts reproducible across caller umasks by normalising and validating generated file modes.

## Summary

- normalise generated `.package` directories to `0755`, ordinary files to `0644`, and declared `bin` targets to `0755`;
- run the regular package gate under a controlled `0077` umask;
- validate every mode reported by `npm pack --json`, including the path, actual mode, and expected mode on failure; and
- document the package-mode contract in the release runbook.

The change is limited to generated `.package` contents. It does not change the process-wide umask, source checkout permissions, or the wider working tree.

## Rationale

A restrictive local umask previously produced `0600` package files and tar entries, while the hosted workflow produced `0644`. The payload bytes were identical, but the tar headers changed the packed size, checksum, and integrity.

## Verification

- confirmed the new regression check failed against the unmodified builder with `Packed file 'LICENSE' has mode 0600; expected 0644`;
- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package`;
- confirmed all 504 current tar entries are `0644` and all 47 generated directories are `0755`; and
- confirmed identical packed size and integrity when generating the same source under `0077` and `0022` umasks.
