### PR TITLE
Prepare Commonlib 0.1.19

### DIFF
--- a/docs/database-lifecycle.md
+++ b/docs/database-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-23
-commonlib-version: "0.1.19-rc.0"
+commonlib-version: "0.1.19"
 self-hosted-livesync-version: "1.0.17"
 status: unreleased
 ---

--- a/docs/offline-scanner.md
+++ b/docs/offline-scanner.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-23
-commonlib-version: "0.1.19-rc.0"
+commonlib-version: "0.1.19"
 self-hosted-livesync-version: "1.0.17"
 status: unreleased
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.19-rc.0",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.19-rc.0",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.19-rc.0",
+  "version": "0.1.19",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.1.19-rc.0
+## 0.1.19
 
 ### Fixed
 


### PR DESCRIPTION
Prepare the stable `@vrtmrz/livesync-commonlib` 0.1.19 release metadata after successful pre-release validation, without changing the validated runtime implementation.

## Summary

- Set the source manifest and lockfile versions to 0.1.19.
- Move the existing 0.1.19 release notes from the pre-release heading to the stable heading.
- Align the database lifecycle and offline scanner document front matter with the stable version.

The runtime implementation is unchanged from 0.1.19-rc.0.

## Validation

- `NODE_OPTIONS=--max-old-space-size=3072 npm run verify:package`
  - 72 unit test files and 1,413 tests passed.
  - Boundary, release-selection, generated-package, clean-consumer, and representative bundle checks passed.
- `npm publish --dry-run .package --tag next --access public`
  - Confirmed `@vrtmrz/livesync-commonlib@0.1.19`, public access, and the `next` dist-tag.
  - Local dry-run SHA-1: `0b89020e3d946b102e0505203caaf88b630f2daa`.
- The exact 0.1.19-rc.0 registry artefact passed the complete Self-hosted LiveSync PR #1128 CI at commit `35e170463e968751cc3ff00e6cb2d889654a12a9`.
- Real Obsidian validation covered the start-up scan, CouchDB onboarding and rebuild, Fast Fetch, and a bidirectional synchronisation round trip.

Stable staged publication remains a separate operation after the exact release commit is merged into `main`.
