### PR TITLE
Prepare Commonlib 0.1.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vrtmrz/livesync-commonlib",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.808.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrtmrz/livesync-commonlib",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Shared data, storage, and replication primitives for Self-hosted LiveSync clients.",
   "private": true,
   "type": "module",

--- a/updates.md
+++ b/updates.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.22
+
 ### Fixed
 
 - An ordinary host start-up may explicitly continue after individual offline-scan file failures without marking those pairs as completed or losing their retry state. Affected paths are logged at verbose level, while recovery and CLI scans retain strict completion by default ([Self-hosted LiveSync issue #1164](https://github.com/vrtmrz/obsidian-livesync/issues/1164)).


### PR DESCRIPTION
This release-metadata change prepares stable `@vrtmrz/livesync-commonlib` 0.1.22 for the reviewed partial offline-scan completion and readiness diagnostics, without changing its merged runtime implementation.

## Summary

- Set the source manifest and lockfile versions to 0.1.22.
- Add release notes for the explicit partial-completion result which lets an ordinary host start-up continue after individual offline-scan file failures without losing their retry state. Recovery and CLI scans remain strict by default.
- Record detailed verbose diagnostics, host ownership of concise user-facing notices, and the descriptive application-initialisation readiness message which replaces the bare 'Not ready' diagnostic.

The runtime correction, documentation, and focused coverage were reviewed and merged through #134. This pull request changes only the source manifest version, the two root lockfile version fields, and the 0.1.22 release heading. Exact registry publication and downstream validation remain separate protected stages.

## Dependency state

The resolved dependency versions and integrity values are unchanged from 0.1.21. Clean installation reports the same 18 moderate nodes documented for that release, with no low, high, or critical finding; this metadata-only change introduces no dependency update.

## Validation

- Clean installation with Node.js 24.18.0 and the reviewed npm 11.18.0 client passed with 230 packages.
- The complete package gate passed sequentially under a 3 GB Node heap limit, with the unit suite restricted to one worker:
  - Commonlib type checking passed.
  - All 85 unit-test files and 1,706 tests passed.
  - All seven package-boundary tests and 31 release-selection and GitHub Release preparation cases passed.
  - The source boundary retained its zero-import migration baseline.
  - The generated package, exact clean consumer, declarations, content, file modes, Node, browser, worker, and bundle-size checks passed with 109 explicit compatibility exports.
- `npm publish --dry-run .package --tag next --access public` confirmed `@vrtmrz/livesync-commonlib@0.1.22`, public access, and the `next` dist-tag.
- Local proof tarball SHA-256: `76ff6052a27e1d04258f744dd509c784747cae566f418060bf7bb5d618ddea23`.
- Local proof tarball integrity: `sha512-8TsFo6xgEO/uZzkQ4TE3yydUyK8pCbuMm0C4DC/8KhG8z06N6hQQmwR7bV+a3Zgt9A5tXPImTFJWTMUIxJYV2g==`.
- The proof tarball contains 543 entries and is 482,166 packed bytes and 2,056,588 unpacked bytes.

The tarball above is local package-proof evidence only. The exact registry artefact has not been published or validated. Stable staged publication must use the exact merged release commit on `main`; registry checksum reconciliation, exact published-package validation in Self-hosted LiveSync, promotion to `latest`, and the GitHub Release remain separate protected operations.
