### PR TITLE
Prepare Commonlib 0.1.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 0.1.21
+
+### Changed
+
+- User-initiated OneShot requests now choose an explicit `quiet` or `notice` progress presentation independently of interaction authority. `UserInitiatedOneShotRequest.progressPresentation` is required, and `ReplicationFailureRequest.progressPresentation` replaces `showMessage` so failure handling retains the caller's presentation choice.
+
+### Fixed
+
+- OneShot admission is now reserved before the first asynchronous readiness check. Additional user-initiated or unattended requests while an attempt is active settle immediately with `replication-in-progress` instead of queuing another replication after it completes.
+
 ## 0.1.20
 
 ### Added


### PR DESCRIPTION
This release-metadata change prepares stable `@vrtmrz/livesync-commonlib` 0.1.21 for the reviewed OneShot admission and progress presentation correction, without changing its merged runtime implementation.

## Summary

- Set the source manifest and lockfile versions to 0.1.21.
- Add release notes for explicit `quiet` and `notice` OneShot progress presentation independently of interaction authority. `UserInitiatedOneShotRequest.progressPresentation` is required, and `ReplicationFailureRequest.progressPresentation` replaces `showMessage`.
- Record immediate coordinator-wide OneShot admission: later user-initiated and unattended requests settle with `replication-in-progress` instead of queuing another replication after the active attempt completes.

The runtime correction and development-lock maintenance were reviewed and merged through #132. This pull request changes only the source manifest version, the two root lockfile version fields, and the 0.1.21 release notes. Companion consumer: vrtmrz/obsidian-livesync#1154.

## Dependency audit

The reviewed npm 11.18.0 full and production-only audits both report 18 moderate nodes, with no low, high, or critical finding. All 18 nodes propagate from one advisory for `uuid@8.3.2`, which PouchDB 9.0.0 pins exactly. The advisory concerns the UUID v3, v5, and v6 APIs when a caller supplies a buffer; the installed PouchDB code uses only v4 without that argument, and Commonlib has no direct UUID use.

npm's suggested remediation downgrades `pouchdb-core` to the incompatible 7.3.1 line rather than providing a patched current release, so it is not applied. The complete rationale and development-only PostCSS and Nano ID update were reviewed in #132.

## Validation

- Clean installation with the reviewed npm 11.18.0 client passed with 230 packages.
- The complete `verify:package` gate passed sequentially under a 3 GB Node heap limit:
  - Commonlib type checking passed.
  - All 85 unit-test files and 1,695 tests passed.
  - All seven package-boundary tests and 31 release-selection and GitHub Release preparation tests passed.
  - The source boundary retained its zero-import migration baseline.
  - The generated package, exact clean consumer, declarations, content, file modes, Node, browser, worker, and bundle-size checks passed with 109 explicit compatibility exports.
- `npm publish --dry-run .package --tag next --access public` confirmed `@vrtmrz/livesync-commonlib@0.1.21`, public access, and the `next` dist-tag.
- Local proof tarball SHA-256: `d06005db82625e240cbae7d4be66ded20936c449b937ce01e15102a250a69dc1`.
- Local proof tarball integrity: `sha512-AGuZ3eqBP37HJXEkTSpJ5M5bvTx2lYNq+6Q5NuCPZeGdbv7g6cujGvccVR5ozGfKdHGSyFZND5x1oFS9crRhUg==`.
- The proof tarball contains 541 entries and is 480,106 packed bytes and 2,048,320 unpacked bytes.

The tarball above is local package-proof evidence only. The exact registry artefact has not been published or validated. Stable staged publication must use the exact merged release commit on `main`; registry checksum reconciliation, exact published-package validation in Self-hosted LiveSync, promotion to `latest`, and the GitHub Release remain separate protected operations.
