### PR TITLE
Automate GitHub Release publication

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -1,0 +1,174 @@
+name: Publish GitHub Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: Exact stable version in package.json and npm latest
+                required: true
+                type: string
+            expected_sha:
+                description: Full 40-character release commit SHA on main
+                required: true
+                type: string
+            confirmation:
+                description: "Type: release @vrtmrz/livesync-commonlib@<version> from <expected-sha>"
+                required: true
+                type: string
+
+permissions:
+    contents: read
+
+concurrency:
+    group: github-release
+    cancel-in-progress: false
+
+env:
+    PACKAGE_NAME: "@vrtmrz/livesync-commonlib"
+
+jobs:
+    verify:
+        name: Verify GitHub Release selection
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        steps:
+            - name: Check out the trusted workflow
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
+
+            - name: Set up Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              with:
+                  node-version: 24
+                  registry-url: https://registry.npmjs.org
+                  package-manager-cache: false
+
+            - name: Verify the release source and prepare notes
+              env:
+                  VERSION: ${{ inputs.version }}
+                  EXPECTED_SHA: ${{ inputs.expected_sha }}
+                  CONFIRMATION: ${{ inputs.confirmation }}
+              run: |
+                  test "$GITHUB_REF" = refs/heads/main
+                  [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+                  git cat-file -e "$EXPECTED_SHA^{commit}"
+                  git merge-base --is-ancestor "$EXPECTED_SHA" "$GITHUB_SHA"
+                  git show "$EXPECTED_SHA:package.json" > "$RUNNER_TEMP/release-package.json"
+                  git show "$EXPECTED_SHA:updates.md" > "$RUNNER_TEMP/release-updates.md"
+                  node _tools/prepare-github-release.mjs \
+                    "$VERSION" \
+                    "$EXPECTED_SHA" \
+                    "$CONFIRMATION" \
+                    "$RUNNER_TEMP/release-package.json" \
+                    "$RUNNER_TEMP/release-updates.md" \
+                    "$RUNNER_TEMP/release-notes.md"
+
+            - name: Require the exact version on npm latest
+              env:
+                  VERSION: ${{ inputs.version }}
+              run: test "$(npm view "$PACKAGE_NAME@latest" version)" = "$VERSION"
+
+            - name: Require an unused version tag
+              env:
+                  VERSION: ${{ inputs.version }}
+              run: |
+                  set +e
+                  git ls-remote --exit-code origin "refs/tags/$VERSION" > "$RUNNER_TEMP/release-tag"
+                  status=$?
+                  set -e
+                  case "$status" in
+                    0)
+                      echo "Tag $VERSION already exists." >&2
+                      exit 1
+                      ;;
+                    2) ;;
+                    *) exit "$status" ;;
+                  esac
+
+            - name: Record the verified selection
+              env:
+                  VERSION: ${{ inputs.version }}
+                  EXPECTED_SHA: ${{ inputs.expected_sha }}
+              run: |
+                  {
+                    echo "### GitHub Release selection"
+                    echo
+                    printf -- '- package: `%s@%s`\n' "$PACKAGE_NAME" "$VERSION"
+                    printf -- '- release commit: `%s`\n' "$EXPECTED_SHA"
+                    echo '- npm dist-tag: `latest`'
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Upload the verified release notes
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+              with:
+                  name: github-release-notes
+                  path: ${{ runner.temp }}/release-notes.md
+                  if-no-files-found: error
+                  retention-days: 1
+
+    publish:
+        name: Publish GitHub Release
+        needs: verify
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        environment: github-release
+        permissions:
+            contents: write
+
+        steps:
+            - name: Set up Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+              with:
+                  node-version: 24
+                  registry-url: https://registry.npmjs.org
+                  package-manager-cache: false
+
+            - name: Download the verified release notes
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+              with:
+                  name: github-release-notes
+                  path: ${{ runner.temp }}/github-release
+
+            - name: Revalidate the release gate
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  VERSION: ${{ inputs.version }}
+              run: |
+                  test "$(npm view "$PACKAGE_NAME@latest" version)" = "$VERSION"
+                  if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" > /dev/null 2>&1; then
+                    echo "Tag $VERSION already exists." >&2
+                    exit 1
+                  fi
+
+            - name: Publish the version tag and GitHub Release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  VERSION: ${{ inputs.version }}
+                  EXPECTED_SHA: ${{ inputs.expected_sha }}
+              run: |
+                  gh release create "$VERSION" \
+                    --repo "$GITHUB_REPOSITORY" \
+                    --target "$EXPECTED_SHA" \
+                    --title "$VERSION" \
+                    --notes-file "$RUNNER_TEMP/github-release/release-notes.md" \
+                    --latest
+
+            - name: Verify the published GitHub Release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  VERSION: ${{ inputs.version }}
+                  EXPECTED_SHA: ${{ inputs.expected_sha }}
+              run: |
+                  test "$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" --jq '.object.type')" = commit
+                  test "$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" --jq '.object.sha')" = "$EXPECTED_SHA"
+                  release_url=$(gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease,url --jq 'select(.isDraft == false and .isPrerelease == false) | .url')
+                  test -n "$release_url"
+                  {
+                    echo "### Published GitHub Release"
+                    echo
+                    printf -- '- release: %s\n' "$release_url"
+                    printf -- '- release commit: `%s`\n' "$EXPECTED_SHA"
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/_tools/prepare-github-release.mjs
+++ b/_tools/prepare-github-release.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const STABLE_VERSION_PATTERN = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u;
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/u;
+
+function requireCondition(condition, message) {
+    if (!condition) throw new Error(message);
+}
+
+export function extractReleaseNotes(updates, version) {
+    const lines = updates.replaceAll("\r\n", "\n").split("\n");
+    const heading = `## ${version}`;
+    const matches = lines.flatMap((line, index) => (line === heading ? [index] : []));
+    requireCondition(matches.length === 1, `Expected exactly one ${heading} heading in updates.md.`);
+
+    const start = matches[0] + 1;
+    let end = lines.length;
+    for (let index = start; index < lines.length; index += 1) {
+        if (lines[index].startsWith("## ")) {
+            end = index;
+            break;
+        }
+    }
+    const notes = lines.slice(start, end).join("\n").trim();
+    requireCondition(notes.length > 0, `Release notes for ${version} are empty.`);
+    return notes;
+}
+
+export function prepareGitHubRelease({ sourceManifest, updates, version, expectedSha, confirmation }) {
+    requireCondition(STABLE_VERSION_PATTERN.test(version), `Invalid stable release version: ${version}`);
+    requireCondition(COMMIT_PATTERN.test(expectedSha), "The release commit must be a full lowercase SHA.");
+    requireCondition(
+        sourceManifest.name === "@vrtmrz/livesync-commonlib",
+        `Unexpected package name: ${sourceManifest.name}`
+    );
+    requireCondition(
+        sourceManifest.version === version,
+        `Source manifest version is ${sourceManifest.version}, not ${version}.`
+    );
+    requireCondition(sourceManifest.private === true, "The source repository manifest must remain private.");
+    const expectedConfirmation = `release ${sourceManifest.name}@${version} from ${expectedSha}`;
+    requireCondition(confirmation === expectedConfirmation, `Confirmation must be: ${expectedConfirmation}`);
+    return extractReleaseNotes(updates, version);
+}
+
+async function main() {
+    const [version, expectedSha, confirmation, manifestPath, updatesPath, notesPath] = process.argv.slice(2);
+    requireCondition(
+        notesPath !== undefined,
+        "GitHub Release preparation requires a version, commit, confirmation, manifest, updates file, and output path."
+    );
+    const sourceManifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    const updates = await readFile(updatesPath, "utf8");
+    const notes = prepareGitHubRelease({ sourceManifest, updates, version, expectedSha, confirmation });
+    await writeFile(notesPath, `${notes}\n`, "utf8");
+    console.log(`Prepared GitHub Release notes for ${sourceManifest.name}@${version} from ${expectedSha}.`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    await main();
+}

--- a/_tools/prepare-github-release.test.mjs
+++ b/_tools/prepare-github-release.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { extractReleaseNotes, prepareGitHubRelease } from "./prepare-github-release.mjs";
+
+const sha = "0123456789abcdef0123456789abcdef01234567";
+
+function validRelease(overrides = {}) {
+    const version = overrides.version ?? "0.1.18";
+    return {
+        sourceManifest: {
+            name: "@vrtmrz/livesync-commonlib",
+            version,
+            private: true,
+            ...overrides.sourceManifest,
+        },
+        updates:
+            overrides.updates ??
+            "# Updates\n\n## Unreleased\n\n## 0.1.18\n\n### Added\n\n- One.\n\n## 0.1.17\n\n- Older.\n",
+        version,
+        expectedSha: overrides.expectedSha ?? sha,
+        confirmation: overrides.confirmation ?? `release @vrtmrz/livesync-commonlib@${version} from ${sha}`,
+    };
+}
+
+describe("GitHub Release preparation", () => {
+    it("extracts only the selected release body", () => {
+        assert.equal(prepareGitHubRelease(validRelease()), "### Added\n\n- One.");
+    });
+
+    it("accepts CRLF update files", () => {
+        const release = validRelease();
+        assert.equal(
+            extractReleaseNotes(release.updates.replaceAll("\n", "\r\n"), release.version),
+            "### Added\n\n- One."
+        );
+    });
+
+    for (const [name, overrides, message] of [
+        ["prerelease version", { version: "0.1.19-rc.0" }, /Invalid stable release version/u],
+        ["short commit", { expectedSha: "0123456" }, /full lowercase SHA/u],
+        ["different package", { sourceManifest: { name: "other" } }, /Unexpected package name/u],
+        ["source version mismatch", { sourceManifest: { version: "0.1.17" } }, /Source manifest version/u],
+        ["public source root", { sourceManifest: { private: false } }, /source repository manifest/u],
+        ["incorrect confirmation", { confirmation: "release something else" }, /Confirmation must be/u],
+        ["missing notes", { updates: "# Updates\n\n## Unreleased\n" }, /exactly one/u],
+        ["duplicate notes", { updates: "## 0.1.18\n\nOne\n\n## 0.1.18\n\nTwo\n" }, /exactly one/u],
+        ["empty notes", { updates: "## 0.1.18\n\n## 0.1.17\n" }, /are empty/u],
+    ]) {
+        it(`rejects ${name}`, () => {
+            assert.throws(() => prepareGitHubRelease(validRelease(overrides)), message);
+        });
+    }
+});

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -92,3 +92,20 @@ gh workflow run publish-npm.yml \
 For a stable release, use `source_ref=main`. The workflow rejects a stable release selected from another branch, rejects a stable release without its trusted workflow commit, and requires the workflow-triggering SHA to equal the packaged `main` SHA. The workflow dispatch itself uses `--ref main` for every release, so an unmerged branch cannot change the trusted publication job or acquire access to the `npm` environment.
 
 The workflow always stages to `next`. Inspect the staged package name, version, access, dist-tag, provenance, checksum, files, selected source branch, and source commit before approving it through npm. Approval and later promotion to `latest` are separate user-authorised operations. Keep the Commonlib and Self-hosted LiveSync consumer pull requests in draft while validating the exact registry pre-release. If validation fails, leave that published version immutable and prepare a new pre-release. After successful consumer validation, merge Commonlib only through its separate maintainer gate. Validate a stable release in Self-hosted LiveSync before promoting it to `latest`.
+
+## Publishing a GitHub Release
+
+Create a GitHub Release for each stable Commonlib release after the exact registry artefact has passed downstream validation and the version has been promoted to `latest`. Target the exact `main` commit used to build the published package, and confirm that any existing version tag points to that commit.
+
+Prepare concise release notes from the corresponding `updates.md` entry. Then create the version tag, when it does not already exist, and publish the GitHub Release in one operation:
+
+```bash
+gh release create <version> \
+  --repo vrtmrz/livesync-commonlib \
+  --target <release-commit> \
+  --title '<version>' \
+  --notes-file <release-notes-file> \
+  --latest
+```
+
+Treat publishing the GitHub Release as a separate user-authorised remote operation. Verify the version, exact release commit, and release notes immediately before publishing it.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -95,17 +95,22 @@ The workflow always stages to `next`. Inspect the staged package name, version, 
 
 ## Publishing a GitHub Release
 
-Create a GitHub Release for each stable Commonlib release after the exact registry artefact has passed downstream validation and the version has been promoted to `latest`. Target the exact `main` commit used to build the published package, and confirm that any existing version tag points to that commit.
+Create a GitHub Release for each stable Commonlib release after the exact registry artefact has passed downstream validation and the version has been promoted to `latest`. Target the exact `main` commit used to build the published package.
 
-Prepare concise release notes from the corresponding `updates.md` entry. Then create the version tag, when it does not already exist, and publish the GitHub Release in one operation:
+Protect the GitHub `github-release` environment with a required reviewer and permit only `main`. The manually dispatched workflow first verifies the release with read-only repository access. Only its protected publication job receives `contents: write` access.
+
+Set the exact version and release commit, then dispatch the workflow from `main`:
 
 ```bash
-gh release create <version> \
-  --repo vrtmrz/livesync-commonlib \
-  --target <release-commit> \
-  --title '<version>' \
-  --notes-file <release-notes-file> \
-  --latest
+version='<version>'
+release_sha='<full-release-commit>'
+gh workflow run publish-github-release.yml \
+  --ref main \
+  -f version="$version" \
+  -f expected_sha="$release_sha" \
+  -f confirmation="release @vrtmrz/livesync-commonlib@$version from $release_sha"
 ```
 
-Treat publishing the GitHub Release as a separate user-authorised remote operation. Verify the version, exact release commit, and release notes immediately before publishing it.
+The workflow requires the release commit to be an ancestor of its trusted `main` commit, reads the exact source version and corresponding release notes from that commit, confirms that npm `latest` points to the version, and rejects an existing version tag. Review those results before approving the `github-release` environment. The protected job rechecks npm `latest`, then creates the version tag and GitHub Release and verifies that the tag points to the selected commit.
+
+Treat dispatching and approving the GitHub Release workflow as separate user-authorised remote operations. Verify the version, exact release commit, and release notes immediately before approval.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:integration": "node _tools/run-integration-tests.mjs",
     "test:integration:managed": "node _tools/run-integration-tests.mjs --manage-services",
     "test:package": "node _tools/run-package-test.mjs",
-    "test:release": "node --test _tools/validate-release-selection.test.mjs",
+    "test:release": "node --test _tools/prepare-github-release.test.mjs _tools/validate-release-selection.test.mjs",
     "update:downstream-import-inventory": "node _tools/update-downstream-import-inventory.mjs",
     "verify:package": "npm run check:types && npm test && npm run test:boundary && npm run test:release && npm run check:boundary && npm run test:package"
   },


### PR DESCRIPTION
Adds a protected, manually dispatched workflow that verifies and publishes each stable Commonlib GitHub Release from its exact release commit.

## Summary

- verify the stable version, full release SHA, `main` ancestry, source manifest, curated `updates.md` entry, npm `latest` dist-tag, and unused version tag before publication;
- grant `contents: write` only to the publication job behind the protected `github-release` environment, then verify the created tag and Release; and
- document the dispatch and approval sequence and cover release-note selection with focused tests.

## Verification

- `npm run test:release`
- `node_modules/.bin/prettier --check .github/workflows/publish-github-release.yml _tools/prepare-github-release.mjs _tools/prepare-github-release.test.mjs docs/releasing.md`
- `actionlint .github/workflows/publish-github-release.yml`
- extracted the 0.1.18 notes from release commit `085b35a9ed9f44ed4765f97b88c1c0ebaccf920e`
