### PR TITLE
Prepare Commonlib 0.1.20

### DIFF
--- a/docs/database-lifecycle.md
+++ b/docs/database-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-27
-commonlib-version: "0.1.19"
+commonlib-version: "0.1.20"
 self-hosted-livesync-version: "1.0.21"
 status: unreleased
 ---

--- a/docs/p2p-transport-lifecycle.md
+++ b/docs/p2p-transport-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-28
-commonlib-version: "0.1.19"
+commonlib-version: "0.1.20"
 self-hosted-livesync-version: "1.0.21"
 status: unreleased
 ---

--- a/docs/service-feature-composition.md
+++ b/docs/service-feature-composition.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-30
-commonlib-version: "0.1.19"
+commonlib-version: "0.1.20"
 self-hosted-livesync-version: "1.0.21"
 status: accepted
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 0.1.20
+
+### Added
+
+- New focused `@vrtmrz/livesync-commonlib/replication` and `@vrtmrz/livesync-commonlib/p2p` package entries expose provider definitions, explicit capability availability, opaque configuration identities, interaction authority, typed replication outcomes, owned finite remote resources, optional central-remote administration, and eight focused P2P service views through package-tested boundaries.
+- A packaged developer guide now explains when to use Service handlers, service features, ServiceModules, private feature contexts, and focused resource owners.
+
+### Changed
+
+- Active Replicator publication is now bound to a provider-owned configuration identity. A changed effective configuration fences new admissions, requests supported transfer cancellation, drains admitted work, closes the previous instance, and only then publishes its replacement. An unchanged identity retains the current instance, and stale asynchronous candidates are discarded.
+- User-initiated, unattended, continuous, and stop operations now have separate capability and interaction contracts. Finite work must report explicit completion, while continuous start retains the legacy permissive `void` settlement only when the provider declares support. `ActiveReplicatorContext.configurationIdentity` is now required, and Replicator termination and closure may settle asynchronously.
+- Replication failure handling now retains the exact failed publication, detached settings, outcome, and interaction authority, preventing a later replacement Replicator from being used to interpret or recover an earlier attempt.
+- P2P now uses one stable service and room-session owner for persistent demand, finite transfers, connection-probe admission, automatic start, replacement, cancellation, and lifecycle reopening. P2P-only participates as a first-class finite Replicator without claiming central-remote milestones or administration.
+- Transitional RPC calls now support abort signals and cancellation-aware handlers. Cancellation is cooperative and does not roll back work which has already settled.
+
+### Fixed
+
+- Journal synchronisation-parameter and milestone reads now distinguish confirmed absence from an unavailable Object Storage backend. Unavailability is propagated and cannot initialise replacement control data or a new Security Seed; stale cached control reads and retired clients are also fenced ([Self-hosted LiveSync issue #1147](https://github.com/vrtmrz/obsidian-livesync/issues/1147)).
+- Failed P2P replication results now preserve a JSON-safe error code, message, and details across RPC instead of losing native `Error` properties as an empty object.
+- Cancelled or partially failed shim replication no longer advances checkpoints beyond an unsettled batch. Missing source revisions and failed bulk writes are reported explicitly.
+
 ## 0.1.19
 
 ### Fixed


### PR DESCRIPTION
Prepare the stable `@vrtmrz/livesync-commonlib` 0.1.20 release metadata for the reviewed Replicator capability and lifecycle contracts, without changing their merged runtime implementation.

## Summary

- Set the source manifest and lockfile versions to 0.1.20.
- Add release notes for the focused replication and P2P package entries, explicit provider, capability, interaction, and resource-ownership contracts, identity-aware active replacement, exact-attempt recovery, stable P2P room-session ownership, and cooperative RPC cancellation.
- Record the Journal unavailable-versus-absent correction related to [Self-hosted LiveSync issue #1147](https://github.com/vrtmrz/obsidian-livesync/issues/1147), safe shim checkpoints, and JSON-safe P2P failure reasons.
- Align the database lifecycle, P2P transport lifecycle, and service-feature composition document front matter with 0.1.20.

Commonlib remains pre-1.0. This release intentionally requires `ActiveReplicatorContext.configurationIdentity`, permits asynchronous Replicator termination and closure, and distinguishes explicit finite outcomes from provider-declared continuous support. These implementation changes were reviewed and merged through #130.

## Validation

- Clean installation with the reviewed npm 11.18.0 client passed.
- The complete `verify:package` gate was run sequentially, with the unit suite bounded to one worker:
  - Commonlib type checking passed.
  - All 85 unit test files and 1,690 tests passed.
  - All seven package-boundary tests and both release-selection tests passed.
  - The source boundary, generated package, exact clean consumer, declarations, Node, browser, worker, content, file-mode, and bundle-size checks passed.
- `npm publish --dry-run .package --tag next --access public` confirmed `@vrtmrz/livesync-commonlib@0.1.20`, public access, and the `next` dist-tag.
- Local tarball SHA-256: `7a46c9a159c18ac9ba13d36842f305b034cc569f46d4ed87f8f86ad72b3e94bb`.
- Local tarball size: 479,385 packed bytes and 2,045,815 unpacked bytes.

The exact registry artefact has not been published or validated. Stable staged publication from the exact merged release commit, registry checksum reconciliation, downstream Self-hosted LiveSync validation, and promotion to `latest` remain separate operations.
